### PR TITLE
feat: Support bearer token refresh for in-cluster deployment

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -64,11 +64,12 @@ func start(newProxy ProxyFactory) error {
 		},
 	}
 
-	if inClusterK8sCfg, _ := rest.InClusterConfig(); inClusterK8sCfg != nil {
+	if inClusterK8sCfg, err := rest.InClusterConfig(); inClusterK8sCfg != nil {
 		logger.Info("Using in-cluster configuration")
 
 		cfg.K8sAPIServerCA = inClusterK8sCfg.CAFile
 		cfg.K8sAPIServerToken = inClusterK8sCfg.BearerToken
+		cfg.K8sAPIServerTokenFile = inClusterK8sCfg.BearerTokenFile
 		cfg.TLSCert = "/etc/tls-secret-volume/tls.crt"
 		cfg.TLSKey = "/etc/tls-secret-volume/tls.key"
 	} else if !errors.Is(err, rest.ErrNotInCluster) {


### PR DESCRIPTION
## Changes

Use client-go's `NewBearerAuthWithRefreshRoundTripper` transport to refresh the bearer token from the provided file (`/var/run/secrets/kubernetes.io/serviceaccount/token` for in-cluster deployment)