### PR TITLE
feat: Better structured logging

### DIFF
--- a/internal/token/gat_claims.go
+++ b/internal/token/gat_claims.go
@@ -65,13 +65,15 @@ type User struct {
 func (u User) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("id", u.ID)
 	enc.AddString("username", u.Username)
-	enc.AddArray("groups", zapcore.ArrayMarshalerFunc(func(arrayEnc zapcore.ArrayEncoder) error {
+	err := enc.AddArray("groups", zapcore.ArrayMarshalerFunc(func(arrayEnc zapcore.ArrayEncoder) error {
 		for _, group := range u.Groups {
 			arrayEnc.AppendString(group)
 		}
+
 		return nil
 	}))
-	return nil
+
+	return err
 }
 
 type Device struct {

--- a/internal/token/gat_claims.go
+++ b/internal/token/gat_claims.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/golang-jwt/jwt/v5"
+	"go.uber.org/zap/zapcore"
 )
 
 var (
@@ -59,6 +60,18 @@ type User struct {
 	ID       string   `json:"id"`
 	Username string   `json:"username"`
 	Groups   []string `json:"groups"`
+}
+
+func (u User) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("id", u.ID)
+	enc.AddString("username", u.Username)
+	enc.AddArray("groups", zapcore.ArrayMarshalerFunc(func(arrayEnc zapcore.ArrayEncoder) error {
+		for _, group := range u.Groups {
+			arrayEnc.AppendString(group)
+		}
+		return nil
+	}))
+	return nil
 }
 
 type Device struct {

--- a/internal/wsproxy/hijacker_test.go
+++ b/internal/wsproxy/hijacker_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 type mockHijackerResponseWriter struct {
@@ -67,7 +69,7 @@ func mockNewConn(conn net.Conn, _ Recorder, _ asciinemaHeader, _ bool) net.Conn 
 }
 
 func mockNewRecorder() *AsciinemaRecorder {
-	return NewRecorder()
+	return NewRecorder(zap.NewNop())
 }
 
 func TestHijacker_New(t *testing.T) {

--- a/internal/wsproxy/recorder.go
+++ b/internal/wsproxy/recorder.go
@@ -55,13 +55,15 @@ const (
 )
 
 type AsciinemaRecorder struct {
+	logger        *zap.Logger
 	start         time.Time
 	state         State
 	recordedLines []string
 }
 
-func NewRecorder() *AsciinemaRecorder {
+func NewRecorder(logger *zap.Logger) *AsciinemaRecorder {
 	return &AsciinemaRecorder{
+		logger:        logger,
 		start:         time.Now(),
 		recordedLines: []string{},
 	}
@@ -92,9 +94,7 @@ func (r *AsciinemaRecorder) IsStarted() bool {
 }
 
 func (r *AsciinemaRecorder) Stop() {
-	logger := zap.S()
-	logger.Info(strings.Join(r.recordedLines, "\n"))
-
+	r.logger.Info("session finished", zap.String("asciinema_data", strings.Join(r.recordedLines, "\n")))
 	r.state = FinishedState
 }
 

--- a/internal/wsproxy/recorder_test.go
+++ b/internal/wsproxy/recorder_test.go
@@ -7,15 +7,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestRecorder_NewRecorder(t *testing.T) {
-	r := NewRecorder()
+	r := NewRecorder(zap.NewNop())
 	assert.NotNil(t, r, "NewRecorder should return a non-nil recording")
 }
 
 func TestRecorder_WriteOutputEvent(t *testing.T) {
-	r := NewRecorder()
+	r := NewRecorder(zap.NewNop())
 
 	err := r.WriteOutputEvent([]byte("test output"))
 	require.NoError(t, err, "WriteOutputEvent should not return an error")
@@ -39,7 +40,7 @@ func TestRecorder_WriteOutputEvent(t *testing.T) {
 }
 
 func TestRecorder_WriteResizeEvent(t *testing.T) {
-	r := NewRecorder()
+	r := NewRecorder(zap.NewNop())
 
 	err := r.WriteResizeEvent(80, 24)
 	require.NoError(t, err, "WriteResizeEvent should not return an error")
@@ -63,7 +64,7 @@ func TestRecorder_WriteResizeEvent(t *testing.T) {
 }
 
 func TestRecorder_WriteHeader(t *testing.T) {
-	r := NewRecorder()
+	r := NewRecorder(zap.NewNop())
 
 	header := asciinemaHeader{
 		Version:   2,
@@ -92,7 +93,7 @@ func TestRecorder_WriteHeader(t *testing.T) {
 }
 
 func TestRecorder_MultipleEvents(t *testing.T) {
-	r := NewRecorder()
+	r := NewRecorder(zap.NewNop())
 
 	header := asciinemaHeader{
 		Version: 2,
@@ -123,7 +124,7 @@ func TestRecorder_MultipleEvents(t *testing.T) {
 }
 
 func TestRecorder_StoreEventAfterStop(t *testing.T) {
-	r := NewRecorder()
+	r := NewRecorder(zap.NewNop())
 
 	// Write an event
 	require.NoError(t, r.WriteOutputEvent([]byte("test")))
@@ -145,7 +146,7 @@ func TestRecorder_StoreEventAfterStop(t *testing.T) {
 }
 
 func TestRecorderFlow(t *testing.T) {
-	r := NewRecorder()
+	r := NewRecorder(zap.NewNop())
 
 	// Verify start time is recent
 	assert.WithinDuration(t, time.Now(), r.start, 1*time.Second, "Recorder start time should be recent")
@@ -207,7 +208,7 @@ func TestK8sMetadata(t *testing.T) {
 }
 
 func TestRecorder_WriteJSON_Error(t *testing.T) {
-	r := NewRecorder()
+	r := NewRecorder(zap.NewNop())
 
 	// Create a value that cannot be marshaled to JSON, a function
 	badValue := struct {
@@ -223,7 +224,7 @@ func TestRecorder_WriteJSON_Error(t *testing.T) {
 }
 
 func TestRecorder_StoreEvent_Error(t *testing.T) {
-	r := NewRecorder()
+	r := NewRecorder(zap.NewNop())
 	r.state = FinishedState
 
 	err := r.storeEvent("test event")


### PR DESCRIPTION
## Changes

- For each API request, create a logger with common log keys so all logging would include them
  + `request_id`
  + `method`
  + `url`
  + `remote_addr`
  + `user` object (from GAT's `user` claim)
- Use this logger in session recording so the recording log can be correlated to a user.
- Separate log keys under `request` key (for request information) and `response` key (for response information)

## Notes

- Sample logs for `kubectl auth`
```
{
  "levelname": "info",
  "ts": "2025-05-27T22:07:32.902Z",
  "logger": "k8sgateway",
  "caller": "http/server.go:2822",
  "message": "API request",
  "version": "0.0.1",
  "request_id": "7d3bbfcc-42fe-4414-b806-017c83c5fb05",
  "method": "POST",
  "url": "/apis/authentication.k8s.io/v1/selfsubjectreviews",
  "remote_addr": "10.16.1.4:59194",
  "user": {
    "id": "VXNlcjoxNTQ4NDQ1",
    "username": "m.le@beamreachinc.com",
    "groups": [
      "MT only"
    ]
  },
  "request": {
    "header": {
      "Accept": [
        "application/json, */*"
      ],
      "Accept-Encoding": [
        "gzip"
      ],
      "Authorization": [
        "Bearer void"
      ],
      "Content-Length": [
        "132"
      ],
      "Content-Type": [
        "application/json"
      ],
      "Kubectl-Command": [
        "kubectl auth whoami"
      ],
      "Kubectl-Session": [
        "31c499b6-c428-4d33-806a-201a438510d9"
      ],
      "User-Agent": [
        "kubectl/v1.31.2 (darwin/arm64) kubernetes/5864a46"
      ]
    },
    "body": "{\"kind\":\"SelfSubjectReview\",\"apiVersion\":\"authentication.k8s.io/v1\",\"metadata\":{\"creationTimestamp\":null},\"status\":{\"userInfo\":{}}}\n"
  }
}
{
  "levelname": "info",
  "ts": "2025-05-27T22:07:33.145Z",
  "logger": "k8sgateway",
  "caller": "http/server.go:2294",
  "message": "API response",
  "version": "0.0.1",
  "request_id": "7d3bbfcc-42fe-4414-b806-017c83c5fb05",
  "method": "POST",
  "url": "/apis/authentication.k8s.io/v1/selfsubjectreviews",
  "remote_addr": "10.16.1.4:59194",
  "user": {
    "id": "VXNlcjoxNTQ4NDQ1",
    "username": "m.le@beamreachinc.com",
    "groups": [
      "MT only"
    ]
  },
  "response": {
    "status_code": 201,
    "header": {
      "Audit-Id": [
        "8f1ff7fb-4806-4ecd-8c92-7f36dded0653"
      ],
      "Cache-Control": [
        "no-cache, private"
      ],
      "Content-Length": [
        "228"
      ],
      "Content-Type": [
        "application/json"
      ],
      "Date": [
        "Tue, 27 May 2025 22:07:33 GMT"
      ],
      "X-Kubernetes-Pf-Flowschema-Uid": [
        "edd5ba11-aa4a-454e-8c6b-02bf1bc06e82"
      ],
      "X-Kubernetes-Pf-Prioritylevel-Uid": [
        "9e7fd9e9-17dc-4882-8ba1-5a8bb9261040"
      ]
    },
    "body": "{\"kind\":\"SelfSubjectReview\",\"apiVersion\":\"authentication.k8s.io/v1\",\"metadata\":{\"creationTimestamp\":\"2025-05-27T22:07:33Z\"},\"status\":{\"userInfo\":{\"username\":\"m.le@beamreachinc.com\",\"groups\":[\"MT only\",\"system:authenticated\"]}}}\n"
  }
}
```

- Sample logs for `kubectl exec`

```
{
  "levelname": "info",
  "ts": "2025-05-27T22:09:29.178Z",
  "logger": "k8sgateway",
  "caller": "http/server.go:2822",
  "message": "API request",
  "version": "0.0.1",
  "request_id": "56fcddb7-094d-4e83-af4e-d844b2730b19",
  "method": "GET",
  "url": "/api/v1/namespaces/default/pods/internal-site-5c56bc6484-fvrgh/exec?command=%2Fbin%2Fash&container=internal-site&stdin=true&stdout=true&tty=true",
  "remote_addr": "10.16.1.4:44048",
  "user": {
    "id": "VXNlcjoxNTQ4NDQ1",
    "username": "m.le@beamreachinc.com",
    "groups": [
      "MT only"
    ]
  },
  "request": {
    "header": {
      "Authorization": [
        "Bearer void"
      ],
      "Connection": [
        "Upgrade"
      ],
      "Kubectl-Command": [
        "kubectl exec"
      ],
      "Kubectl-Session": [
        "63279c17-1a5b-4708-abe4-077a02a74d00"
      ],
      "Sec-Websocket-Key": [
        "9h4cDfx6r89VoTalsTlK6g=="
      ],
      "Sec-Websocket-Protocol": [
        "v5.channel.k8s.io"
      ],
      "Sec-Websocket-Version": [
        "13"
      ],
      "Upgrade": [
        "websocket"
      ],
      "User-Agent": [
        "kubectl/v1.31.2 (darwin/arm64) kubernetes/5864a46"
      ]
    },
    "body": ""
  }
}
{
  "levelname": "info",
  "ts": "2025-05-27T22:09:41.218Z",
  "logger": "k8sgateway",
  "caller": "httputil/reverseproxy.go:797",
  "message": "session finished",
  "version": "0.0.1",
  "request_id": "56fcddb7-094d-4e83-af4e-d844b2730b19",
  "method": "GET",
  "url": "/api/v1/namespaces/default/pods/internal-site-5c56bc6484-fvrgh/exec?command=%2Fbin%2Fash&container=internal-site&stdin=true&stdout=true&tty=true",
  "remote_addr": "10.16.1.4:44048",
  "user": {
    "id": "VXNlcjoxNTQ4NDQ1",
    "username": "m.le@beamreachinc.com",
    "groups": [
      "MT only"
    ]
  },
  "asciinema_data": "{\"version\":2,\"width\":158,\"height\":34,\"timestamp\":1748383769,\"command\":\"/bin/ash\",\"env\":null,\"user\":\"m.le@beamreachinc.com\",\"kubernetes\":{\"podname\":\"internal-site-5c56bc6484-fvrgh\",\"namespace\":\"default\",\"container\":\"internal-site\"}}\n[0.061540451,\"o\",\"\"]\n[0.31213546,\"o\",\"/ # \\u001b[6n\"]\n[9.653715077,\"o\",\"l\"]\n[9.766232528,\"o\",\"s\"]\n[10.124589908,\"o\",\"\\r\\n\"]\n[10.125627924,\"o\",\"\\u001b[1;34mbin\\u001b[m                   \\u001b[1;32mdocker-entrypoint.sh\\u001b[m  \\u001b[1;34mlib\\u001b[m                   \\u001b[1;34mopt\\u001b[m                   \\u001b[1;34mrun\\u001b[m                   \\u001b[1;34msys\\u001b[m                   \\u001b[1;34mvar\\u001b[m\\r\\n\\u001b[1;34mdev\\u001b[m                   \\u001b[1;34metc\\u001b[m                   \\u001b[1;34mmedia\\u001b[m                 \\u001b[1;34mproc\\u001b[m                  \\u001b[1;34msbin\\u001b[m                  \\u001b[1;34mtmp\\u001b[m\\r\\n\\u001b[1;34mdocker-entrypoint.d\\u001b[m   \\u001b[1;34mhome\\u001b[m                  \\u001b[1;34mmnt\\u001b[m                   \\u001b[1;34mroot\\u001b[m                  \\u001b[1;34msrv\\u001b[m                   \\u001b[1;34musr\\u001b[m\\r\\n\"]\n[10.125636796,\"o\",\"/ # \\u001b[6n\"]\n[10.892691563,\"o\",\"e\"]\n[11.074541612,\"o\",\"x\"]\n[11.177231742,\"o\",\"i\"]\n[11.310634709,\"o\",\"t\"]\n[11.427423738,\"o\",\"\\r\\n\"]"
}
```