### PR TITLE
feat: Skip auditing for certain operations

### DIFF
--- a/internal/httpproxy/http_proxy.go
+++ b/internal/httpproxy/http_proxy.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -33,11 +34,6 @@ const healthCheckPath = "/healthz"
 const ConnContextKey connContextKey = "CONN_CONTEXT"
 
 const secretLen = 32
-
-const (
-	upgradeHeaderKey      = "Upgrade"
-	upgradeWebsocketValue = "websocket"
-)
 
 const (
 	bodyLogMaxSize           = 16 * 1024 // 16KB
@@ -463,20 +459,18 @@ func (p *Proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		zap.String("body", logReqBody),
 	)
 
-	if r.Header.Get(upgradeHeaderKey) == upgradeWebsocketValue {
-		// check for websocket with tunneling subprotocol and treat as regular TCP traffic without recording
-		if wsstream.IsWebSocketRequestWithTunnelingProtocol(r) {
-			p.proxy.ServeHTTP(w, r)
-		} else {
-			// start hijacker which will parse websocket messages and record the session
-			recorderFactory := func() wsproxy.Recorder {
-				return wsproxy.NewRecorder(auditLogger)
-			}
-			wsHijacker := wsproxy.NewHijacker(r, w, conn.claims.User.Username, recorderFactory, wsproxy.NewConn)
-			p.proxy.ServeHTTP(wsHijacker, r)
+	isWebSocketRequest := wsstream.IsWebSocketRequest(r)
+
+	switch {
+	case isWebSocketRequest && !shouldSkipWebSocketRequest(r):
+		// Audit Websocket streaming session
+		recorderFactory := func() wsproxy.Recorder {
+			return wsproxy.NewRecorder(auditLogger)
 		}
-	} else {
-		// for HTTP we want to log the response
+		wsHijacker := wsproxy.NewHijacker(r, w, conn.claims.User.Username, recorderFactory, wsproxy.NewConn)
+		p.proxy.ServeHTTP(wsHijacker, r)
+	case !isWebSocketRequest && !shouldSkipRESTRequest(r):
+		// Audit REST API response
 		responseLogger := &responseLogger{ResponseWriter: w, statusCode: http.StatusOK, body: &bytes.Buffer{}}
 		defer func() {
 			// truncate the body log if it's too large
@@ -489,7 +483,25 @@ func (p *Proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {
 				zap.String("body", logResBody),
 			)
 		}()
-
 		p.proxy.ServeHTTP(responseLogger, r)
+	default:
+		// No audit
+		p.proxy.ServeHTTP(w, r)
 	}
+}
+
+var podLogPattern = regexp.MustCompile(`^/api/v1/namespaces/[^/]+/pods/[^/]+/log$`)
+
+func shouldSkipWebSocketRequest(r *http.Request) bool {
+	// Skip tunneling requests (e.g. `kubectl proxy`)
+	return wsstream.IsWebSocketRequestWithTunnelingProtocol(r) ||
+		// Skip file transferring from `kubectl cp`
+		r.Header.Get("Kubectl-Command") == "kubectl cp" ||
+		// Skip executing `tar` command
+		r.URL.Query().Get("command") == "tar"
+}
+
+func shouldSkipRESTRequest(r *http.Request) bool {
+	// Skip requests for pod logs
+	return podLogPattern.MatchString(r.URL.Path)
 }

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -645,7 +645,7 @@ func TestProxy_ForwardRequest(t *testing.T) {
 	assert.Equal(t, "Upstream API Server Response!", string(body))
 }
 
-func TestShouldAuditRESTRequest(t *testing.T) {
+func TestShouldSkipRESTRequest(t *testing.T) {
 	tests := []struct {
 		name     string
 		request  *http.Request
@@ -676,7 +676,7 @@ func TestShouldAuditRESTRequest(t *testing.T) {
 	}
 }
 
-func TestShouldAuditWebSocketRequest(t *testing.T) {
+func TestShouldSkipWebSocketRequest(t *testing.T) {
 	tests := []struct {
 		name         string
 		newRequestFn func() *http.Request

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -644,3 +644,86 @@ func TestProxy_ForwardRequest(t *testing.T) {
 	// check response
 	assert.Equal(t, "Upstream API Server Response!", string(body))
 }
+
+func TestShouldAuditRESTRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		request  *http.Request
+		expected bool
+	}{
+		{
+			name:     "Get a pod log request",
+			request:  httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/pod-1/log", nil),
+			expected: true,
+		},
+		{
+			name:     "Get a pod request",
+			request:  httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/pod-1", nil),
+			expected: false,
+		},
+		{
+			name:     "Get a namespace request",
+			request:  httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default", nil),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldSkipRESTRequest(tt.request)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestShouldAuditWebSocketRequest(t *testing.T) {
+	tests := []struct {
+		name         string
+		newRequestFn func() *http.Request
+		expected     bool
+	}{
+		{
+			name: "WebSocket request with tunneling protocol",
+			newRequestFn: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/", nil)
+				r.Header.Set("Upgrade", "websocket")
+				r.Header.Set("Connection", "upgrade")
+				r.Header.Set("Sec-WebSocket-Protocol", "SPDY/3.1+portforward.k8s.io")
+
+				return r
+			},
+			expected: true,
+		},
+		{
+			name: "WebSocket request with `kubectl cp` command",
+			newRequestFn: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/", nil)
+				r.Header.Set("Kubectl-Command", "kubectl cp")
+
+				return r
+			},
+			expected: true,
+		},
+		{
+			name: "WebSocket request with tar command",
+			newRequestFn: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/pod-1/exec?command=tar", nil)
+			},
+			expected: true,
+		},
+		{
+			name: "WebSocket request with other command",
+			newRequestFn: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/pod-1/exec?command=ls", nil)
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldSkipWebSocketRequest(tt.newRequestFn())
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Changes

Skip auditing for the following operations
- `kubectl cp`
- `kubectl exec` with `tar` command (`kubectl cp` actually does this behind the scene)
- `kubectl logs`