### PR TITLE
chore: Update Helm installation instruction for `LoadBalancer` service type

### DIFF
--- a/deploy/gateway/templates/NOTES.txt
+++ b/deploy/gateway/templates/NOTES.txt
@@ -13,9 +13,9 @@ Admin Console URL - {{ printf "https://%s.%s" .Values.twingate.network (include 
 
 {{- else if eq "LoadBalancer"  .Values.service.type }}
 
-1. The Gateway is accessible via its LoadBalancer IP. It may take a few minutes for the IP address to be available.
+1. The Gateway is accessible via its LoadBalancer IP or hostname. It may take a few minutes for the address to be available.
 
-Watch the IP address with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "gateway.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0]}''
+Watch the LoadBalancer address with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "gateway.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0]}''
 
 {{- end }}
 

--- a/deploy/gateway/templates/NOTES.txt
+++ b/deploy/gateway/templates/NOTES.txt
@@ -15,7 +15,7 @@ Admin Console URL - {{ printf "https://%s.%s" .Values.twingate.network (include 
 
 1. The Gateway is accessible via its LoadBalancer IP. It may take a few minutes for the IP address to be available.
 
-Watch the IP address with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "gateway.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}''
+Watch the IP address with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "gateway.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0]}''
 
 {{- end }}
 

--- a/deploy/gateway/tests/__snapshot__/NOTES_test.yaml.snap
+++ b/deploy/gateway/tests/__snapshot__/NOTES_test.yaml.snap
@@ -36,9 +36,9 @@ should show LoadBalancer instructions when service type is LoadBalancer:
 
       Admin Console URL - https://.twingate.com
 
-      1. The Gateway is accessible via its LoadBalancer IP. It may take a few minutes for the IP address to be available.
+      1. The Gateway is accessible via its LoadBalancer IP or hostname. It may take a few minutes for the address to be available.
 
-      Watch the IP address with: 'kubectl get svc --namespace NAMESPACE -w RELEASE-NAME-kubernetes-access-gateway -o jsonpath='{.status.loadBalancer.ingress[0]}''
+      Watch the LoadBalancer address with: 'kubectl get svc --namespace NAMESPACE -w RELEASE-NAME-kubernetes-access-gateway -o jsonpath='{.status.loadBalancer.ingress[0]}''
 
       2. The Gateway uses TLS certificates from the "RELEASE-NAME-kubernetes-access-gateway-tls" Secret. The CA certificate is
 

--- a/deploy/gateway/tests/__snapshot__/NOTES_test.yaml.snap
+++ b/deploy/gateway/tests/__snapshot__/NOTES_test.yaml.snap
@@ -38,7 +38,7 @@ should show LoadBalancer instructions when service type is LoadBalancer:
 
       1. The Gateway is accessible via its LoadBalancer IP. It may take a few minutes for the IP address to be available.
 
-      Watch the IP address with: 'kubectl get svc --namespace NAMESPACE -w RELEASE-NAME-kubernetes-access-gateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}''
+      Watch the IP address with: 'kubectl get svc --namespace NAMESPACE -w RELEASE-NAME-kubernetes-access-gateway -o jsonpath='{.status.loadBalancer.ingress[0]}''
 
       2. The Gateway uses TLS certificates from the "RELEASE-NAME-kubernetes-access-gateway-tls" Secret. The CA certificate is
 


### PR DESCRIPTION
## Changes
- Update `NOTES.txt` installation instructions for `LoadBalancer` service type

## Notes
Some Cloud providers (E.g. AWS) do not have the `ip` field in the `status.loadBalancer.ingress[0]` object.