### PR TITLE
feat: connection id

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,9 +61,6 @@ linters:
             - allowRegex: "^_"
         - name: unused-receiver
           disabled: true
-        - name: function-result-limit
-          arguments:
-            - 4
 
 formatters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,6 +61,9 @@ linters:
             - allowRegex: "^_"
         - name: unused-receiver
           disabled: true
+        - name: function-result-limit
+          arguments:
+            - 4
 
 formatters:
   enable:

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -13,13 +12,6 @@ import (
 
 	"k8sgateway/internal/token"
 )
-
-var (
-	errExpectedConnectRequest      = errors.New("expected CONNECT request")
-	errSignatureVerificationFailed = errors.New("failed to verify signature")
-)
-
-const unauthorizedResponse = "HTTP/1.1 401 Unauthorized\r\n\r\n"
 
 type ECDSASignature struct {
 	R, S *big.Int
@@ -34,52 +26,90 @@ const AuthSignatureHeaderKey string = "X-Token-Signature"
 // header that contains the Connection ID.
 const ConnIDHeaderKey string = "X-Connection-Id"
 
+type Info struct {
+	Claims *token.GATClaims
+	ConnID string
+}
+
+type HTTPError struct {
+	Err     error
+	Code    int // HTTP status code
+	Message string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("%d: %s", e.Code, e.Message)
+}
+
+func (e *HTTPError) Unwrap() error {
+	return e.Err
+}
+
 type Validator interface {
-	ParseConnect(req *http.Request, ekm []byte) (claims *token.GATClaims, connID string, response string, err error)
+	ParseConnect(req *http.Request, ekm []byte) (connectInfo Info, err error)
 }
 
 type MessageValidator struct {
 	TokenParser *token.Parser
 }
 
-func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (claims *token.GATClaims, connID string, response string, err error) {
+func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (connectInfo Info, err error) {
 	if req.Method != http.MethodConnect {
-		// did not receive CONNECT, respond with 405 Method Not Allowed
-		response = "HTTP/1.1 405 Method Not Allowed\r\n\r\n"
-
-		return nil, "", response, fmt.Errorf("%w, got %s", errExpectedConnectRequest, req.Method)
+		// did not receive CONNECT, return 405 Method Not Allowed
+		return Info{
+				Claims: nil,
+				ConnID: "",
+			}, &HTTPError{
+				Code:    http.StatusMethodNotAllowed,
+				Message: "expected CONNECT request got " + req.Method,
+				Err:     nil,
+			}
 	}
 
-	connID = req.Header.Get(ConnIDHeaderKey)
+	connID := req.Header.Get(ConnIDHeaderKey)
 
 	authHeader := req.Header.Get(AuthHeaderKey)
 
-	bearerToken, err := token.ParseBearerToken(authHeader)
-	if err != nil {
-		// did not receive identity header in CONNECT, respond with 407 Proxy Authentication Required and
-		// close the connection
-		response = "HTTP/1.1 407 Proxy Authentication Required\r\n\r\n"
-
-		return nil, connID, response, fmt.Errorf("missing identity header in CONNECT %w", err)
+	bearerToken, tokenErr := token.ParseBearerToken(authHeader)
+	if tokenErr != nil {
+		// did not receive identity header in CONNECT, return 407 Proxy Authentication Required
+		return Info{
+				Claims: nil,
+				ConnID: connID,
+			}, &HTTPError{
+				Code:    http.StatusProxyAuthRequired,
+				Message: fmt.Sprintf("missing identity header in CONNECT %v", tokenErr),
+				Err:     tokenErr,
+			}
 	}
 
 	gatClaims := &token.GATClaims{}
 
-	_, err = v.TokenParser.ParseWithClaims(bearerToken, gatClaims)
-	if err != nil {
-		response = unauthorizedResponse
-
-		return nil, connID, response, fmt.Errorf("failed to parse token with error %w", err)
+	_, tokenErr = v.TokenParser.ParseWithClaims(bearerToken, gatClaims)
+	if tokenErr != nil {
+		return Info{
+				Claims: nil,
+				ConnID: connID,
+			}, &HTTPError{
+				Code:    http.StatusUnauthorized,
+				Message: fmt.Sprintf("failed to parse token with error %v", tokenErr),
+				Err:     tokenErr,
+			}
 	}
 
 	// parse signature header for Proof-of-Possession
 	signatureB64 := req.Header.Get(AuthSignatureHeaderKey)
 
-	clientSig, err := base64.StdEncoding.DecodeString(signatureB64)
-	if err != nil {
-		response = unauthorizedResponse
-
-		return gatClaims, connID, response, fmt.Errorf("failed to decode client signature with error %w", err)
+	clientSig, tokenErr := base64.StdEncoding.DecodeString(signatureB64)
+	if tokenErr != nil {
+		return Info{
+				Claims: gatClaims,
+				ConnID: connID,
+			}, &HTTPError{
+				Code:    http.StatusUnauthorized,
+				Message: fmt.Sprintf("failed to decode client signature with error %v", tokenErr),
+				Err:     tokenErr,
+			}
 	}
 
 	// verify signature
@@ -87,28 +117,44 @@ func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (claims *
 
 	ok := ecdsa.VerifyASN1(&gatClaims.ClientPublicKey.PublicKey, hashed[:], clientSig)
 	if !ok {
-		response = unauthorizedResponse
-
-		return gatClaims, connID, response, errSignatureVerificationFailed
+		return Info{
+				Claims: gatClaims,
+				ConnID: connID,
+			}, &HTTPError{
+				Code:    http.StatusUnauthorized,
+				Message: "failed to verify signature",
+				Err:     nil,
+			}
 	}
 
 	// verify address in CONNECT with the GAT token
 	address := req.RequestURI
 
-	host, _, err := net.SplitHostPort(address)
-	if err != nil {
-		response = unauthorizedResponse
-
-		return gatClaims, connID, response, fmt.Errorf("failed to parse CONNECT destination: %w", err)
+	host, _, hostErr := net.SplitHostPort(address)
+	if hostErr != nil {
+		return Info{
+				Claims: gatClaims,
+				ConnID: connID,
+			}, &HTTPError{
+				Code:    http.StatusBadRequest,
+				Message: fmt.Sprintf("failed to parse CONNECT destination: %v", hostErr),
+				Err:     hostErr,
+			}
 	}
 
 	if !strings.EqualFold(host, gatClaims.Resource.Address) {
-		response = unauthorizedResponse
-
-		return gatClaims, connID, response, fmt.Errorf("failed to verify CONNECT destination: %s(err: %w) with token resource address %s", host, err, gatClaims.Resource.Address)
+		return Info{
+				Claims: gatClaims,
+				ConnID: connID,
+			}, &HTTPError{
+				Code:    http.StatusUnauthorized,
+				Message: fmt.Sprintf("failed to verify CONNECT destination: %s with token resource address %s", host, gatClaims.Resource.Address),
+				Err:     nil,
+			}
 	}
 
-	response = "HTTP/1.1 200 Connection Established\r\n\r\n"
-
-	return gatClaims, connID, response, nil
+	return Info{
+		Claims: gatClaims,
+		ConnID: connID,
+	}, nil
 }

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -147,7 +147,7 @@ func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (connectI
 				Claims: gatClaims,
 				ConnID: connID,
 			}, &HTTPError{
-				Code:    http.StatusUnauthorized,
+				Code:    http.StatusBadRequest,
 				Message: fmt.Sprintf("failed to verify CONNECT destination: %s with token resource address %s", host, gatClaims.Resource.Address),
 				Err:     nil,
 			}

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -310,7 +310,7 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 
 		require.NoError(t, httpErr.Err)
 		require.Error(t, httpErr)
-		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
+		assert.Equal(t, http.StatusBadRequest, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to verify CONNECT destination")
 		assert.Equal(t, *connectInfo.Claims, gatClaims)
 		assert.Equal(t, "conn-id", connectInfo.ConnID)

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -352,7 +352,7 @@ func TestHTTPError_Error(t *testing.T) {
 		want    string
 	}{
 		{
-			name:    "404 Not Found",
+			name:    "Not Found",
 			code:    404,
 			message: "Not Found",
 			want:    "404: Not Found",

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -366,8 +366,8 @@ func TestHTTPError_Error(t *testing.T) {
 		{
 			name:    "Bad Request",
 			code:    400,
-			message: "",
-			want:    "400: ",
+			message: "Bad Request",
+			want:    "400: Bad Request",
 		},
 	}
 

--- a/internal/httpproxy/http_proxy.go
+++ b/internal/httpproxy/http_proxy.go
@@ -178,7 +178,7 @@ func (l *tcpListener) Accept() (net.Conn, error) {
 		if errors.As(err, &httpErr) {
 			response = httpResponseString(httpErr.Code)
 		} else {
-			logger.Errorf("failed to parse CONNECT: %v", err)
+			logger.Error("failed to parse CONNECT:", zap.Error(err))
 
 			response = httpResponseString(http.StatusBadRequest)
 		}

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -187,7 +187,6 @@ type mockValidator struct {
 
 func (m *mockValidator) ParseConnect(req *http.Request, _ []byte) (connectInfo connect.Info, err error) {
 	if m.shouldFail {
-		// return nil, "", "HTTP/1.1 407 Proxy Authentication Required\r\n\r\n", errors.New("failed to validate token")
 		return connect.Info{
 				Claims: nil,
 				ConnID: "",


### PR DESCRIPTION
## Changes
- parse `X-Connection-ID` from CONNECT and store as conn metadata
- use connection ID for logging
- add user info to logging if available in listener `Accept()`

## Notes
example logs:
```
{"levelname":"error","ts":"2025-05-31T23:45:45.544-0700","logger":"k8sgateway","caller":"httpproxy/http_proxy.go:394","message":"failed to serve request: missing identity header in CONNECT failed to parse bearer token : Bearer","version":"0.0.1","conn_id":"467e6404-58ab-4a34-8534-534a9f16d228"}
```

```
{"levelname":"error","ts":"2025-05-31T23:47:06.328-0700","logger":"k8sgateway","caller":"httpproxy/http_proxy.go:394","message":"failed to serve request: failed to verify signature","version":"0.0.1","user":{"id":"VXNlcjoxNTQ4NDQ2","username":"sean@acme.com","groups":["Everyone"]},"conn_id":"e1aa3a08-1535-423a-9032-e24bc3e6a060"}
```

```
{"levelname":"info","ts":"2025-05-31T23:48:43.481-0700","logger":"k8sgateway","caller":"httputil/reverseproxy.go:797","message":"session finished","version":"0.0.1","request_id":"a832b4b0-3603-4fb8-9b64-c8c2b53d3148","method":"GET","url":"/api/v1/namespaces/default/pods/internal-site-9c7cd947c-njbmt/exec?command=%2Fbin%2Fash&container=internal-site&stdin=true&stdout=true&tty=true","remote_addr":"127.0.0.1:33860","user":{"id":"VXNlcjoxNTQ4NDQ2","username":"sean@acme.com","groups":["Everyone"]},"conn_id":"ddc671ff-c180-4231-bb01-084d89bebdb1","asciinema_data":"{\"version\":2,\"width\":132,\"height\":41,\"timestamp\":1748760521,\"command\":\"/bin/ash\",\"env\":null,\"user\":\"sean@acme.com\",\"kubernetes\":{\"podname\":\"internal-site-9c7cd947c-njbmt\",\"namespace\":\"default\",\"container\":\"internal-site\"}}\n[0.124635579,\"o\",\"\"]\n[0.124669784,\"o\",\"/ # \\u001b[6n\"]\n[0.126202384,\"o\",\"\\r/ # \\u001b[J\"]\n[0.718207141,\"o\",\"l\"]\n[0.806812138,\"o\",\"s\"]\n[0.883865886,\"o\",\"\\r\\n\"]\n[0.885164343,\"o\",\"\\u001b[1;34mbin\\u001b[m                   \\u001b[1;34mhome\\u001b[m                  \\u001b[1;34mproc\\u001b[m                  \\u001b[1;34msbin\\u001b[m                  \\u001b[1;34mvar\\u001b[m\\r\\n\\u001b[1;34mdev\\u001b[m                   \\u001b[1;34mlib\\u001b[m                   \\u001b[0;0mproduct_name\\u001b[m          \\u001b[1;34msrv\\u001b[m\\r\\n\\u001b[1;34mdocker-entrypoint.d\\u001b[m   \\u001b[1;34mmedia\\u001b[m                 \\u001b[0;0mproduct_uuid\\u001b[m          \\u001b[1;34msys\\u001b[m\\r\\n\\u001b[1;32mdocker-entrypoint.sh\\u001b[m  \\u001b[1;34mmnt\\u001b[m                   \\u001b[1;34mroot\\u001b[m                  \\u001b[1;34mtmp\\u001b[m\\r\\n\\u001b[1;34metc\\u001b[m                   \\u001b[1;34mopt\\u001b[m                   \\u001b[1;34mrun\\u001b[m                   \\u001b[1;34musr\\u001b[m\\r\\n\"]\n[0.885330368,\"o\",\"/ # \\u001b[6n\"]\n[1.565372743,\"o\",\"\\r\\n\"]"}
```
