### PR TITLE
feat: Improve audit log for API requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.10.0 // indirect

--- a/internal/httpproxy/audit_middleware.go
+++ b/internal/httpproxy/audit_middleware.go
@@ -1,0 +1,132 @@
+package httpproxy
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+var (
+	errFailedToHijack = errors.New("failed to hijack")
+)
+
+type responseWriter struct {
+	http.ResponseWriter
+	headerWritten bool
+	statusCode    int
+	headers       http.Header
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.headerWritten = true
+	rw.statusCode = code
+	rw.headers = rw.Header().Clone()
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (rw *responseWriter) Write(p []byte) (int, error) {
+	if !rw.headerWritten {
+		// Mirror ResponseWriter.Write behavior by setting 200 status code
+		// if no header has been written yet.
+		rw.WriteHeader(http.StatusOK)
+	}
+
+	return rw.ResponseWriter.Write(p)
+}
+
+func (rw *responseWriter) Flush() {
+	if flusher, ok := rw.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hijacker, ok := rw.ResponseWriter.(http.Hijacker); ok {
+		return hijacker.Hijack()
+	}
+
+	return nil, nil, errFailedToHijack
+}
+
+// Compile-time checks that responseWriter implements http.Flusher and http.Hijacker.
+var _ http.Flusher = &responseWriter{}  // Support HTTP streaming
+var _ http.Hijacker = &responseWriter{} // Support WebSocket streaming
+
+type handlerWithAuditLogger func(w http.ResponseWriter, r *http.Request, conn *ProxyConn, auditLogger *zap.Logger)
+
+type config struct {
+	next handlerWithAuditLogger
+	//nolint:godox
+	// TODO: we should always pass in a logger here instead of falling back to the global logger.
+	// For now, if nil, a default logger will be used.
+	logger *zap.Logger
+}
+
+func auditMiddleware(config config) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger := config.logger
+		if logger == nil {
+			logger = zap.L().Named("audit")
+		}
+
+		auditLogger := logger.With(
+			zap.String("request_id", uuid.New().String()),
+			zap.Time("requested_at", time.Now()),
+			zap.String("method", r.Method),
+			zap.String("url", r.URL.String()),
+			zap.String("remote_addr", r.RemoteAddr),
+		)
+		conn, ok := r.Context().Value(ConnContextKey).(*ProxyConn)
+
+		if !ok {
+			auditLogger.Error("Failed to retrieve proxy connection from context")
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+
+			return
+		}
+
+		auditLogger = auditLogger.With(
+			zap.Object("user", conn.claims.User),
+			zap.String("conn_id", conn.id),
+		)
+
+		rw := &responseWriter{ResponseWriter: w}
+
+		defer func() {
+			// Check if there was a panic. `http.ErrAbortHandler` is considered
+			// okay e.g. client closes connection during HTTP streaming.
+			if recovered := recover(); recovered != nil && recovered != http.ErrAbortHandler { //nolint:err113,errorlint
+				auditLogger.Error("API request failed",
+					zap.Any("request", map[string]any{
+						"headers": r.Header,
+					}),
+					zap.Any("response", map[string]any{
+						"status_code": rw.statusCode,
+						"headers":     rw.headers,
+					}),
+					zap.Any("panic", recovered),
+				)
+
+				// Re-panic to let others handle it
+				panic(recovered)
+			}
+
+			auditLogger.Info("API request completed",
+				zap.Any("request", map[string]any{
+					"headers": r.Header,
+				}),
+				zap.Any("response", map[string]any{
+					"status_code": rw.statusCode,
+					"headers":     rw.headers,
+				}),
+			)
+		}()
+
+		config.next(rw, r, conn, auditLogger)
+	})
+}

