### PR TITLE
feat: Add Twingate Gateway-specific Prometheus metrics

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -30,16 +30,16 @@ var (
 )
 
 var (
-	APIConnectionsActiveTotal       prometheus.Gauge
+	APIConnectionsActive            prometheus.Gauge
 	APIConnectionsDurationSeconds   prometheus.Histogram
-	ClientConnectionsActiveTotal    prometheus.Gauge
+	ClientConnectionsActive         prometheus.Gauge
 	ClientConnectionDurationSeconds prometheus.Histogram
 	ClientConnectionErrorsTotal     *prometheus.CounterVec
 	ClientAuthenticationsTotal      *prometheus.CounterVec
 	HTTPRequestsTotal               *prometheus.CounterVec
 	HTTPRequestSizeBytes            *prometheus.HistogramVec
 	HTTPResponseSizeBytes           prometheus.Histogram
-	WebsocketSessionsActiveTotal    prometheus.Gauge
+	WebsocketSessionsActive         prometheus.Gauge
 	WebsocketSessionDurationSeconds prometheus.Histogram
 	WebsocketSessionErrorsTotal     *prometheus.CounterVec
 )
@@ -85,9 +85,9 @@ func initMetricCollectors(reg *prometheus.Registry) {
 	processCollector = collectors.NewProcessCollector(collectors.ProcessCollectorOpts{})
 
 	// region API Server Metrics.
-	APIConnectionsActiveTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+	APIConnectionsActive = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
-		Name:      "api_connections_active_total",
+		Name:      "api_connections_active",
 		Help:      "Number of currently active API server connections",
 	})
 
@@ -100,9 +100,9 @@ func initMetricCollectors(reg *prometheus.Registry) {
 	// endregion
 
 	// region Client Metrics.
-	ClientConnectionsActiveTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+	ClientConnectionsActive = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
-		Name:      "client_connections_active_total",
+		Name:      "client_connections_active",
 		Help:      "Number of currently active client connections",
 	})
 
@@ -149,9 +149,9 @@ func initMetricCollectors(reg *prometheus.Registry) {
 	// endregion
 
 	// region Websocket Metrics.
-	WebsocketSessionsActiveTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+	WebsocketSessionsActive = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
-		Name:      "websocket_sessions_active_total",
+		Name:      "websocket_sessions_active",
 		Help:      "Total number of currently active WebSocket sessions",
 	})
 
@@ -173,16 +173,16 @@ func initMetricCollectors(reg *prometheus.Registry) {
 		buildInfo,
 		goCollector,
 		processCollector,
-		APIConnectionsActiveTotal,
+		APIConnectionsActive,
 		APIConnectionsDurationSeconds,
-		ClientConnectionsActiveTotal,
+		ClientConnectionsActive,
 		ClientConnectionDurationSeconds,
 		ClientConnectionErrorsTotal,
 		ClientAuthenticationsTotal,
 		HTTPRequestsTotal,
 		HTTPRequestSizeBytes,
 		HTTPResponseSizeBytes,
-		WebsocketSessionsActiveTotal,
+		WebsocketSessionsActive,
 		WebsocketSessionDurationSeconds,
 		WebsocketSessionErrorsTotal,
 	)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -32,10 +32,10 @@ func TestInitMetricCollectors(t *testing.T) {
 		// Process Metric
 		"process_cpu_seconds_total",
 		// API Server Metrics
-		"twingate_gateway_api_connections_active_total",
+		"twingate_gateway_api_connections_active",
 		"twingate_gateway_api_connection_duration_seconds",
 		// Client Metrics
-		"twingate_gateway_client_connections_active_total",
+		"twingate_gateway_client_connections_active",
 		"twingate_gateway_client_connection_duration_seconds",
 		"twingate_gateway_client_connection_errors_total",
 		"twingate_gateway_client_authentications_total",
@@ -44,7 +44,7 @@ func TestInitMetricCollectors(t *testing.T) {
 		"twingate_gateway_http_request_size_bytes",
 		"twingate_gateway_http_response_size_bytes",
 		// WebSocket Metrics
-		"twingate_gateway_websocket_sessions_active_total",
+		"twingate_gateway_websocket_sessions_active",
 		"twingate_gateway_websocket_session_duration_seconds",
 		"twingate_gateway_websocket_session_errors_total",
 	}


### PR DESCRIPTION
Branched out from #31 

## Changes
- Add Twingate Gateway-specific Prometheus metrics. See notes below for the full list.

## Notes
### Gateway <-> API Server connection metrics
1. `twingate_gateway_api_connections_active`
2. `twingate_gateway_api_connection_duration_seconds`

### Gateway <-> Client connection Metrics
1. `twingate_gateway_client_connections_active`
2. `twingate_gateway_client_connection_duration_seconds`
3. `twingate_gateway_client_connection_errors_total`
4. `twingate_gateway_client_authentications_total`

### HTTP Metrics
1. `twingate_gateway_http_requests_total`
2. `twingate_gateway_http_request_size_bytes`
3. `twingate_gateway_http_response_size_bytes`

### WebSocket Metrics
1. `twingate_gateway_websocket_sessions_active`
2. `twingate_gateway_websocket_session_duration_seconds`
3. `twingate_gateway_websocket_session_errors_total`
 