### PR TITLE
refactor: Modernize tests to use `testify`

### DIFF
--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -169,6 +169,7 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		var httpErr *HTTPError
 
 		require.ErrorAs(t, err, &httpErr)
+		require.Error(t, httpErr.Err)
 		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to parse token")
 		assert.Nil(t, connectInfo.Claims)
@@ -189,6 +190,7 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		var httpErr *HTTPError
 
 		require.ErrorAs(t, err, &httpErr)
+		require.Error(t, httpErr.Err)
 		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to decode client signature")
 		assert.Equal(t, *connectInfo.Claims, gatClaims)
@@ -208,6 +210,7 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		var httpErr *HTTPError
 
 		require.ErrorAs(t, err, &httpErr)
+		require.NoError(t, httpErr.Err)
 		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to verify signature")
 		assert.Equal(t, *connectInfo.Claims, gatClaims)
@@ -229,6 +232,7 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		var httpErr *HTTPError
 
 		require.ErrorAs(t, err, &httpErr)
+		require.NoError(t, httpErr.Err)
 		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to verify signature")
 		assert.Equal(t, *connectInfo.Claims, gatClaims)
@@ -252,6 +256,7 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		var httpErr *HTTPError
 
 		require.ErrorAs(t, err, &httpErr)
+		require.NoError(t, httpErr.Err)
 		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to verify signature")
 		assert.Equal(t, *connectInfo.Claims, gatClaims)
@@ -275,6 +280,7 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		var httpErr *HTTPError
 
 		require.ErrorAs(t, err, &httpErr)
+		require.NoError(t, httpErr.Err)
 		assert.Equal(t, http.StatusBadRequest, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to verify CONNECT destination")
 		assert.Equal(t, *connectInfo.Claims, gatClaims)
@@ -298,6 +304,7 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		var httpErr *HTTPError
 
 		require.ErrorAs(t, err, &httpErr)
+		require.Error(t, httpErr.Err)
 		assert.Equal(t, http.StatusBadRequest, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to parse CONNECT destination")
 		assert.Equal(t, *connectInfo.Claims, gatClaims)

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -345,7 +345,7 @@ func TestHTTPError_Error(t *testing.T) {
 				Code:    tt.code,
 				Message: tt.message,
 			}
-			assert.Equal(t, tt.want, e.Error(), "HTTPError.Error() = %v, want %v", e.Error(), tt.want)
+			assert.Equal(t, tt.want, e.Error())
 		})
 	}
 }

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -122,12 +121,8 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		connectInfo, err := validator.ParseConnect(req, []byte(sigData))
 
 		var httpErr *HTTPError
-		if !errors.As(err, &httpErr) {
-			t.Fatalf("expected error of type *HTTPError, but got %T (%v)", err, err)
-		}
 
-		require.NoError(t, httpErr.Err)
-		require.Error(t, httpErr)
+		require.ErrorAs(t, err, &httpErr)
 		assert.Equal(t, http.StatusMethodNotAllowed, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "expected CONNECT request")
 		assert.Nil(t, connectInfo.Claims)
@@ -144,12 +139,8 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		connectInfo, err := validator.ParseConnect(req, []byte(sigData))
 
 		var httpErr *HTTPError
-		if !errors.As(err, &httpErr) {
-			t.Fatalf("expected error of type *HTTPError, but got %T (%v)", err, err)
-		}
 
-		require.Error(t, httpErr.Err)
-		require.Error(t, httpErr)
+		require.ErrorAs(t, err, &httpErr)
 		assert.Equal(t, http.StatusProxyAuthRequired, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "missing identity header")
 		assert.Nil(t, connectInfo.Claims)
@@ -176,12 +167,8 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		connectInfo, err := validator.ParseConnect(req, []byte(sigData))
 
 		var httpErr *HTTPError
-		if !errors.As(err, &httpErr) {
-			t.Fatalf("expected error of type *HTTPError, but got %T (%v)", err, err)
-		}
 
-		require.Error(t, httpErr.Err)
-		require.Error(t, httpErr)
+		require.ErrorAs(t, err, &httpErr)
 		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to parse token")
 		assert.Nil(t, connectInfo.Claims)
@@ -200,12 +187,8 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		connectInfo, err := validator.ParseConnect(req, []byte(sigData))
 
 		var httpErr *HTTPError
-		if !errors.As(err, &httpErr) {
-			t.Fatalf("expected error of type *HTTPError, but got %T (%v)", err, err)
-		}
 
-		require.Error(t, httpErr.Err)
-		require.Error(t, httpErr)
+		require.ErrorAs(t, err, &httpErr)
 		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to decode client signature")
 		assert.Equal(t, *connectInfo.Claims, gatClaims)
@@ -223,12 +206,8 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		connectInfo, err := validator.ParseConnect(req, []byte(sigData))
 
 		var httpErr *HTTPError
-		if !errors.As(err, &httpErr) {
-			t.Fatalf("expected error of type *HTTPError, but got %T (%v)", err, err)
-		}
 
-		require.NoError(t, httpErr.Err)
-		require.Error(t, httpErr)
+		require.ErrorAs(t, err, &httpErr)
 		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to verify signature")
 		assert.Equal(t, *connectInfo.Claims, gatClaims)
@@ -248,12 +227,8 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		connectInfo, err := validator.ParseConnect(req, []byte(sigData))
 
 		var httpErr *HTTPError
-		if !errors.As(err, &httpErr) {
-			t.Fatalf("expected error of type *HTTPError, but got %T (%v)", err, err)
-		}
 
-		require.NoError(t, httpErr.Err)
-		require.Error(t, httpErr)
+		require.ErrorAs(t, err, &httpErr)
 		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to verify signature")
 		assert.Equal(t, *connectInfo.Claims, gatClaims)
@@ -275,12 +250,8 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		connectInfo, err := validator.ParseConnect(req, []byte(sigData))
 
 		var httpErr *HTTPError
-		if !errors.As(err, &httpErr) {
-			t.Fatalf("expected error of type *HTTPError, but got %T (%v)", err, err)
-		}
 
-		require.NoError(t, httpErr.Err)
-		require.Error(t, httpErr)
+		require.ErrorAs(t, err, &httpErr)
 		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to verify signature")
 		assert.Equal(t, *connectInfo.Claims, gatClaims)
@@ -302,12 +273,8 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		connectInfo, err := validator.ParseConnect(req, []byte(sigData))
 
 		var httpErr *HTTPError
-		if !errors.As(err, &httpErr) {
-			t.Fatalf("expected error of type *HTTPError, but got %T (%v)", err, err)
-		}
 
