### PR TITLE
fix: Make `tls` object optional in Helm JSON schema

### DIFF
--- a/deploy/gateway/values.schema.json
+++ b/deploy/gateway/values.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/schema#",
   "type": "object",
   "title": "JSON schema for Twingate Gateway Helm Chart values",
-  "required": ["twingate", "tls"],
+  "required": ["twingate"],
   "properties": {
     "twingate": {
       "type": "object",


### PR DESCRIPTION
## Changes

`tls` object has a default behavior to auto-generated TLS certificates so the user doesn't need to specify it in the Helm value file