### PR TITLE
refactor: Cleaner configuration setup using Viper

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,6 @@ linters:
     - forcetypeassert  # Covered by revive linter's unchecked-type-assertion rule
     - funlen
     - gochecknoglobals
-    - gochecknoinits
     - godox  # FIXME
     - gosmopolitan
     - lll  # Covered by revive linter's line-length-limit rule

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ linters:
     - forcetypeassert  # Covered by revive linter's unchecked-type-assertion rule
     - funlen
     - gochecknoglobals
-    - gochecknoinits  # FIXME
+    - gochecknoinits
     - godox  # FIXME
     - gosmopolitan
     - lll  # Covered by revive linter's line-length-limit rule

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 
 	"k8sgateway/internal/log"
@@ -26,10 +27,11 @@ func TestRootCmd_StartCommandArgs(t *testing.T) {
 
 	cmd.SetArgs([]string{
 		"start",
-		"--k8sAPIToken", "test-token",
-		"--ca", "test-ca",
-		"--tls.key", "test-tls-key",
-		"--tls.cert", "test-tls-cert",
+		"--network", "acme",
+		"--tlsKey", "test-tls-key",
+		"--tlsCert", "test-tls-cert",
+		"--k8sAPIServerToken", "test-token",
+		"--k8sAPIServerCA", "test-ca",
 		"--debug",
 	})
 
@@ -37,10 +39,11 @@ func TestRootCmd_StartCommandArgs(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.True(t, startMockCalled)
 
-		assert.Equal(t, "test-token", startFlags.K8sAPIServerToken)
-		assert.Equal(t, "test-ca", startFlags.CA)
-		assert.Equal(t, "test-tls-key", startFlags.TLSKey)
-		assert.Equal(t, "test-tls-cert", startFlags.TLSCert)
-		assert.True(t, startFlags.Debug)
+		assert.Equal(t, "acme", viper.GetString("network"))
+		assert.Equal(t, "test-tls-key", viper.GetString("tlsKey"))
+		assert.Equal(t, "test-tls-cert", viper.GetString("tlsCert"))
+		assert.Equal(t, "test-token", viper.GetString("k8sAPIServerToken"))
+		assert.Equal(t, "test-ca", viper.GetString("k8sAPIServerCA"))
+		assert.True(t, viper.GetBool("debug"))
 	}
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -80,7 +80,7 @@ func start(newProxy ProxyFactory) error {
 	return nil
 }
 
-func init() {
+func init() { //nolint:gochecknoinits
 	viper.SetEnvPrefix("TWINGATE")
 	viper.AutomaticEnv()
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -96,7 +96,7 @@ func init() { //nolint:gochecknoinits
 	flags.String("tlsKey", "", "Path to the TLS key for the Gateway")
 
 	// Kubernetes flags
-	flags.String("k8sAPIServerCA", "", "Path to the K8sAPIServerCA certificate for the Kubernetes API server")
+	flags.String("k8sAPIServerCA", "", "Path to the CA certificate for the Kubernetes API server")
 	flags.String("k8sAPIServerToken", "", "Bearer token to authenticate to the Kubernetes API server")
 
 	// Misc flags

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -15,25 +15,12 @@ import (
 	"k8sgateway/internal/token"
 )
 
-type StartFlags = struct {
-	CA                string
-	TLSKey            string
-	TLSCert           string
-	K8sAPIServerToken string
-	Network           string
-	Host              string
-	Debug             bool
-}
-
-var startFlags = StartFlags{}
+var errRequiredConfig = errors.New("required configuration must be set")
 
 var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start Twingate Kubernetes Access Gateway",
 	RunE: func(_cmd *cobra.Command, _args []string) error {
-		startFlags.Network = viper.GetString("network")
-		startFlags.Host = viper.GetString("host")
-
 		newProxy := func(cfg httpproxy.Config) (httpproxy.ProxyService, error) {
 			return httpproxy.NewProxy(cfg)
 		}
@@ -45,39 +32,45 @@ var startCmd = &cobra.Command{
 type ProxyFactory func(httpproxy.Config) (httpproxy.ProxyService, error)
 
 func start(newProxy ProxyFactory) error {
-	f := startFlags
-	log.InitializeLogger("k8sgateway", f.Debug)
+	log.InitializeLogger("k8sgateway", viper.GetBool("debug"))
 
 	logger := zap.S()
-	logger.Infof("Gateway start called with: %+v", startFlags)
+	logger.Infof("Gateway start called: %+v", viper.AllSettings())
 
-	parser, err := token.NewParserWithRemotesJWKS(f.Network, f.Host)
+	network := viper.GetString("network")
+
+	if network == "" {
+		return fmt.Errorf("%w: network", errRequiredConfig)
+	}
+
+	parser, err := token.NewParserWithRemotesJWKS(network, viper.GetString("host"))
 	if err != nil {
 		return fmt.Errorf("failed to create token parser %w", err)
 	}
 
-	connectValidator := &connect.MessageValidator{
-		TokenParser: parser,
+	cfg := httpproxy.Config{
+		Port:              viper.GetInt("port"),
+		TLSKey:            viper.GetString("tlsKey"),
+		TLSCert:           viper.GetString("tlsCert"),
+		K8sAPIServerCA:    viper.GetString("k8sAPIServerCA"),
+		K8sAPIServerToken: viper.GetString("k8sAPIServerToken"),
+		ConnectValidator: &connect.MessageValidator{
+			TokenParser: parser,
+		},
 	}
 
 	if inClusterK8sCfg, _ := rest.InClusterConfig(); inClusterK8sCfg != nil {
-		logger.Infof("Using in-cluster configuration")
+		logger.Info("Using in-cluster configuration")
 
-		f.CA = inClusterK8sCfg.CAFile
-		f.K8sAPIServerToken = inClusterK8sCfg.BearerToken
-		f.TLSCert = "/etc/tls-secret-volume/tls.crt"
-		f.TLSKey = "/etc/tls-secret-volume/tls.key"
+		cfg.K8sAPIServerCA = inClusterK8sCfg.CAFile
+		cfg.K8sAPIServerToken = inClusterK8sCfg.BearerToken
+		cfg.TLSCert = "/etc/tls-secret-volume/tls.crt"
+		cfg.TLSKey = "/etc/tls-secret-volume/tls.key"
 	} else if !errors.Is(err, rest.ErrNotInCluster) {
 		logger.Errorf("failed to load in-cluster config: %v", err)
 	}
 
-	proxy, err := newProxy(httpproxy.Config{
-		CA:                f.CA,
-		TLSKey:            f.TLSKey,
-		TLSCert:           f.TLSCert,
-		K8sAPIServerToken: f.K8sAPIServerToken,
-		ConnectValidator:  connectValidator,
-	})
+	proxy, err := newProxy(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create k8s gateway %w", err)
 	}
@@ -92,20 +85,25 @@ func init() {
 	viper.AutomaticEnv()
 
 	flags := startCmd.Flags()
-	flags.StringVar(&startFlags.CA, "ca", "../../test/data/ca.crt", "Root CA certificate")
-	flags.StringVar(&startFlags.TLSKey, "tls.key", "../../test/data/domain.key", "TLS key")
-	flags.StringVar(&startFlags.TLSCert, "tls.cert", "../../test/data/domain.crt", "TLS certificate")
-	flags.StringVar(&startFlags.K8sAPIServerToken, "k8sAPIToken", "", "k8s API Server Token")
-	flags.StringVar(&startFlags.Network, "network", "", "Twingate network ID. For example, network ID is autoco if your URL is autoco.twingate.com")
-	flags.StringVar(&startFlags.Host, "host", "twingate.com", "The Twingate service domain")
-	flags.BoolVarP(&startFlags.Debug, "debug", "d", viper.GetBool("DEBUG"), "Run in debug mode")
 
-	if err := viper.BindPFlag("network", flags.Lookup("network")); err != nil {
-		panic(fmt.Sprintf("failed to initialize: %v", err))
-	}
+	// Twingate flags
+	flags.String("network", "", "Twingate network ID. For example, network ID is autoco if your URL is autoco.twingate.com")
+	flags.String("host", "twingate.com", "The Twingate service domain")
 
-	if err := viper.BindPFlag("host", flags.Lookup("host")); err != nil {
-		panic(fmt.Sprintf("failed to initialize: %v", err))
+	// Gateway flags
+	flags.String("port", "8443", "Port to listen on")
+	flags.String("tlsCert", "", "Path to the TLS certificate for the Gateway")
+	flags.String("tlsKey", "", "Path to the TLS key for the Gateway")
+
+	// Kubernetes flags
+	flags.String("k8sAPIServerCA", "", "Path to the K8sAPIServerCA certificate for the Kubernetes API server")
+	flags.String("k8sAPIServerToken", "", "Bearer token to authenticate to the Kubernetes API server")
+
+	// Misc flags
+	flags.BoolP("debug", "d", false, "Run in debug mode")
+
+	if err := viper.BindPFlags(flags); err != nil {
+		panic(fmt.Sprintf("failed to bind flags: %v", err))
 	}
 
 	rootCmd.AddCommand(startCmd)

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,40 +22,17 @@ func (m *mockProxy) Start(_ready chan struct{}) {
 func TestStart(t *testing.T) {
 	tests := []struct {
 		name           string
-		setFlags       func()
 		newProxyErr    error
 		wantErr        bool
 		wantErrMessage string
 	}{
 		{
-			name: "successful start",
-			setFlags: func() {
-				startFlags = StartFlags{
-					CA:                "test-ca",
-					TLSKey:            "test-key",
-					TLSCert:           "test-cert",
-					K8sAPIServerToken: "test-token",
-					Network:           "test-network",
-					Host:              "test-host.com",
-					Debug:             false,
-				}
-			},
+			name:        "successful start",
 			newProxyErr: nil,
 			wantErr:     false,
 		},
 		{
-			name: "gateway creation fails",
-			setFlags: func() {
-				startFlags = StartFlags{
-					CA:                "invalid-ca",
-					TLSKey:            "invalid-key",
-					TLSCert:           "invalid-cert",
-					K8sAPIServerToken: "invalid-token",
-					Network:           "invalid-network",
-					Host:              "invalid-host",
-					Debug:             true,
-				}
-			},
+			name:           "gateway creation fails",
 			newProxyErr:    errors.New("invalid configuration"),
 			wantErr:        true,
 			wantErrMessage: "failed to create k8s gateway invalid configuration",
@@ -63,7 +41,7 @@ func TestStart(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.setFlags()
+			viper.Set("network", "acme")
 
 			var mockProxyInstance *mockProxy
 

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -527,12 +527,11 @@ func TestProxy_ForwardRequest(t *testing.T) {
 
 	// k8s proxy configuration
 	cfg := Config{
-		CA:                "../../test/data/api_server.crt",
+		K8sAPIServerCA:    "../../test/data/api_server.crt",
 		TLSCert:           "../../test/data/proxy_server.crt",
 		TLSKey:            "../../test/data/proxy_server.key",
-		K8sAPIServerURL:   apiServer.URL,
 		K8sAPIServerToken: "mock-token",
-		listenPort:        45678,
+		Port:              45678,
 		ConnectValidator:  mockValidator,
 	}
 

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -527,12 +527,12 @@ func TestProxy_ForwardRequest(t *testing.T) {
 
 	// k8s proxy configuration
 	cfg := Config{
-		K8sAPIServerCA:    "../../test/data/api_server.crt",
 		TLSCert:           "../../test/data/proxy_server.crt",
 		TLSKey:            "../../test/data/proxy_server.key",
+		K8sAPIServerCA:    "../../test/data/api_server.crt",
 		K8sAPIServerToken: "mock-token",
-		Port:              45678,
 		ConnectValidator:  mockValidator,
+		Port:              45678,
 	}
 
 	// create and start the proxy


### PR DESCRIPTION
## Changes

- Use Viper to bind all command flags so they can be set as environment variables.
- Standardize flag names 