-		require.NoError(t, httpErr.Err)
-		require.Error(t, httpErr)
+		require.ErrorAs(t, err, &httpErr)
 		assert.Equal(t, http.StatusBadRequest, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to verify CONNECT destination")
 		assert.Equal(t, *connectInfo.Claims, gatClaims)
@@ -329,12 +296,8 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		connectInfo, err := validator.ParseConnect(req, []byte(sigData))
 
 		var httpErr *HTTPError
-		if !errors.As(err, &httpErr) {
-			t.Fatalf("expected error of type *HTTPError, but got %T (%v)", err, err)
-		}
 
-		require.Error(t, httpErr.Err)
-		require.Error(t, httpErr)
+		require.ErrorAs(t, err, &httpErr)
 		assert.Equal(t, http.StatusBadRequest, httpErr.Code)
 		assert.Contains(t, httpErr.Error(), "failed to parse CONNECT destination")
 		assert.Equal(t, *connectInfo.Claims, gatClaims)
@@ -375,9 +338,7 @@ func TestHTTPError_Error(t *testing.T) {
 				Code:    tt.code,
 				Message: tt.message,
 			}
-			if got := e.Error(); got != tt.want {
-				t.Errorf("HTTPError.Error() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, e.Error(), "HTTPError.Error() = %v, want %v", e.Error(), tt.want)
 		})
 	}
 }

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -506,9 +506,8 @@ func TestProxy_ForwardRequest(t *testing.T) {
 		// proxy should provide the correct token for the upstream server
 		assert.Equal(t, "Bearer mock-token", r.Header.Get("Authorization"))
 		// response
-		if _, err := io.WriteString(w, "Upstream API Server Response!"); err != nil {
-			t.Fatalf("Failed to write API server response: %v", err)
-		}
+		_, err := io.WriteString(w, "Upstream API Server Response!")
+		assert.NoError(t, err)
 	}))
 
 	// load certs for mock API server

