### PR TITLE
feat: Include Asciinema header in every session recording part

### DIFF
--- a/internal/wsproxy/recorder.go
+++ b/internal/wsproxy/recorder.go
@@ -255,7 +255,8 @@ func (r *AsciinemaRecorder) flush(isFinal bool) {
 	defer r.mu.Unlock()
 
 	// Always flush final logs. Otherwise, flush if there is a header and some events.
-	if !isFinal && (len(r.recordedLines) == 0 || r.header == "") {
+	shouldFlush := isFinal || (len(r.recordedLines) > 0 && r.header != "")
+	if !shouldFlush {
 		return
 	}
 


### PR DESCRIPTION
## Changes

This allows each session recording part is a valid Asciinema. End user should remove the header of subsequent parts when "stitching" the whole recording.