### PR TITLE
fix: Fix the default `host` value to `twingate.com` in Helm chart

### DIFF
--- a/deploy/gateway/templates/_helpers.tpl
+++ b/deploy/gateway/templates/_helpers.tpl
@@ -106,7 +106,7 @@ Create the existing alternative names hash of the TLS secret
 Create the Twingate host
 */}}
 {{- define "gateway.twingate.host" -}}
-{{- default "twingate.host" .Values.twingate.host }}
+{{- default "twingate.com" .Values.twingate.host }}
 {{- end }}
 
 

--- a/deploy/gateway/tests/__snapshot__/NOTES_test.yaml.snap
+++ b/deploy/gateway/tests/__snapshot__/NOTES_test.yaml.snap
@@ -2,7 +2,7 @@ should show ClusterIP instructions when service type is ClusterIP:
   1: |+
     raw: |2+
 
-      Admin Console URL - https://.twingate.host
+      Admin Console URL - https://.twingate.com
 
       1. The Gateway is accessible via its ClusterIP DNS at
 
@@ -34,7 +34,7 @@ should show LoadBalancer instructions when service type is LoadBalancer:
   1: |+
     raw: |2+
 
-      Admin Console URL - https://.twingate.host
+      Admin Console URL - https://.twingate.com
 
       1. The Gateway is accessible via its LoadBalancer IP. It may take a few minutes for the IP address to be available.
 
@@ -66,7 +66,7 @@ should show previously generated CA when the alternative names have not changed:
   1: |+
     raw: |2+
 
-      Admin Console URL - https://.twingate.host
+      Admin Console URL - https://.twingate.com
 
       1. The Gateway is accessible via its ClusterIP DNS at
 
@@ -98,7 +98,7 @@ should use `existingSecret` Secret object when provided:
   1: |+
     raw: |2+
 
-      Admin Console URL - https://.twingate.host
+      Admin Console URL - https://.twingate.com
 
       1. The Gateway is accessible via its ClusterIP DNS at
 
@@ -130,7 +130,7 @@ should use `tls.ca` value when provided:
   1: |+
     raw: |2+
 
-      Admin Console URL - https://.twingate.host
+      Admin Console URL - https://.twingate.com
 
       1. The Gateway is accessible via its ClusterIP DNS at
 

--- a/deploy/gateway/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/deploy/gateway/tests/__snapshot__/snapshot_test.yaml.snap
@@ -57,7 +57,7 @@ should render:
                 - name: TWINGATE_NETWORK
                   value: null
                 - name: TWINGATE_HOST
-                  value: twingate.host
+                  value: twingate.com
               image: twingate/kubernetes-access-gateway:0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:


### PR DESCRIPTION
## Changes

Fix the default `host` value to "twingate.com" in Helm chart