--- a/internal/token/parser_test.go
+++ b/internal/token/parser_test.go
@@ -133,9 +133,7 @@ func TestNewParser(t *testing.T) {
 
 	t.Run("Valid token", func(t *testing.T) {
 		tokenStr, err := tokenService.signToken(jwt.MapClaims{}, nil)
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
+		require.NoError(t, err)
 
 		token, err := parser.ParseWithClaims(tokenStr, jwt.MapClaims{})
 

--- a/internal/wsproxy/conn_test.go
+++ b/internal/wsproxy/conn_test.go
@@ -677,8 +677,8 @@ func TestConn_shouldRecordReadMessage(t *testing.T) {
 				k8sStreamID: tt.streamID,
 			}
 
-			result := c.shouldRecordReadMessage(msg)
-			assert.Equal(t, tt.want, result)
+			got := c.shouldRecordReadMessage(msg)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -729,8 +729,8 @@ func TestConn_shouldRecordWriteMessage(t *testing.T) {
 				k8sStreamID: tt.streamID,
 			}
 
-			result := c.shouldRecordWriteMessage(msg)
-			assert.Equal(t, tt.want, result)
+			got := c.shouldRecordWriteMessage(msg)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/wsproxy/conn_test.go
+++ b/internal/wsproxy/conn_test.go
@@ -677,8 +677,8 @@ func TestConn_shouldRecordReadMessage(t *testing.T) {
 				k8sStreamID: tt.streamID,
 			}
 
-			got := c.shouldRecordReadMessage(msg)
-			assert.Equal(t, tt.want, got)
+			result := c.shouldRecordReadMessage(msg)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 }
@@ -729,8 +729,8 @@ func TestConn_shouldRecordWriteMessage(t *testing.T) {
 				k8sStreamID: tt.streamID,
 			}
 
-			got := c.shouldRecordWriteMessage(msg)
-			assert.Equal(t, tt.want, got)
+			result := c.shouldRecordWriteMessage(msg)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 }

--- a/internal/wsproxy/hijacker_test.go
+++ b/internal/wsproxy/hijacker_test.go
@@ -84,7 +84,7 @@ func TestHijacker_New(t *testing.T) {
 	}
 	hijacker := NewHijacker(req, w, user, recorderFactory, mockNewConn)
 
-	assert.NotEmpty(t, hijacker)
+	assert.NotNil(t, hijacker)
 	assert.Equal(t, w, hijacker.ResponseWriter)
 	assert.Equal(t, req, hijacker.request)
 	assert.Equal(t, user, hijacker.user)

--- a/internal/wsproxy/hijacker_test.go
+++ b/internal/wsproxy/hijacker_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -82,21 +84,10 @@ func TestHijacker_New(t *testing.T) {
 	}
 	hijacker := NewHijacker(req, w, user, recorderFactory, mockNewConn)
 
-	if hijacker == nil {
-		t.Fatal("Expected non-nil hijacker")
-	}
-
-	if hijacker.ResponseWriter != w {
-		t.Errorf("Expected ResponseWriter to be %v, got %v", w, hijacker.ResponseWriter)
-	}
-
-	if hijacker.request != req {
-		t.Errorf("Expected request to be %v, got %v", req, hijacker.request)
-	}
-
-	if hijacker.user != user {
-		t.Errorf("Expected user to be %s, got %s", user, hijacker.user)
-	}
+	assert.NotEmpty(t, hijacker)
+	assert.Equal(t, w, hijacker.ResponseWriter)
+	assert.Equal(t, req, hijacker.request)
+	assert.Equal(t, user, hijacker.user)
 }
 
 func TestHijacker_Hijack_Success(t *testing.T) {
@@ -117,17 +108,9 @@ func TestHijacker_Hijack_Success(t *testing.T) {
 
 	conn, rw, err := hijacker.Hijack()
 
-	if err != nil {
-		t.Fatalf("Expected no error, got: %v", err)
-	}
-
-	if conn != mockConn {
-		t.Errorf("Expected conn to be %v, got %v", mockConn, conn)
-	}
-
-	if rw != mockRW {
-		t.Errorf("Expected rw to be %v, got %v", mockRW, rw)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, mockConn, conn)
+	assert.Equal(t, mockRW, rw)
 }
 
 func TestHijacker_Hijack_Failure(t *testing.T) {
@@ -146,13 +129,7 @@ func TestHijacker_Hijack_Failure(t *testing.T) {
 
 	_, _, err := hijacker.Hijack()
 
-	if err == nil {
-		t.Fatal("Expected error, got nil")
-	}
-
-	if !errors.Is(err, errFailedToHijack) {
-		t.Errorf("Expected error to wrap errFailedToHijack, got: %v", err)
-	}
+	assert.ErrorIs(t, err, errFailedToHijack)
 }
 
 func TestHijacker_StartRecorder(t *testing.T) {
@@ -174,9 +151,7 @@ func TestHijacker_StartRecorder(t *testing.T) {
 	mockConn := &mockHijackerConn{}
 	conn := hijacker.startRecording(mockConn)
 
-	if conn != mockConn {
-		t.Errorf("Expected conn to be %v, got %v", mockConn, conn)
-	}
+	assert.Equal(t, mockConn, conn)
 }
 
 func TestHijacker_AsciinemaHeaderCreation(t *testing.T) {
@@ -213,35 +188,12 @@ func TestHijacker_AsciinemaHeaderCreation(t *testing.T) {
 
 	hijacker.startRecording(mockConn)
 
-	if capturedHeader.Version != 2 {
-		t.Errorf("Expected Version to be 2, got %d", capturedHeader.Version)
-	}
-
-	if capturedHeader.User != "testuser" {
-		t.Errorf("Expected User to be 'testuser', got %s", capturedHeader.User)
-	}
-
-	if capturedHeader.Command != "bash" {
-		t.Errorf("Expected Command to be 'bash', got %s", capturedHeader.Command)
-	}
-
-	if capturedHeader.K8sMetadata == nil {
-		t.Fatal("Expected K8sMetadata to be non-nil")
-	}
-
-	if capturedHeader.K8sMetadata.PodName != "test-pod" {
-		t.Errorf("Expected PodName to be 'test-pod', got %s", capturedHeader.K8sMetadata.PodName)
-	}
-
-	if capturedHeader.K8sMetadata.Namespace != "default" {
-		t.Errorf("Expected Namespace to be 'default', got %s", capturedHeader.K8sMetadata.Namespace)
-	}
-
-	if capturedHeader.K8sMetadata.Container != "test-container" {
-		t.Errorf("Expected Container to be 'test-container', got %s", capturedHeader.K8sMetadata.Container)
-	}
-
-	if !capturedTty {
-		t.Errorf("Expected TTY flag to be true")
-	}
+	assert.Equal(t, 2, capturedHeader.Version)
+	assert.Equal(t, "testuser", capturedHeader.User)
+	assert.Equal(t, "bash", capturedHeader.Command)
+	assert.NotEmpty(t, capturedHeader.K8sMetadata)
+	assert.Equal(t, "test-pod", capturedHeader.K8sMetadata.PodName)
+	assert.Equal(t, "default", capturedHeader.K8sMetadata.Namespace)
+	assert.Equal(t, "test-container", capturedHeader.K8sMetadata.Container)
+	assert.True(t, capturedTty)
 }

--- a/internal/wsproxy/msg_test.go
+++ b/internal/wsproxy/msg_test.go
@@ -24,13 +24,13 @@ func TestMessage_Parse_SimpleMessage(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.Equal(t, 5, parsed, "Expected to parse 5 bytes, got %d", parsed)
+	assert.Equal(t, 5, parsed)
 
-	assert.Equal(t, MessageStateFinished, msg.state, "Expected msg.state to be MessageStateFinished")
+	assert.Equal(t, MessageStateFinished, msg.state)
 
-	assert.Equal(t, uint32(1), msg.k8sStreamID, "Expected k8sStreamID=1, got %d", msg.k8sStreamID)
+	assert.Equal(t, uint32(1), msg.k8sStreamID)
 
-	assert.Equal(t, []byte{0x41, 0x42}, msg.payload, "Expected payload [0x41, 0x42], got %v", msg.payload)
+	assert.Equal(t, []byte{0x41, 0x42}, msg.payload)
 }
 
 func TestMessage_Parse_MaskedMessage(t *testing.T) {
@@ -49,13 +49,13 @@ func TestMessage_Parse_MaskedMessage(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.Equal(t, 9, parsed, "Expected to parse 9 bytes, got %d", parsed)
+	assert.Equal(t, 9, parsed)
 
-	assert.Equal(t, MessageStateFinished, msg.state, "Expected msg.state to be MessageStateFinished")
+	assert.Equal(t, MessageStateFinished, msg.state)
 
-	assert.Equal(t, uint32(2), msg.k8sStreamID, "Expected k8sStreamID=2, got %d", msg.k8sStreamID)
+	assert.Equal(t, uint32(2), msg.k8sStreamID)
 
-	assert.Equal(t, []byte{0x41, 0x42}, msg.payload, "Expected payload [0x41, 0x42], got %v", msg.payload)
+	assert.Equal(t, []byte{0x41, 0x42}, msg.payload)
 }
 
 func TestMessage_Parse_MediumLengthMessage(t *testing.T) {
@@ -79,11 +79,11 @@ func TestMessage_Parse_MediumLengthMessage(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.Equal(t, len(data), parsed, "Expected to parse %d bytes, got %d", len(data), parsed)
+	assert.Equal(t, len(data), parsed)
 
-	assert.Equal(t, uint32(2), msg.k8sStreamID, "Expected k8sStreamID=2, got %d", msg.k8sStreamID)
+	assert.Equal(t, uint32(2), msg.k8sStreamID)
 
-	assert.Len(t, msg.payload, 129, "Expected payload length 129, got %d", len(msg.payload))
+	assert.Len(t, msg.payload, 129)
 }
 
 func TestMessage_Parse_LargeLengthMessage(t *testing.T) {
@@ -107,11 +107,11 @@ func TestMessage_Parse_LargeLengthMessage(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.Equal(t, len(data), parsed, "Expected to parse %d bytes, got %d", len(data), parsed)
+	assert.Equal(t, len(data), parsed)
 
-	assert.Equal(t, uint32(3), msg.k8sStreamID, "Expected k8sStreamID=3, got %d", msg.k8sStreamID)
+	assert.Equal(t, uint32(3), msg.k8sStreamID)
 
-	assert.Len(t, msg.payload, 259, "Expected payload length 259, got %d", len(msg.payload))
+	assert.Len(t, msg.payload, 259)
 }
 
 func TestMessage_Parse_FragmentedMessage(t *testing.T) {
@@ -138,18 +138,18 @@ func TestMessage_Parse_FragmentedMessage(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.Equal(t, 5, parsed1, "Expected to parse 5 bytes in first fragment, got %d", parsed1)
+	assert.Equal(t, 5, parsed1)
 
-	assert.Equal(t, MessageStateFragmented, msg.state, "Expected msg.state to be MessageStateFragmented after first fragment")
+	assert.Equal(t, MessageStateFragmented, msg.state)
 
 	parsed2, err := msg.Parse(data2)
 	require.NoError(t, err)
 
-	assert.Equal(t, 5, parsed2, "Expected to parse 5 bytes in second fragment, got %d", parsed2)
+	assert.Equal(t, 5, parsed2)
 
-	assert.Equal(t, MessageStateFinished, msg.state, "Expected msg.state to be MessageStateFinished after second fragment")
+	assert.Equal(t, MessageStateFinished, msg.state)
 
-	assert.Equal(t, uint32(4), msg.k8sStreamID, "Expected k8sStreamID=4, got %d", msg.k8sStreamID)
+	assert.Equal(t, uint32(4), msg.k8sStreamID)
 
 	assert.Equal(t, []byte{0x41, 0x42, 0x43, 0x44}, msg.payload, "Expected concatenated payload [0x41, 0x42, 0x43, 0x44], got %v", msg.payload)
 }
@@ -196,7 +196,7 @@ func TestMessage_Parse_IncompleteData(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.Equal(t, 0, parsed, "Expected parsed=0 for incomplete data, got %d", parsed)
+	assert.Equal(t, 0, parsed)
 }
 
 func TestMessage_Parse_EmptyPayload(t *testing.T) {
@@ -246,13 +246,13 @@ func TestMessage_Parse_ControlMessagePing(t *testing.T) {
 
 	// The parsed bytes should include the first byte (FIN/opcode), second byte (mask/length),
 	// For this example: 1 (0x89) + 1 (0x03) + 3 (ping data) = 6 bytes
-	assert.Equal(t, len(data), parsed, "Expected to parse %d bytes, got %d", len(data), parsed)
+	assert.Equal(t, len(data), parsed)
 
-	assert.Equal(t, MessageStateFinished, msg.state, "Expected msg.state to be MessageStateFinished")
+	assert.Equal(t, MessageStateFinished, msg.state)
 
 	// For PING messages, the payload can contain data, check it matches
 	expectedPayload := []byte{0x70, 0x69, 0x6e}
-	assert.Equal(t, expectedPayload, msg.payload, "Expected payload %v, got %v", expectedPayload, msg.payload)
+	assert.Equal(t, expectedPayload, msg.payload)
 }
 
 func TestMessage_Parse_ControlMessageCloseMasked(t *testing.T) {
@@ -285,17 +285,17 @@ func TestMessage_Parse_ControlMessageCloseMasked(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.Equal(t, len(data), parsed, "Expected to parse %d bytes, got %d", len(data), parsed)
+	assert.Equal(t, len(data), parsed)
 
-	assert.Equal(t, MessageStateFinished, msg.state, "Expected msg.state to be MessageStateFinished")
+	assert.Equal(t, MessageStateFinished, msg.state)
 
 	// For standard WebSocket control messages (like CLOSE), a K8s Stream ID is not part of the protocol.
 	// Therefore, we expect msg.k8sStreamID to be its zero-value (0), indicating it's not present/applicable.
-	assert.Equal(t, uint32(0), msg.k8sStreamID, "Expected k8sStreamID=0 (not applicable for control frames), got %d", msg.k8sStreamID)
+	assert.Equal(t, uint32(0), msg.k8sStreamID)
 
 	// Expected unmasked payload: Status Code 1000 (0x03E8) and Reason "Bye"
 	expectedPayload := []byte{0x03, 0xE8, 0x42, 0x79, 0x65}
-	assert.Equal(t, expectedPayload, msg.payload, "Expected payload %v, got %v", expectedPayload, msg.payload)
+	assert.Equal(t, expectedPayload, msg.payload)
 }
 
 func TestUnmask(t *testing.T) {
@@ -332,7 +332,7 @@ func TestUnmask(t *testing.T) {
 
 			unmask(tc.mask, dataCopy)
 
-			assert.Equal(t, tc.expected, dataCopy, "Expected %v, got %v", tc.expected, dataCopy)
+			assert.Equal(t, tc.expected, dataCopy)
 		})
 	}
 }
@@ -397,8 +397,8 @@ func TestIsDataFrame(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsDataFrame(tt.input)
-			assert.Equal(t, tt.expected, got, "IsDataFrame(%v) = %v; want %v", tt.input, got, tt.expected)
+			result := IsDataFrame(tt.input)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
@@ -463,8 +463,8 @@ func TestIsK8sStreamFrame(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsK8sStreamFrame(tt.input)
-			assert.Equal(t, tt.expected, got, "IsK8sStreamFrame(%v) = %v; want %v", tt.input, got, tt.expected)
+			result := IsK8sStreamFrame(tt.input)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/internal/wsproxy/msg_test.go
+++ b/internal/wsproxy/msg_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/websocket"
 )
 
@@ -21,7 +22,7 @@ func TestMessage_Parse_SimpleMessage(t *testing.T) {
 	msg := &wsMessage{}
 	parsed, err := msg.Parse(data)
 
-	assert.NoError(t, err, "Parse failed")
+	require.NoError(t, err)
 
 	assert.Equal(t, 5, parsed, "Expected to parse 5 bytes, got %d", parsed)
 
@@ -46,7 +47,7 @@ func TestMessage_Parse_MaskedMessage(t *testing.T) {
 	msg := &wsMessage{}
 	parsed, err := msg.Parse(data)
 
-	assert.NoError(t, err, "Parse failed")
+	require.NoError(t, err)
 
 	assert.Equal(t, 9, parsed, "Expected to parse 9 bytes, got %d", parsed)
 
@@ -76,13 +77,13 @@ func TestMessage_Parse_MediumLengthMessage(t *testing.T) {
 	msg := &wsMessage{}
 	parsed, err := msg.Parse(data)
 
-	assert.NoError(t, err, "Parse failed")
+	require.NoError(t, err)
 
 	assert.Equal(t, len(data), parsed, "Expected to parse %d bytes, got %d", len(data), parsed)
 
 	assert.Equal(t, uint32(2), msg.k8sStreamID, "Expected k8sStreamID=2, got %d", msg.k8sStreamID)
 
-	assert.Equal(t, 129, len(msg.payload), "Expected payload length 129, got %d", len(msg.payload))
+	assert.Len(t, msg.payload, 129, "Expected payload length 129, got %d", len(msg.payload))
 }
 
 func TestMessage_Parse_LargeLengthMessage(t *testing.T) {
@@ -104,13 +105,13 @@ func TestMessage_Parse_LargeLengthMessage(t *testing.T) {
 	msg := &wsMessage{}
 	parsed, err := msg.Parse(data)
 
-	assert.NoError(t, err, "Parse failed")
+	require.NoError(t, err)
 
 	assert.Equal(t, len(data), parsed, "Expected to parse %d bytes, got %d", len(data), parsed)
 
 	assert.Equal(t, uint32(3), msg.k8sStreamID, "Expected k8sStreamID=3, got %d", msg.k8sStreamID)
 
-	assert.Equal(t, 259, len(msg.payload), "Expected payload length 259, got %d", len(msg.payload))
+	assert.Len(t, msg.payload, 259, "Expected payload length 259, got %d", len(msg.payload))
 }
 
 func TestMessage_Parse_FragmentedMessage(t *testing.T) {
@@ -135,14 +136,14 @@ func TestMessage_Parse_FragmentedMessage(t *testing.T) {
 	msg := &wsMessage{}
 	parsed1, err := msg.Parse(data1)
 
-	assert.NoError(t, err, "Parse of first fragment failed")
+	require.NoError(t, err)
 
 	assert.Equal(t, 5, parsed1, "Expected to parse 5 bytes in first fragment, got %d", parsed1)
 
 	assert.Equal(t, MessageStateFragmented, msg.state, "Expected msg.state to be MessageStateFragmented after first fragment")
 
 	parsed2, err := msg.Parse(data2)
-	assert.NoError(t, err, "Parse of second fragment failed")
+	require.NoError(t, err)
 
 	assert.Equal(t, 5, parsed2, "Expected to parse 5 bytes in second fragment, got %d", parsed2)
 
@@ -175,10 +176,10 @@ func TestMessage_Parse_MismatchedStreamID(t *testing.T) {
 	msg := &wsMessage{}
 
 	_, err := msg.Parse(data1)
-	assert.NoError(t, err, "Parse of first fragment failed")
+	require.NoError(t, err)
 
 	_, err = msg.Parse(data2)
-	assert.ErrorIs(t, err, errMismatchedStreamID, "Expected errMismatchedStreamID error, got %v", err)
+	require.ErrorIs(t, err, errMismatchedStreamID)
 }
 
 func TestMessage_Parse_IncompleteData(t *testing.T) {
@@ -193,7 +194,7 @@ func TestMessage_Parse_IncompleteData(t *testing.T) {
 	msg := &wsMessage{}
 	parsed, err := msg.Parse(data)
 
-	assert.NoError(t, err, "Parse failed")
+	require.NoError(t, err)
 
 	assert.Equal(t, 0, parsed, "Expected parsed=0 for incomplete data, got %d", parsed)
 }
@@ -208,7 +209,7 @@ func TestMessage_Parse_EmptyPayload(t *testing.T) {
 	msg := &wsMessage{}
 	_, err := msg.Parse(data)
 
-	assert.ErrorIs(t, err, errPayloadEmpty, "Expected errPayloadEmpty error, got %v", err)
+	require.ErrorIs(t, err, errPayloadEmpty)
 }
 
 func TestMessage_Parse_TooLargePayload(t *testing.T) {
@@ -225,7 +226,7 @@ func TestMessage_Parse_TooLargePayload(t *testing.T) {
 	msg := &wsMessage{}
 	_, err := msg.Parse(data)
 
-	assert.ErrorIs(t, err, errPayloadTooLarge, "Expected errPayloadTooLarge error, got %v", err)
+	require.ErrorIs(t, err, errPayloadTooLarge)
 }
 
 func TestMessage_Parse_ControlMessagePing(t *testing.T) {
@@ -241,7 +242,7 @@ func TestMessage_Parse_ControlMessagePing(t *testing.T) {
 	msg := &wsMessage{}
 	parsed, err := msg.Parse(data)
 
-	assert.NoError(t, err, "Parse failed")
+	require.NoError(t, err)
 
 	// The parsed bytes should include the first byte (FIN/opcode), second byte (mask/length),
 	// For this example: 1 (0x89) + 1 (0x03) + 3 (ping data) = 6 bytes
@@ -282,7 +283,7 @@ func TestMessage_Parse_ControlMessageCloseMasked(t *testing.T) {
 	msg := &wsMessage{}
 	parsed, err := msg.Parse(data)
 
-	assert.NoError(t, err, "Parse failed")
+	require.NoError(t, err)
 
 	assert.Equal(t, len(data), parsed, "Expected to parse %d bytes, got %d", len(data), parsed)
 

--- a/internal/wsproxy/msg_test.go
+++ b/internal/wsproxy/msg_test.go
@@ -379,8 +379,8 @@ func TestIsDataFrame(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsDataFrame(tt.input)
-			assert.Equal(t, tt.expected, result)
+			got := IsDataFrame(tt.input)
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }
@@ -445,8 +445,8 @@ func TestIsK8sStreamFrame(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsK8sStreamFrame(tt.input)
-			assert.Equal(t, tt.expected, result)
+			got := IsK8sStreamFrame(tt.input)
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/internal/wsproxy/msg_test.go
+++ b/internal/wsproxy/msg_test.go
@@ -1,12 +1,10 @@
 package wsproxy
 
 import (
-	"bytes"
 	"encoding/binary"
-	"errors"
-	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/websocket"
 )
 
@@ -23,25 +21,15 @@ func TestMessage_Parse_SimpleMessage(t *testing.T) {
 	msg := &wsMessage{}
 	parsed, err := msg.Parse(data)
 
-	if err != nil {
-		t.Fatalf("Parse failed: %v", err)
-	}
+	assert.NoError(t, err, "Parse failed")
 
-	if parsed != 5 {
-		t.Errorf("Expected to parse 5 bytes, got %d", parsed)
-	}
+	assert.Equal(t, 5, parsed, "Expected to parse 5 bytes, got %d", parsed)
 
-	if msg.state != MessageStateFinished {
-		t.Error("Expected msg.state to be MessageStateFinished")
-	}
+	assert.Equal(t, MessageStateFinished, msg.state, "Expected msg.state to be MessageStateFinished")
 
-	if msg.k8sStreamID != 1 {
-		t.Errorf("Expected k8sStreamID=1, got %d", msg.k8sStreamID)
-	}
+	assert.Equal(t, uint32(1), msg.k8sStreamID, "Expected k8sStreamID=1, got %d", msg.k8sStreamID)
 
-	if !bytes.Equal(msg.payload, []byte{0x41, 0x42}) {
-		t.Errorf("Expected payload [0x41, 0x42], got %v", msg.payload)
-	}
+	assert.Equal(t, []byte{0x41, 0x42}, msg.payload, "Expected payload [0x41, 0x42], got %v", msg.payload)
 }
 
 func TestMessage_Parse_MaskedMessage(t *testing.T) {
@@ -58,25 +46,15 @@ func TestMessage_Parse_MaskedMessage(t *testing.T) {
 	msg := &wsMessage{}
 	parsed, err := msg.Parse(data)
 
-	if err != nil {
-		t.Fatalf("Parse failed: %v", err)
-	}
+	assert.NoError(t, err, "Parse failed")
 
-	if parsed != 9 {
-		t.Errorf("Expected to parse 9 bytes, got %d", parsed)
-	}
+	assert.Equal(t, 9, parsed, "Expected to parse 9 bytes, got %d", parsed)
 
-	if msg.state != MessageStateFinished {
-		t.Error("Expected msg.state to be MessageStateFinished")
-	}
+	assert.Equal(t, MessageStateFinished, msg.state, "Expected msg.state to be MessageStateFinished")
 
-	if msg.k8sStreamID != 2 {
-		t.Errorf("Expected k8sStreamID=2, got %d", msg.k8sStreamID)
-	}
+	assert.Equal(t, uint32(2), msg.k8sStreamID, "Expected k8sStreamID=2, got %d", msg.k8sStreamID)
 
-	if !bytes.Equal(msg.payload, []byte{0x41, 0x42}) {
-		t.Errorf("Expected payload [0x41, 0x42], got %v", msg.payload)
-	}
+	assert.Equal(t, []byte{0x41, 0x42}, msg.payload, "Expected payload [0x41, 0x42], got %v", msg.payload)
 }
 
 func TestMessage_Parse_MediumLengthMessage(t *testing.T) {
@@ -98,21 +76,13 @@ func TestMessage_Parse_MediumLengthMessage(t *testing.T) {
 	msg := &wsMessage{}
 	parsed, err := msg.Parse(data)
 
-	if err != nil {
-		t.Fatalf("Parse failed: %v", err)
-	}
+	assert.NoError(t, err, "Parse failed")
 
-	if parsed != len(data) {
-		t.Errorf("Expected to parse %d bytes, got %d", len(data), parsed)
-	}
+	assert.Equal(t, len(data), parsed, "Expected to parse %d bytes, got %d", len(data), parsed)
 
-	if msg.k8sStreamID != 2 {
-		t.Errorf("Expected k8sStreamID=2, got %d", msg.k8sStreamID)
-	}
+	assert.Equal(t, uint32(2), msg.k8sStreamID, "Expected k8sStreamID=2, got %d", msg.k8sStreamID)
 
-	if len(msg.payload) != 129 {
-		t.Errorf("Expected payload length 129, got %d", len(msg.payload))
-	}
+	assert.Equal(t, 129, len(msg.payload), "Expected payload length 129, got %d", len(msg.payload))
 }
 
 func TestMessage_Parse_LargeLengthMessage(t *testing.T) {
@@ -134,21 +104,13 @@ func TestMessage_Parse_LargeLengthMessage(t *testing.T) {
 	msg := &wsMessage{}
 	parsed, err := msg.Parse(data)
 
-	if err != nil {
-		t.Fatalf("Parse failed: %v", err)
-	}
+	assert.NoError(t, err, "Parse failed")
 
-	if parsed != len(data) {
-		t.Errorf("Expected to parse %d bytes, got %d", len(data), parsed)
-	}
+	assert.Equal(t, len(data), parsed, "Expected to parse %d bytes, got %d", len(data), parsed)
 
-	if msg.k8sStreamID != 3 {
-		t.Errorf("Expected k8sStreamID=3, got %d", msg.k8sStreamID)
-	}
+	assert.Equal(t, uint32(3), msg.k8sStreamID, "Expected k8sStreamID=3, got %d", msg.k8sStreamID)
 
-	if len(msg.payload) != 259 {
-		t.Errorf("Expected payload length 259, got %d", len(msg.payload))
-	}
+	assert.Equal(t, 259, len(msg.payload), "Expected payload length 259, got %d", len(msg.payload))
 }
 
 func TestMessage_Parse_FragmentedMessage(t *testing.T) {
@@ -173,38 +135,22 @@ func TestMessage_Parse_FragmentedMessage(t *testing.T) {
 	msg := &wsMessage{}
 	parsed1, err := msg.Parse(data1)
 
-	if err != nil {
-		t.Fatalf("Parse of first fragment failed: %v", err)
-	}
+	assert.NoError(t, err, "Parse of first fragment failed")
 
-	if parsed1 != 5 {
-		t.Errorf("Expected to parse 5 bytes in first fragment, got %d", parsed1)
-	}
+	assert.Equal(t, 5, parsed1, "Expected to parse 5 bytes in first fragment, got %d", parsed1)
 
-	if msg.state != MessageStateFragmented {
-		t.Error("Expected msg.state to be MessageStateFragmented after first fragment")
-	}
+	assert.Equal(t, MessageStateFragmented, msg.state, "Expected msg.state to be MessageStateFragmented after first fragment")
 
 	parsed2, err := msg.Parse(data2)
-	if err != nil {
-		t.Fatalf("Parse of second fragment failed: %v", err)
-	}
+	assert.NoError(t, err, "Parse of second fragment failed")
 
-	if parsed2 != 5 {
-		t.Errorf("Expected to parse 5 bytes in second fragment, got %d", parsed2)
-	}
+	assert.Equal(t, 5, parsed2, "Expected to parse 5 bytes in second fragment, got %d", parsed2)
 
-	if msg.state != MessageStateFinished {
-		t.Error("Expected msg.state to be MessageStateFinished after second fragment")
-	}
+	assert.Equal(t, MessageStateFinished, msg.state, "Expected msg.state to be MessageStateFinished after second fragment")
 
-	if msg.k8sStreamID != 4 {
-		t.Errorf("Expected k8sStreamID=4, got %d", msg.k8sStreamID)
-	}
+	assert.Equal(t, uint32(4), msg.k8sStreamID, "Expected k8sStreamID=4, got %d", msg.k8sStreamID)
 
-	if !bytes.Equal(msg.payload, []byte{0x41, 0x42, 0x43, 0x44}) {
-		t.Errorf("Expected concatenated payload [0x41, 0x42, 0x43, 0x44], got %v", msg.payload)
-	}
+	assert.Equal(t, []byte{0x41, 0x42, 0x43, 0x44}, msg.payload, "Expected concatenated payload [0x41, 0x42, 0x43, 0x44], got %v", msg.payload)
 }
 
 func TestMessage_Parse_MismatchedStreamID(t *testing.T) {
@@ -229,14 +175,10 @@ func TestMessage_Parse_MismatchedStreamID(t *testing.T) {
 	msg := &wsMessage{}
 
 	_, err := msg.Parse(data1)
-	if err != nil {
-		t.Fatalf("Parse of first fragment failed: %v", err)
-	}
+	assert.NoError(t, err, "Parse of first fragment failed")
 
 	_, err = msg.Parse(data2)
-	if !errors.Is(err, errMismatchedStreamID) {
-		t.Errorf("Expected errMismatchedStreamID error, got %v", err)
-	}
+	assert.ErrorIs(t, err, errMismatchedStreamID, "Expected errMismatchedStreamID error, got %v", err)
 }
 
 func TestMessage_Parse_IncompleteData(t *testing.T) {
@@ -251,13 +193,9 @@ func TestMessage_Parse_IncompleteData(t *testing.T) {
 	msg := &wsMessage{}
 	parsed, err := msg.Parse(data)
 
-	if err != nil {
-		t.Errorf("Expected nil error for incomplete data, got %v", err)
-	}
+	assert.NoError(t, err, "Parse failed")
 
-	if parsed != 0 {
-		t.Errorf("Expected parsed=0 for incomplete data, got %d", parsed)
-	}
+	assert.Equal(t, 0, parsed, "Expected parsed=0 for incomplete data, got %d", parsed)
 }
 
 func TestMessage_Parse_EmptyPayload(t *testing.T) {
@@ -270,9 +208,7 @@ func TestMessage_Parse_EmptyPayload(t *testing.T) {
 	msg := &wsMessage{}
 	_, err := msg.Parse(data)
 
-	if !errors.Is(err, errPayloadEmpty) {
-		t.Errorf("Expected errPayloadEmpty error, got %v", err)
-	}
+	assert.ErrorIs(t, err, errPayloadEmpty, "Expected errPayloadEmpty error, got %v", err)
 }
 
 func TestMessage_Parse_TooLargePayload(t *testing.T) {
@@ -289,9 +225,7 @@ func TestMessage_Parse_TooLargePayload(t *testing.T) {
 	msg := &wsMessage{}
 	_, err := msg.Parse(data)
 
-	if !errors.Is(err, errPayloadTooLarge) {
-		t.Errorf("Expected errPayloadTooLarge error, got %v", err)
-	}
+	assert.ErrorIs(t, err, errPayloadTooLarge, "Expected errPayloadTooLarge error, got %v", err)
 }
 
 func TestMessage_Parse_ControlMessagePing(t *testing.T) {
@@ -307,25 +241,17 @@ func TestMessage_Parse_ControlMessagePing(t *testing.T) {
 	msg := &wsMessage{}
 	parsed, err := msg.Parse(data)
 
-	if err != nil {
-		t.Fatalf("Parse failed: %v", err)
-	}
+	assert.NoError(t, err, "Parse failed")
 
 	// The parsed bytes should include the first byte (FIN/opcode), second byte (mask/length),
 	// For this example: 1 (0x89) + 1 (0x03) + 3 (ping data) = 6 bytes
-	if parsed != len(data) {
-		t.Errorf("Expected to parse 6 bytes, got %d", parsed)
-	}
+	assert.Equal(t, len(data), parsed, "Expected to parse %d bytes, got %d", len(data), parsed)
 
-	if msg.state != MessageStateFinished {
-		t.Error("Expected msg.state to be MessageStateFinished")
-	}
+	assert.Equal(t, MessageStateFinished, msg.state, "Expected msg.state to be MessageStateFinished")
 
 	// For PING messages, the payload can contain data, check it matches
 	expectedPayload := []byte{0x70, 0x69, 0x6e}
-	if !bytes.Equal(msg.payload, expectedPayload) {
-		t.Errorf("Expected payload %v, got %v", expectedPayload, msg.payload)
-	}
+	assert.Equal(t, expectedPayload, msg.payload, "Expected payload %v, got %v", expectedPayload, msg.payload)
 }
 
 func TestMessage_Parse_ControlMessageCloseMasked(t *testing.T) {
@@ -356,29 +282,19 @@ func TestMessage_Parse_ControlMessageCloseMasked(t *testing.T) {
 	msg := &wsMessage{}
 	parsed, err := msg.Parse(data)
 
-	if err != nil {
-		t.Fatalf("Parse failed: %v", err)
-	}
+	assert.NoError(t, err, "Parse failed")
 
-	if parsed != len(data) {
-		t.Errorf("Expected to parse 11 bytes, got %d", parsed)
-	}
+	assert.Equal(t, len(data), parsed, "Expected to parse %d bytes, got %d", len(data), parsed)
 
-	if msg.state != MessageStateFinished {
-		t.Error("Expected msg.state to be MessageStateFinished")
-	}
+	assert.Equal(t, MessageStateFinished, msg.state, "Expected msg.state to be MessageStateFinished")
 
 	// For standard WebSocket control messages (like CLOSE), a K8s Stream ID is not part of the protocol.
 	// Therefore, we expect msg.k8sStreamID to be its zero-value (0), indicating it's not present/applicable.
-	if msg.k8sStreamID != 0 {
-		t.Errorf("Expected k8sStreamID=0 (not applicable for control frames), got %d", msg.k8sStreamID)
-	}
+	assert.Equal(t, uint32(0), msg.k8sStreamID, "Expected k8sStreamID=0 (not applicable for control frames), got %d", msg.k8sStreamID)
 
 	// Expected unmasked payload: Status Code 1000 (0x03E8) and Reason "Bye"
 	expectedPayload := []byte{0x03, 0xE8, 0x42, 0x79, 0x65}
-	if !bytes.Equal(msg.payload, expectedPayload) {
-		t.Errorf("Expected payload %v, got %v", expectedPayload, msg.payload)
-	}
+	assert.Equal(t, expectedPayload, msg.payload, "Expected payload %v, got %v", expectedPayload, msg.payload)
 }
 
 func TestUnmask(t *testing.T) {
@@ -415,9 +331,7 @@ func TestUnmask(t *testing.T) {
 
 			unmask(tc.mask, dataCopy)
 
-			if !reflect.DeepEqual(dataCopy, tc.expected) {
-				t.Errorf("Expected %v, got %v", tc.expected, dataCopy)
-			}
+			assert.Equal(t, tc.expected, dataCopy, "Expected %v, got %v", tc.expected, dataCopy)
 		})
 	}
 }
@@ -483,9 +397,7 @@ func TestIsDataFrame(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := IsDataFrame(tt.input)
-			if got != tt.expected {
-				t.Errorf("IsDataFrame(%v) = %v; want %v", tt.input, got, tt.expected)
-			}
+			assert.Equal(t, tt.expected, got, "IsDataFrame(%v) = %v; want %v", tt.input, got, tt.expected)
 		})
 	}
 }
@@ -551,9 +463,7 @@ func TestIsK8sStreamFrame(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := IsK8sStreamFrame(tt.input)
-			if got != tt.expected {
-				t.Errorf("IsDataFrame(%v) = %v; want %v", tt.input, got, tt.expected)
-			}
+			assert.Equal(t, tt.expected, got, "IsK8sStreamFrame(%v) = %v; want %v", tt.input, got, tt.expected)
 		})
 	}
 }

--- a/internal/wsproxy/msg_test.go
+++ b/internal/wsproxy/msg_test.go
@@ -179,7 +179,7 @@ func TestMessage_Parse_MismatchedStreamID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = msg.Parse(data2)
-	require.ErrorIs(t, err, errMismatchedStreamID)
+	assert.ErrorIs(t, err, errMismatchedStreamID)
 }
 
 func TestMessage_Parse_IncompleteData(t *testing.T) {

--- a/internal/wsproxy/msg_test.go
+++ b/internal/wsproxy/msg_test.go
@@ -25,11 +25,8 @@ func TestMessage_Parse_SimpleMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 5, parsed)
-
 	assert.Equal(t, MessageStateFinished, msg.state)
-
 	assert.Equal(t, uint32(1), msg.k8sStreamID)
-
 	assert.Equal(t, []byte{0x41, 0x42}, msg.payload)
 }
 
@@ -50,11 +47,8 @@ func TestMessage_Parse_MaskedMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 9, parsed)
-
 	assert.Equal(t, MessageStateFinished, msg.state)
-
 	assert.Equal(t, uint32(2), msg.k8sStreamID)
-
 	assert.Equal(t, []byte{0x41, 0x42}, msg.payload)
 }
 
@@ -80,9 +74,7 @@ func TestMessage_Parse_MediumLengthMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, len(data), parsed)
-
 	assert.Equal(t, uint32(2), msg.k8sStreamID)
-
 	assert.Len(t, msg.payload, 129)
 }
 
@@ -108,9 +100,7 @@ func TestMessage_Parse_LargeLengthMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, len(data), parsed)
-
 	assert.Equal(t, uint32(3), msg.k8sStreamID)
-
 	assert.Len(t, msg.payload, 259)
 }
 
@@ -135,23 +125,18 @@ func TestMessage_Parse_FragmentedMessage(t *testing.T) {
 
 	msg := &wsMessage{}
 	parsed1, err := msg.Parse(data1)
-
 	require.NoError(t, err)
 
 	assert.Equal(t, 5, parsed1)
-
 	assert.Equal(t, MessageStateFragmented, msg.state)
 
 	parsed2, err := msg.Parse(data2)
 	require.NoError(t, err)
 
 	assert.Equal(t, 5, parsed2)
-
 	assert.Equal(t, MessageStateFinished, msg.state)
-
 	assert.Equal(t, uint32(4), msg.k8sStreamID)
-
-	assert.Equal(t, []byte{0x41, 0x42, 0x43, 0x44}, msg.payload, "Expected concatenated payload [0x41, 0x42, 0x43, 0x44], got %v", msg.payload)
+	assert.Equal(t, []byte{0x41, 0x42, 0x43, 0x44}, msg.payload)
 }
 
 func TestMessage_Parse_MismatchedStreamID(t *testing.T) {
@@ -247,7 +232,6 @@ func TestMessage_Parse_ControlMessagePing(t *testing.T) {
 	// The parsed bytes should include the first byte (FIN/opcode), second byte (mask/length),
 	// For this example: 1 (0x89) + 1 (0x03) + 3 (ping data) = 6 bytes
 	assert.Equal(t, len(data), parsed)
-
 	assert.Equal(t, MessageStateFinished, msg.state)
 
 	// For PING messages, the payload can contain data, check it matches
@@ -286,9 +270,7 @@ func TestMessage_Parse_ControlMessageCloseMasked(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, len(data), parsed)
-
 	assert.Equal(t, MessageStateFinished, msg.state)
-
 	// For standard WebSocket control messages (like CLOSE), a K8s Stream ID is not part of the protocol.
 	// Therefore, we expect msg.k8sStreamID to be its zero-value (0), indicating it's not present/applicable.
 	assert.Equal(t, uint32(0), msg.k8sStreamID)

--- a/test/integration/authentication_test.go
+++ b/test/integration/authentication_test.go
@@ -322,7 +322,7 @@ func gatewayHealthCheck(t *testing.T) {
 			resp.Body.Close()
 		}
 
-		require.Equal(t, attempt, maxAttempts, "Gateway failed to start after %d attempts", maxAttempts)
+		require.NotEqual(t, attempt, maxAttempts, "Gateway failed to start after %d attempts", maxAttempts)
 
 		time.Sleep(backoff)
 	}

--- a/test/integration/authentication_test.go
+++ b/test/integration/authentication_test.go
@@ -324,7 +324,7 @@ func gatewayHealthCheck(t *testing.T) {
 			resp.Body.Close()
 		}
 
-		require.NotEqual(t, attempt, maxAttempts, "Gateway failed to start after %d attempts", maxAttempts)
+		require.NotEqual(t, maxAttempts, attempt, "Gateway failed to start after %d attempts", maxAttempts)
 
 		time.Sleep(backoff)
 	}

--- a/test/integration/authentication_test.go
+++ b/test/integration/authentication_test.go
@@ -232,7 +232,9 @@ func setupKinD(t *testing.T) (*Kubectl, *rest.Config, string) {
 
 	err = wait.PollUntilContextTimeout(t.Context(), time.Second, 30*time.Second, true, func(_ctx context.Context) (bool, error) {
 		_, err = k.Command("get", "serviceaccount", "default")
-		require.NoError(t, err, "failed to get default service account")
+		if err != nil {
+			return false, nil //nolint:nilerr
+		}
 
 		return true, nil
 	})

--- a/test/integration/authentication_test.go
+++ b/test/integration/authentication_test.go
@@ -332,6 +332,7 @@ func assertWhoAmI(t *testing.T, output []byte, expectedUsername string, expected
 	t.Helper()
 
 	var whoami authv1.SelfSubjectReview
+
 	require.NoError(t, json.Unmarshal(output, &whoami), "failed to parse kubectl auth whoami output")
 
 	username := whoami.Status.UserInfo.Username

--- a/test/integration/authentication_test.go
+++ b/test/integration/authentication_test.go
@@ -334,8 +334,9 @@ func assertWhoAmI(t *testing.T, output []byte, expectedUsername string, expected
 	t.Helper()
 
 	var whoami authv1.SelfSubjectReview
+	err := json.Unmarshal(output, &whoami)
 
-	require.NoError(t, json.Unmarshal(output, &whoami), "failed to parse kubectl auth whoami output")
+	require.NoError(t, err, "failed to parse kubectl auth whoami output")
 
 	username := whoami.Status.UserInfo.Username
 	groups := whoami.Status.UserInfo.Groups

--- a/test/integration/authentication_test.go
+++ b/test/integration/authentication_test.go
@@ -211,7 +211,7 @@ func setupKinD(t *testing.T) (*Kubectl, *rest.Config, string) {
 
 	t.Cleanup(func() {
 		err := provider.Delete(clusterName, "")
-		require.NoError(t, err, "failed to delete kind cluster")
+		assert.NoError(t, err, "failed to delete kind cluster")
 	})
 
 	// Get kubeconfig for KinD context


### PR DESCRIPTION
## Changes
- Update unit test to use `testify/assert` and `testify/require`