### PR TITLE
docs: Change k8s cluster min version to 1.31 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Kubernetes cluster (1.16+)
+- Kubernetes cluster (1.31+)
 - Twingate account setup with a `Remote Network` for the Kubernetes cluster and
  connectors deployed (see the [Twingate Kubernetes Operator](https://github.com/Twingate/kubernetes-operator) or [the Helm chart](https://github.com/Twingate/helm-charts)
  if required)


### PR DESCRIPTION
## Changes

Streaming protocol is default to Websocket since Kubernetes v1.31. See https://kubernetes.io/blog/2024/08/20/websockets-transition/#how-to-use-the-new-websocket-streaming-protocol