### PR TITLE
chore: Using `ecdsa.SignASN1` to simplify test code

### DIFF
--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -5,17 +5,12 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"math/big"
 	"net"
 	"net/http"
 	"strings"
 
 	"k8sgateway/internal/token"
 )
-
-type ECDSASignature struct {
-	R, S *big.Int
-}
 
 // header that contains the auth token.
 const AuthHeaderKey string = "Proxy-Authorization"

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
-	"encoding/asn1"
 	"encoding/base64"
 	"errors"
 	"net/http"
@@ -31,9 +30,7 @@ func (c client) getPublicKey() token.PublicKey {
 
 func (c client) sign(t string) string {
 	hash := sha256.Sum256([]byte(t))
-	r, s, _ := ecdsa.Sign(rand.Reader, c.privateKey, hash[:])
-
-	signature, _ := asn1.Marshal(ECDSASignature{R: r, S: s})
+	signature, _ := ecdsa.SignASN1(rand.Reader, c.privateKey, hash[:])
 
 	return base64.StdEncoding.EncodeToString(signature)
 }


### PR DESCRIPTION
## Changes

Using `ecdsa.SignASN1` to simplify test code and remove unnecessary struct