--- a/internal/httpproxy/audit_middleware_test.go
+++ b/internal/httpproxy/audit_middleware_test.go
@@ -1,0 +1,183 @@
+package httpproxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"k8sgateway/internal/token"
+)
+
+type mockHandler struct {
+	mock.Mock
+}
+
+func (m *mockHandler) serveHTTP(w http.ResponseWriter, r *http.Request, conn *ProxyConn, auditLogger *zap.Logger) {
+	m.Called(w, r, conn, auditLogger)
+}
+
+func TestAuditMiddleware(t *testing.T) {
+	tests := []struct {
+		name               string
+		handlerFn          func(w http.ResponseWriter)
+		expectedLogMessage string
+		expectedLogLevel   zapcore.Level
+		expectedStatusCode int
+		expectedPanic      string
+	}{
+		{
+			name: "Normal handler",
+			handlerFn: func(w http.ResponseWriter) {
+				// Simulate a successful response
+				w.WriteHeader(http.StatusAccepted)
+				_, _ = w.Write([]byte("Accepted"))
+			},
+			expectedLogMessage: "API request completed",
+			expectedLogLevel:   zapcore.InfoLevel,
+			expectedStatusCode: http.StatusAccepted,
+			expectedPanic:      "",
+		},
+		{
+			name: "Handler without explicitly setting response header",
+			handlerFn: func(w http.ResponseWriter) {
+				_, _ = w.Write([]byte("Response"))
+			},
+			expectedLogMessage: "API request completed",
+			expectedLogLevel:   zapcore.InfoLevel,
+			expectedStatusCode: http.StatusOK,
+			expectedPanic:      "",
+		},
+		{
+			name: "Handler panics with http.ErrAbortHandler",
+			handlerFn: func(w http.ResponseWriter) {
+				_, _ = w.Write([]byte("Streaming..."))
+				panic(http.ErrAbortHandler)
+			},
+			expectedLogMessage: "API request completed",
+			expectedLogLevel:   zapcore.InfoLevel,
+			expectedStatusCode: http.StatusOK,
+			expectedPanic:      "",
+		},
+		{
+			name: "Handler panics with other error",
+			handlerFn: func(w http.ResponseWriter) {
+				_, _ = w.Write([]byte("Streaming..."))
+				panic("Something went wrong!")
+			},
+			expectedLogMessage: "API request failed",
+			expectedLogLevel:   zapcore.ErrorLevel,
+			expectedStatusCode: http.StatusOK,
+			expectedPanic:      "Something went wrong!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockHandler := &mockHandler{}
+			claims := &token.GATClaims{
+				User: token.User{
+					ID:       "user-id-1",
+					Username: "user@acme.com",
+					Groups:   []string{"OnCall", "Engineering"},
+				},
+			}
+			conn := &ProxyConn{id: "conn-id-1", claims: claims}
+			ctx := context.WithValue(t.Context(), ConnContextKey, conn)
+			request := httptest.NewRequestWithContext(ctx, "GET", "/api", nil)
+			request.Header.Set("Kubectl-Command", "kubectl exec")
+
+			recorder := httptest.NewRecorder()
+			recorder.Header().Set("Audit-Id", "audit-id-1")
+
+			mockHandler.
+				On("serveHTTP", mock.Anything, request, conn, mock.Anything).
+				Run(func(args mock.Arguments) {
+					rw := args[0].(http.ResponseWriter)
+					tt.handlerFn(rw)
+				})
+
+			core, logs := observer.New(zap.DebugLevel)
+			logger := zap.New(core)
+
+			func() {
+				defer func() {
+					// Recover if handler panics
+					_ = recover()
+				}()
+				auditMiddleware(config{
+					next:   mockHandler.serveHTTP,
+					logger: logger,
+				}).ServeHTTP(recorder, request)
+			}()
+
+			mockHandler.AssertExpectations(t)
+
+			assert.Len(t, logs.All(), 1)
+			log := logs.All()[0]
+			assert.Equal(t, tt.expectedLogLevel, log.Level)
+			assert.Equal(t, tt.expectedLogMessage, log.Message)
+
+			logContext := log.ContextMap()
+			assert.Subset(t, logContext, map[string]any{
+				"method":      "GET",
+				"url":         "/api",
+				"remote_addr": request.RemoteAddr,
+				"conn_id":     "conn-id-1",
+				"user":        map[string]any{"id": "user-id-1", "username": "user@acme.com", "groups": []any{"OnCall", "Engineering"}},
+				"request": map[string]any{
+					"headers": http.Header{"Kubectl-Command": {"kubectl exec"}},
+				},
+				"response": map[string]any{
+					"status_code": tt.expectedStatusCode,
+					"headers":     http.Header{"Audit-Id": {"audit-id-1"}},
+				},
+			})
+			assert.NotEmpty(t, logContext["request_id"])
+			assert.NotEmpty(t, logContext["requested_at"])
+
+			if tt.expectedPanic != "" {
+				assert.Equal(t, tt.expectedPanic, logContext["panic"])
+			}
+		})
+	}
+}
+
+func TestAuditMiddleware_FailedToRetrieveProxyConn(t *testing.T) {
+	mockHandler := &mockHandler{}
+
+	request := httptest.NewRequest(http.MethodGet, "/api", nil)
+	recorder := httptest.NewRecorder()
+
+	core, logs := observer.New(zap.DebugLevel)
+	logger := zap.New(core)
+
+	auditMiddleware(config{
+		next:   mockHandler.serveHTTP,
+		logger: logger,
+	}).ServeHTTP(recorder, request)
+
+	response := recorder.Result()
+	assert.Equal(t, http.StatusInternalServerError, response.StatusCode)
+	assert.Equal(t, "Internal server error\n", recorder.Body.String())
+
+	assert.Len(t, logs.All(), 1)
+	log := logs.All()[0]
+	assert.Equal(t, zapcore.ErrorLevel, log.Level)
+	assert.Equal(t, "Failed to retrieve proxy connection from context", log.Message)
+
+	logContext := log.ContextMap()
+	assert.Subset(t, logContext, map[string]any{
+		"method":      "GET",
+		"url":         "/api",
+		"remote_addr": request.RemoteAddr,
+	})
+	assert.NotEmpty(t, logContext["request_id"])
+	assert.NotEmpty(t, logContext["requested_at"])
+}

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -2,7 +2,6 @@ package httpproxy
 
 import (
 	"bufio"
-	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -79,95 +78,6 @@ func TestProxyConn_Close(t *testing.T) {
 		assert.Fail(t, "Timer should have been stopped")
 	default:
 	}
-}
-
-func TestTruncateBody(t *testing.T) {
-	testCases := []struct {
-		name     string
-		input    []byte
-		expected string
-	}{
-		{
-			name:     "Empty body",
-			input:    []byte{},
-			expected: "",
-		},
-		{
-			name:     "Short body",
-			input:    []byte("This is a short body"),
-			expected: "This is a short body",
-		},
-		{
-			name:     "Exactly max size body",
-			input:    bytes.Repeat([]byte("a"), bodyLogMaxSize),
-			expected: string(bytes.Repeat([]byte("a"), bodyLogMaxSize)),
-		},
-		{
-			name:     "Body longer than max size",
-			input:    bytes.Repeat([]byte("a"), bodyLogMaxSize+50),
-			expected: string(bytes.Repeat([]byte("a"), bodyLogMaxSizeWithSuffix)) + bodyLogTruncationSuffix,
-		},
-		{
-			name:     "Unicode body truncation",
-			input:    bytes.Repeat([]byte("こんにちは世界"), bodyLogMaxSize),
-			expected: string(bytes.Repeat([]byte("こんにちは世界"), bodyLogMaxSize)[:bodyLogMaxSizeWithSuffix]) + bodyLogTruncationSuffix,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := truncateBody(tc.input)
-
-			assert.Equal(t, tc.expected, result)
-			assert.LessOrEqual(t, len(result), bodyLogMaxSize, "Truncated body exceeds max size")
-		})
-	}
-}
-
-func TestResponseLogger(t *testing.T) {
-	recorder := httptest.NewRecorder()
-	buffer := &bytes.Buffer{}
-	logger := &responseLogger{
-		ResponseWriter: recorder,
-		body:           buffer,
-	}
-
-	t.Run("WriteHeader", func(t *testing.T) {
-		testStatusCode := http.StatusBadRequest
-		logger.WriteHeader(testStatusCode)
-		assert.Equal(t, testStatusCode, logger.statusCode, "Status code not set correctly")
-		assert.NotNil(t, logger.headers, "Headers should be cloned")
-	})
-
-	t.Run("Write", func(t *testing.T) {
-		testData := []byte("hello!!!")
-		n, err := logger.Write(testData)
-
-		require.NoError(t, err, "Write should not return an error")
-		assert.Equal(t, len(testData), n, "Number of bytes written should match input")
-		assert.Equal(t, testData, logger.body.Bytes(), "Body buffer should contain written data")
-	})
-
-	t.Run("Write and WriteHeader combined", func(t *testing.T) {
-		recorder := httptest.NewRecorder()
-		buffer := &bytes.Buffer{}
-		logger := &responseLogger{
-			ResponseWriter: recorder,
-			body:           buffer,
-		}
-
-		testStatusCode := http.StatusOK
-		testData := []byte("test response")
-
-		logger.WriteHeader(testStatusCode)
-		n, err := logger.Write(testData)
-
-		require.NoError(t, err, "Write should not return an error")
-		assert.Equal(t, testStatusCode, logger.statusCode, "Status code should be set correctly")
-		assert.Equal(t, len(testData), n, "Number of bytes written should match input")
-		assert.Equal(t, testData, logger.body.Bytes(), "Body buffer should contain written data")
-		assert.Equal(t, recorder.Body.Bytes(), testData, "Underlying ResponseWriter should receive data")
-	})
 }
 
 type mockValidator struct {
@@ -617,37 +527,6 @@ func TestProxy_ForwardRequest(t *testing.T) {
 
 	// check response
 	assert.Equal(t, "Upstream API Server Response!", string(body))
-}
-
-func TestShouldSkipRESTRequest(t *testing.T) {
-	tests := []struct {
-		name     string
-		request  *http.Request
-		expected bool
-	}{
-		{
-			name:     "Get a pod log request",
-			request:  httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/pod-1/log", nil),
-			expected: true,
-		},
-		{
-			name:     "Get a pod request",
-			request:  httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/pod-1", nil),
-			expected: false,
-		},
-		{
-			name:     "Get a namespace request",
-			request:  httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default", nil),
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := shouldSkipRESTRequest(tt.request)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
 }
 
 func TestShouldSkipWebSocketRequest(t *testing.T) {

--- a/test/integration/authentication_test.go
+++ b/test/integration/authentication_test.go
@@ -371,7 +371,7 @@ func assertLogsForExec(t *testing.T, logs *observer.ObservedLogs, expectedURL, e
 	secondLog := expectedLogs[1]
 	assert.Equal(t, "API request completed", secondLog.Message)
 	assert.Equal(t, expectedUser, secondLog.ContextMap()["user"])
-	assert.Subset(t, secondLog.ContextMap()["response"], map[string]any{"status_code": 200})
+	assert.Subset(t, secondLog.ContextMap()["response"], map[string]any{"status_code": 101})
 
 	// Request and response logs must have the same request ID
 	assert.Equal(t, firstLog.ContextMap()["request_id"], secondLog.ContextMap()["request_id"])

--- a/test/integration/authentication_test.go
+++ b/test/integration/authentication_test.go
@@ -349,20 +349,12 @@ func assertLogsForREST(t *testing.T, logs *observer.ObservedLogs, expectedURL st
 	t.Helper()
 
 	expectedLogs := logs.FilterField(zap.String("url", expectedURL)).All()
-	assert.Len(t, expectedLogs, 2)
+	assert.Len(t, expectedLogs, 1)
 
 	firstLog := expectedLogs[0]
-	assert.Equal(t, "API request", firstLog.Message)
+	assert.Equal(t, "API request completed", firstLog.Message)
 	assert.Equal(t, expectedUser, firstLog.ContextMap()["user"])
-	assert.NotEmpty(t, firstLog.ContextMap()["request"])
-
-	secondLog := expectedLogs[1]
-	assert.Equal(t, "API response", secondLog.Message)
-	assert.Equal(t, expectedUser, secondLog.ContextMap()["user"])
-	assert.NotEmpty(t, secondLog.ContextMap()["response"])
-
-	// Request and response logs must have the same request ID
-	assert.Equal(t, firstLog.ContextMap()["request_id"], secondLog.ContextMap()["request_id"])
+	assert.Subset(t, firstLog.ContextMap()["response"], map[string]any{"status_code": 201})
 }
 
 func assertLogsForExec(t *testing.T, logs *observer.ObservedLogs, expectedURL, expectedOutput string, expectedUser map[string]any) {
@@ -372,13 +364,14 @@ func assertLogsForExec(t *testing.T, logs *observer.ObservedLogs, expectedURL, e
 	assert.Len(t, expectedLogs, 2)
 
 	firstLog := expectedLogs[0]
-	assert.Equal(t, "API request", firstLog.Message)
+	assert.Equal(t, "session finished", firstLog.Message)
 	assert.Equal(t, expectedUser, firstLog.ContextMap()["user"])
+	assert.Contains(t, firstLog.ContextMap()["asciinema_data"], expectedOutput)
 
 	secondLog := expectedLogs[1]
-	assert.Equal(t, "session finished", secondLog.Message)
+	assert.Equal(t, "API request completed", secondLog.Message)
 	assert.Equal(t, expectedUser, secondLog.ContextMap()["user"])
-	assert.Contains(t, secondLog.ContextMap()["asciinema_data"], expectedOutput)
+	assert.Subset(t, secondLog.ContextMap()["response"], map[string]any{"status_code": 200})
 
 	// Request and response logs must have the same request ID
 	assert.Equal(t, firstLog.ContextMap()["request_id"], secondLog.ContextMap()["request_id"])


### PR DESCRIPTION
## Changes

- For each API request, create 1 audit log (instead of 2) when the response is completed.
  + Add `requested_at` timestamp field
  + `request` field contains the request info e.g. `headers`
  + `response` field contains the response info e.g.g `status_code` and `headers`.
- No longer log the request and response's body

## Notes

- This change would log all API requests, including requests that are upgraded to WebSocket streaming. Previously, if a request fails to upgrade to WebSocket streaming, we didn't log its response.
- Sample log
```json
{
  "message": "API request complete",
  "request_id": "767848ad-2dc4-4a4f-b685-fe98e8a1ecd1",
  "requested_at": "2025-06-20T15:55:55.540-0700" 
  "method": "GET",
  "url": "/api/v1/namespaces/default/pods?limit=500",
  "remote_addr": "10.16.0.3:36634",
  "user": {
    "id": "VXNlcjoxNTQ4NDQ1",
    "username": "alex@acme.com",
    "groups": []
  },
  "conn_id": "f8c4c2f6-bc12-4e83-9f13-0f1e75a25ac4",
  "request": {
    "headers": {
      "Accept": [
        "application/json;as=Table;v=v1;g=meta.k8s.io,application/json;as=Table;v=v1beta1;g=meta.k8s.io,application/json"
      ],
      "Accept-Encoding": [
        "gzip"
      ],
      "Authorization": [
        "Bearer void"
      ],
      "Kubectl-Command": [
        "kubectl get"
      ],
      "Kubectl-Session": [
        "2798bbb2-2bbb-47f6-9c50-fa320da29af0"
      ],
      "User-Agent": [
        "kubectl/v1.31.2 (darwin/arm64) kubernetes/5864a46"
      ]
    },
  },
  "response": {
    "status_code": 200,
    "headers": {
      "Audit-Id": [
        "ef60c8ae-0740-4625-b792-561a1c570383"
      ],
      "Cache-Control": [
        "no-cache, private"
      ],
      "Content-Type": [
        "application/json"
      ],
      "Date": [
        "Tue, 17 Jun 2025 21:29:10 GMT"
      ],
      "X-Kubernetes-Pf-Flowschema-Uid": [
        "edd5ba11-aa4a-454e-8c6b-02bf1bc06e82"
      ],
      "X-Kubernetes-Pf-Prioritylevel-Uid": [
        "9e7fd9e9-17dc-4882-8ba1-5a8bb9261040"
      ]
    }
  }
}
```
