### PR TITLE
chore: Enable `godox` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,6 @@ linters:
     - forcetypeassert  # Covered by revive linter's unchecked-type-assertion rule
     - funlen
     - gochecknoglobals
-    - godox  # FIXME
     - gosmopolitan
     - lll  # Covered by revive linter's line-length-limit rule
     - maintidx


### PR DESCRIPTION
## Changes

We have addressed and removed all `FIXME` comments