### PR TITLE
feat: Move `livenessProbe` and `readinessProbe` configuration to `values.yaml` to allow debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ You can debug the Gateway locally using Minikube or other Kubernetes environment
    ```sh
    helm upgrade <release-name> ./deploy/gateway/ --install -f <values.yaml> \
      --set image.tag="<one of the tags from previous step>" \
+     --set livenessProbe.timeoutSeconds=3600 \
+     --set readinessProbe.timeoutSeconds=3600
    ```
 
    > **Note:** Replace `<release-name>` and `<values.yaml>` with your actual release name and values file.

--- a/deploy/gateway/templates/deployment.yaml
+++ b/deploy/gateway/templates/deployment.yaml
@@ -45,19 +45,9 @@ spec:
               containerPort: {{ (.Values.containerPorts | default dict).https | default 8443 }}
               protocol: TCP
           livenessProbe:
-            httpGet:
-              port: https
-              scheme: HTTPS
-              path: /healthz
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              port: https
-              scheme: HTTPS
-              path: /healthz
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/deploy/gateway/values.yaml
+++ b/deploy/gateway/values.yaml
@@ -106,3 +106,19 @@ service:
   # This can be used to set the LoadBalancer service type to internal only.
   # For more information checkout: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
   annotations: {}
+
+livenessProbe:
+  httpGet:
+    port: https
+    scheme: HTTPS
+    path: /healthz
+  initialDelaySeconds: 5
+  periodSeconds: 5
+
+readinessProbe:
+  httpGet:
+    port: https
+    scheme: HTTPS
+    path: /healthz
+  initialDelaySeconds: 5
+  periodSeconds: 5


### PR DESCRIPTION
## Changes
- Moved the `livenessProbe` and `readinessProbe` configuration to `values.yaml`
- Update `README.md` helm instruction to extend `livenessProbe` and `readinessProbe` timeout duration for debugging