### PR TITLE
feat: Logging improvements

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,8 +32,6 @@ builds:
     ldflags:
       - -s -w
       - -X k8sgateway/internal/version.Version={{.Version}}
-      - -X k8sgateway/internal/version.Commit={{.Commit}}
-      - -X k8sgateway/internal/version.Date={{.Date}}
     mod_timestamp: '{{ .CommitTimestamp }}'
   - id: gateway-debug
     binary: gateway-debug
@@ -49,8 +47,6 @@ builds:
       - -trimpath
     ldflags:
       - -X k8sgateway/internal/version.Version={{.Version}}
-      - -X k8sgateway/internal/version.Commit={{.Commit}}
-      - -X k8sgateway/internal/version.Date={{.Date}}
     mod_timestamp: '{{ .CommitTimestamp }}'
 
 dockers:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,9 +31,9 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
-      - -X main.commit={{.Commit}}
-      - -X main.date={{.Date}}
+      - -X k8sgateway/internal/version.Version={{.Version}}
+      - -X k8sgateway/internal/version.Commit={{.Commit}}
+      - -X k8sgateway/internal/version.Date={{.Date}}
     mod_timestamp: '{{ .CommitTimestamp }}'
   - id: gateway-debug
     binary: gateway-debug
@@ -48,9 +48,9 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -X main.version={{.Version}}
-      - -X main.commit={{.Commit}}
-      - -X main.date={{.Date}}
+      - -X k8sgateway/internal/version.Version={{.Version}}
+      - -X k8sgateway/internal/version.Commit={{.Commit}}
+      - -X k8sgateway/internal/version.Date={{.Date}}
     mod_timestamp: '{{ .CommitTimestamp }}'
 
 dockers:

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRootCmd_StartCommandArgs(t *testing.T) {
-	log.InitializeLogger("k8sgatewaytest", false)
+	log.InitializeLogger("gateway", false)
 
 	startMockCalled := false
 	startCmd.RunE = func(_cmd *cobra.Command, _args []string) error {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -32,7 +32,7 @@ var startCmd = &cobra.Command{
 type ProxyFactory func(httpproxy.Config) (httpproxy.ProxyService, error)
 
 func start(newProxy ProxyFactory) error {
-	log.InitializeLogger("k8sgateway", viper.GetBool("debug"))
+	log.InitializeLogger("gateway", viper.GetBool("debug"))
 
 	logger := zap.S()
 	logger.Infof("Gateway start called: %+v", viper.AllSettings())

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -89,7 +89,7 @@ func createParserAndGATToken(t *testing.T, claims token.GATClaims) (*token.Parse
 }
 
 func TestConnectValidator_ParseConnect(t *testing.T) {
-	log.InitializeLogger("k8sproxytest", false)
+	log.InitializeLogger("gateway", false)
 
 	c := newClient()
 	gatClaims := newGATTokenClaims(c.getPublicKey())

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -217,7 +217,7 @@ func startMockListener(t *testing.T) (net.Listener, string) {
 }
 
 func TestTCPListener_Accept_BadRequest(t *testing.T) {
-	log.InitializeLogger("k8sproxytest", false)
+	log.InitializeLogger("gateway", false)
 
 	listener, addr := startMockListener(t)
 	defer listener.Close()
@@ -283,7 +283,7 @@ func TestTCPListener_Accept_BadRequest(t *testing.T) {
 }
 
 func TestTCPListener_Accept_Healthcheck(t *testing.T) {
-	log.InitializeLogger("k8sproxytest", false)
+	log.InitializeLogger("gateway", false)
 
 	listener, addr := startMockListener(t)
 	defer listener.Close()
@@ -343,7 +343,7 @@ func TestTCPListener_Accept_Healthcheck(t *testing.T) {
 }
 
 func TestTCPListener_Accept_ValidConnectRequest(t *testing.T) {
-	log.InitializeLogger("k8sproxytest", false)
+	log.InitializeLogger("gateway", false)
 
 	listener, addr := startMockListener(t)
 	defer listener.Close()
@@ -426,7 +426,7 @@ func TestTCPListener_Accept_ValidConnectRequest(t *testing.T) {
 }
 
 func TestTCPListener_Accept_FailedValidation(t *testing.T) {
-	log.InitializeLogger("k8sproxytest", false)
+	log.InitializeLogger("gateway", false)
 
 	listener, addr := startMockListener(t)
 	defer listener.Close()
@@ -492,7 +492,7 @@ func TestTCPListener_Accept_FailedValidation(t *testing.T) {
 }
 
 func TestProxy_ForwardRequest(t *testing.T) {
-	log.InitializeLogger("k8sproxytest", false)
+	log.InitializeLogger("gateway", false)
 
 	// create mock API server (upstream)
 	apiServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -5,6 +5,8 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"k8sgateway/internal/version"
 )
 
 // Used to allow testing.
@@ -29,7 +31,7 @@ func InitializeLogger(name string, debug bool) {
 		logger = logger.Named(name)
 	}
 
-	logger = logger.With(zap.String("version", "0.0.1")) // TODO: version
+	logger = logger.With(zap.String("version", version.Version))
 
 	undoGlobals := zapReplaceGlobals(logger)
 	undoStd := zapRedirectStdLog(logger)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,10 +3,4 @@ package version
 var (
 	// Version is the current version of the application.
 	Version = "dev"
-
-	// Commit is the git commit SHA at build time.
-	Commit = "unknown"
-
-	// Date is the build timestamp.
-	Date = "unknown"
 )

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 var (
-	// Version is the current version of the application.
+	// Version represents the application version, set at build time via ldflags.
+	// Defaults to "dev" during development.
 	Version = "dev"
 )

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,12 @@
+package version
+
+var (
+	// Version is the current version of the application.
+	Version = "dev"
+
+	// Commit is the git commit SHA at build time.
+	Commit = "unknown"
+
+	// Date is the build timestamp.
+	Date = "unknown"
+)


### PR DESCRIPTION
## Changes

- Setup `ldflags` to receive the build metadata in Go code
- Use build version in log context
- Change logger name to `gateway` (default, for gateway issue) and `audit` (for auditing user activities) 

## Notes

Sample logs from local build
```
{
  "levelname": "info",
  "ts": "2025-05-30T22:40:13.567-0700",
  "logger": "gateway",
  "caller": "cmd/start.go:28",
  "message": "initializing Logger",
  "version": "0.1.2-local+0069f57"
}
{
  "levelname": "info",
  "ts": "2025-05-30T22:40:13.568-0700",
  "logger": "gateway",
  "caller": "cobra@v1.9.1/command.go:1015",
  "message": "Gateway start called: map[debug:false host:twingate.com k8sapiserverca: k8sapiservertoken: network: port:8443 tlscert: tlskey:]",
  "version": "0.1.2-local+0069f57"
}
```