### PR TITLE
fix: Move `CONNECT` handling logic from `Listener.Accept()` to `ProxyConn.Read()`

### DIFF
--- a/internal/httpproxy/http_proxy.go
+++ b/internal/httpproxy/http_proxy.go
@@ -68,28 +68,33 @@ type Config struct {
 	LogFlushInterval      time.Duration
 }
 
-// custom Conn that wraps a net.Conn, adding the user identity field.
+// ProxyConn is a custom connection that wraps the underlying TCP net.Conn, handling downstream
+// proxy (Twingate Client)'s authentication via the initial CONNECT message. It handles 2 TLS
+// upgrades: with downstream proxy and then with downstream client e.g. `kubectl`.
 type ProxyConn struct {
 	net.Conn
+	TLSConfig        *tls.Config
+	ConnectValidator connect.Validator
+	logger           *zap.Logger
+
+	isAuthenticated bool
+
 	id     string
 	claims *token.GATClaims
 	timer  *time.Timer
 	mu     sync.Mutex
 }
 
-func NewProxyConn(conn net.Conn, connID string, claims *token.GATClaims) *ProxyConn {
-	p := &ProxyConn{
-		Conn:   conn,
-		id:     connID,
-		claims: claims,
+func (p *ProxyConn) Read(b []byte) (int, error) {
+	if p.isAuthenticated {
+		return p.Conn.Read(b)
 	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.timer = time.AfterFunc(time.Until(claims.ExpiresAt.Time), func() {
-		_ = p.Close()
-	})
 
-	return p
+	if err := p.authenticate(); err != nil {
+		return 0, err
+	}
+
+	return p.Conn.Read(b)
 }
 
 func (p *ProxyConn) Close() error {
@@ -103,36 +108,15 @@ func (p *ProxyConn) Close() error {
 	return p.Conn.Close()
 }
 
-func ExportKeyingMaterial(conn *tls.Conn) ([]byte, error) {
-	cs := conn.ConnectionState()
+// authenticate sets up TLS and processes the CONNECT message for authentication.
+func (p *ProxyConn) authenticate() error {
+	// Establish TLS connection with the downstream proxy
+	tlsConnectConn := tls.Server(p.Conn, p.TLSConfig)
 
-	return cs.ExportKeyingMaterial(keyingMaterialLabel, nil, keyingMaterialLength)
-}
-
-// custom listener to handle HTTP CONNECT and then upgrade to HTTPS.
-type tcpListener struct {
-	Listener         net.Listener
-	TLSConfig        *tls.Config
-	ConnectValidator connect.Validator
-}
-
-func (l *tcpListener) Accept() (net.Conn, error) {
-	logger := zap.S()
-
-	// start accepting connections
-	conn, err := l.Listener.Accept()
-	if err != nil {
-		return nil, err
-	}
-
-	// now upgrade the net.Conn to a TLS connection
-	tlsConnectConn := tls.Server(conn, l.TLSConfig)
-
-	// start TLS handshake with the downstream proxy
 	if err := tlsConnectConn.Handshake(); err != nil {
 		tlsConnectConn.Close()
 
-		return tlsConnectConn, nil //nolint:nilerr
+		return err
 	}
 
 	// parse HTTP request
@@ -140,111 +124,142 @@ func (l *tcpListener) Accept() (net.Conn, error) {
 
 	req, err := http.ReadRequest(bufReader)
 	if err != nil {
-		logger.Errorf("failed to parse HTTP request: %v", err)
+		p.logger.Error("failed to parse HTTP request", zap.Error(err))
 
 		responseStr := "HTTP/1.1 400 Bad Request\r\n\r\n"
 
 		_, writeErr := tlsConnectConn.Write([]byte(responseStr))
 		if writeErr != nil {
-			logger.Errorf("failed to write response: %v", writeErr)
+			p.logger.Error("failed to write response", zap.Error(writeErr))
 			tlsConnectConn.Close()
 
-			return tlsConnectConn, nil
+			return writeErr
 		}
 
 		tlsConnectConn.Close()
 
-		return tlsConnectConn, nil
+		return err
 	}
 
+	// Health check request
 	if req.Method == http.MethodGet && req.URL.Path == healthCheckPath {
 		responseStr := "HTTP/1.1 200 OK\r\n\r\n"
 
 		_, writeErr := tlsConnectConn.Write([]byte(responseStr))
 		if writeErr != nil {
-			logger.Errorf("failed to write response: %v", writeErr)
+			p.logger.Error("failed to write response", zap.Error(writeErr))
 			tlsConnectConn.Close()
 
-			return tlsConnectConn, nil
+			return writeErr
 		}
 
 		tlsConnectConn.Close()
 
-		return tlsConnectConn, nil
+		return nil
 	}
 
 	// get the keying material for the TLS session
 	ekm, err := ExportKeyingMaterial(tlsConnectConn)
 	if err != nil {
-		logger.Errorf("failed to get keying material: %v", err)
+		p.logger.Error("failed to get keying material", zap.Error(err))
 		tlsConnectConn.Close()
 
-		return tlsConnectConn, nil
+		return err
 	}
 
 	// Parse and validate HTTP request, expecting CONNECT with
 	// valid token and signature
 	response := httpResponseString(http.StatusOK)
 
-	connectInfo, err := l.ConnectValidator.ParseConnect(req, ekm)
+	connectInfo, err := p.ConnectValidator.ParseConnect(req, ekm)
 	if err != nil {
 		var httpErr *connect.HTTPError
 		if errors.As(err, &httpErr) {
 			response = httpResponseString(httpErr.Code)
 		} else {
-			logger.Error("failed to parse CONNECT:", zap.Error(err))
+			p.logger.Error("failed to parse CONNECT:", zap.Error(err))
 
 			response = httpResponseString(http.StatusBadRequest)
 		}
 	}
 
 	if connectInfo.Claims != nil {
-		logger = logger.With(
+		p.logger = p.logger.With(
 			zap.Object("user", connectInfo.Claims.User),
 		)
 	}
 
-	logger = logger.With(
+	p.logger = p.logger.With(
 		zap.String("conn_id", connectInfo.ConnID),
 	)
 
 	_, writeErr := tlsConnectConn.Write([]byte(response))
 	if writeErr != nil {
-		logger.Errorf("failed to write response: %v", writeErr)
+		p.logger.Error("failed to write response", zap.Error(writeErr))
 		tlsConnectConn.Close()
 
-		return tlsConnectConn, nil
+		return writeErr
 	}
 
 	if err != nil {
-		logger.Errorf("failed to serve request: %v", err)
+		p.logger.Error("failed to serve request", zap.Error(err))
 		tlsConnectConn.Close()
 
-		return tlsConnectConn, nil
+		return err
 	}
 
 	// CONNECT from downstream proxy is finished, now perform handshake with the downstream client
-	tlsConn := tls.Server(tlsConnectConn, l.TLSConfig)
+	tlsConn := tls.Server(tlsConnectConn, p.TLSConfig)
 	if err := tlsConn.Handshake(); err != nil {
 		tlsConn.Close()
 
-		return tlsConn, nil //nolint:nilerr
+		return err
 	}
 
-	// add auth information to the net.Conn by using ProxyConn which wraps net.Conn with
-	// a field for the user identity
-	proxyConn := NewProxyConn(tlsConn, connectInfo.ConnID, connectInfo.Claims)
+	// Replace the underlying connection with the downstream client TLS connection
+	p.Conn = tlsConn
+	p.setConnectInfo(connectInfo)
+	p.isAuthenticated = true
 
-	// return the wrapped and 'upgraded to TLS' net.Conn (ProxyConn) to the caller
-	return proxyConn, nil
+	return nil
 }
 
-func (l *tcpListener) Close() error {
-	return l.Listener.Close()
+func (p *ProxyConn) setConnectInfo(connectInfo connect.Info) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.id = connectInfo.ConnID
+	p.claims = connectInfo.Claims
+	p.timer = time.AfterFunc(time.Until(connectInfo.Claims.ExpiresAt.Time), func() {
+		_ = p.Close()
+	})
 }
 
-func (l *tcpListener) Addr() net.Addr {
-	return l.Listener.Addr()
+func ExportKeyingMaterial(conn *tls.Conn) ([]byte, error) {
+	cs := conn.ConnectionState()
+
+	return cs.ExportKeyingMaterial(keyingMaterialLabel, nil, keyingMaterialLength)
+}
+
+type proxyListener struct {
+	net.Listener
+	TLSConfig        *tls.Config
+	ConnectValidator connect.Validator
+	logger           *zap.Logger
+}
+
+func (l *proxyListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ProxyConn{
+		Conn:             conn,
+		TLSConfig:        l.TLSConfig,
+		ConnectValidator: l.ConnectValidator,
+		logger:           l.logger,
+	}, nil
 }
 
 type responseLogger struct {
@@ -409,29 +424,27 @@ func NewProxy(cfg Config) (*Proxy, error) {
 }
 
 func (p *Proxy) Start(ready chan struct{}) {
-	logger := zap.S()
+	logger := zap.L()
 
-	// create the TCP listener
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", p.config.Port))
 	if err != nil {
-		logger.Fatal(err)
+		logger.Fatal("failed to create listener", zap.Error(err))
 	}
 
 	if ready != nil {
 		close(ready)
 	}
 
-	// use custom listener with TLS config
-	customListener := &tcpListener{
+	listener = &proxyListener{
 		Listener:         listener,
 		TLSConfig:        p.downstreamTLSConfig,
 		ConnectValidator: p.config.ConnectValidator,
+		logger:           logger,
 	}
 
-	// start serving HTTP
-	err = p.httpServer.Serve(customListener)
+	err = p.httpServer.Serve(listener)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Fatal("failed to start HTTP server", zap.Error(err))
 	}
 }
 

--- a/internal/httpproxy/http_proxy.go
+++ b/internal/httpproxy/http_proxy.go
@@ -122,8 +122,6 @@ func (p *ProxyConn) authenticate() error {
 	tlsConnectConn := tls.Server(p.Conn, p.TLSConfig)
 
 	if err := tlsConnectConn.Handshake(); err != nil {
-		tlsConnectConn.Close()
-
 		return err
 	}
 
@@ -139,12 +137,9 @@ func (p *ProxyConn) authenticate() error {
 		_, writeErr := tlsConnectConn.Write([]byte(responseStr))
 		if writeErr != nil {
 			p.logger.Error("failed to write response", zap.Error(writeErr))
-			tlsConnectConn.Close()
 
 			return writeErr
 		}
-
-		tlsConnectConn.Close()
 
 		return err
 	}
@@ -156,12 +151,9 @@ func (p *ProxyConn) authenticate() error {
 		_, writeErr := tlsConnectConn.Write([]byte(responseStr))
 		if writeErr != nil {
 			p.logger.Error("failed to write response", zap.Error(writeErr))
-			tlsConnectConn.Close()
 
 			return writeErr
 		}
-
-		tlsConnectConn.Close()
 
 		return nil
 	}
@@ -170,7 +162,6 @@ func (p *ProxyConn) authenticate() error {
 	ekm, err := ExportKeyingMaterial(tlsConnectConn)
 	if err != nil {
 		p.logger.Error("failed to get keying material", zap.Error(err))
-		tlsConnectConn.Close()
 
 		return err
 	}
@@ -204,14 +195,12 @@ func (p *ProxyConn) authenticate() error {
 	_, writeErr := tlsConnectConn.Write([]byte(response))
 	if writeErr != nil {
 		p.logger.Error("failed to write response", zap.Error(writeErr))
-		tlsConnectConn.Close()
 
 		return writeErr
 	}
 
 	if err != nil {
 		p.logger.Error("failed to serve request", zap.Error(err))
-		tlsConnectConn.Close()
 
 		return err
 	}
@@ -219,8 +208,6 @@ func (p *ProxyConn) authenticate() error {
 	// CONNECT from downstream proxy is finished, now perform handshake with the downstream client
 	tlsConn := tls.Server(tlsConnectConn, p.TLSConfig)
 	if err := tlsConn.Handshake(); err != nil {
-		tlsConn.Close()
-
 		return err
 	}
 

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"k8sgateway/internal/connect"
-	"k8sgateway/internal/log"
 	"k8sgateway/internal/token"
 )
 
@@ -40,7 +40,7 @@ func (m *mockConn) IsClosed() bool {
 	return m.isClosed.Load()
 }
 
-func TestNewProxyConn(t *testing.T) {
+func TestProxyConn_setConnectInfo(t *testing.T) {
 	conn := &mockConn{}
 	claims := &token.GATClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -49,12 +49,15 @@ func TestNewProxyConn(t *testing.T) {
 	}
 	connID := "conn-id-1"
 
-	proxyConn := NewProxyConn(conn, connID, claims)
+	proxyConn := &ProxyConn{Conn: conn}
 
-	assert.NotNil(t, proxyConn)
-	assert.Equal(t, claims, proxyConn.claims)
+	proxyConn.setConnectInfo(connect.Info{
+		Claims: claims,
+		ConnID: connID,
+	})
+
 	assert.Equal(t, connID, proxyConn.id)
-	assert.Equal(t, conn, proxyConn.Conn)
+	assert.Equal(t, claims, proxyConn.claims)
 
 	// Wait for timer to happen, the connection should be closed
 	time.Sleep(100 * time.Millisecond)
@@ -218,9 +221,7 @@ func startMockListener(t *testing.T) (net.Listener, string) {
 	return listener, addr
 }
 
-func TestTCPListener_Accept_BadRequest(t *testing.T) {
-	log.InitializeLogger("gateway", false)
-
+func TestProxyConn_Read_BadRequest(t *testing.T) {
 	listener, addr := startMockListener(t)
 	defer listener.Close()
 
@@ -236,10 +237,11 @@ func TestTCPListener_Accept_BadRequest(t *testing.T) {
 		shouldFail: false,
 	}
 
-	tcpListener := &tcpListener{
+	listener = &proxyListener{
 		Listener:         listener,
 		TLSConfig:        proxyTLSConfig,
 		ConnectValidator: mockValidator,
+		logger:           zap.NewNop(),
 	}
 
 	// make client TLS
@@ -277,16 +279,16 @@ func TestTCPListener_Accept_BadRequest(t *testing.T) {
 		done <- struct{}{}
 	}()
 
-	conn, err := tcpListener.Accept()
+	conn, err := listener.Accept()
 	require.NoError(t, err)
-	assert.NotNil(t, conn)
+
+	b := make([]byte, 0)
+	_, _ = conn.Read(b)
 
 	<-done
 }
 
-func TestTCPListener_Accept_Healthcheck(t *testing.T) {
-	log.InitializeLogger("gateway", false)
-
+func TestProxyConn_Read_HealthCheck(t *testing.T) {
 	listener, addr := startMockListener(t)
 	defer listener.Close()
 
@@ -297,7 +299,7 @@ func TestTCPListener_Accept_Healthcheck(t *testing.T) {
 		Certificates: []tls.Certificate{serverCert},
 	}
 
-	tcpListener := &tcpListener{
+	listener = &proxyListener{
 		Listener:  listener,
 		TLSConfig: proxyTLSConfig,
 	}
@@ -337,24 +339,23 @@ func TestTCPListener_Accept_Healthcheck(t *testing.T) {
 		done <- struct{}{}
 	}()
 
-	conn, err := tcpListener.Accept()
+	conn, err := listener.Accept()
 	require.NoError(t, err)
-	assert.NotNil(t, conn)
+
+	b := make([]byte, 0)
+	_, _ = conn.Read(b)
 
 	<-done
 }
 
-func TestTCPListener_Accept_ValidConnectRequest(t *testing.T) {
-	log.InitializeLogger("gateway", false)
-
+func TestProxyConn_Read_ValidConnectRequest(t *testing.T) {
 	listener, addr := startMockListener(t)
 	defer listener.Close()
 
-	// make proxy TLS
-	serverCert, _ := tls.LoadX509KeyPair("../../test/data/proxy_server.crt", "../../test/data/proxy_server.key")
+	proxyCert, _ := tls.LoadX509KeyPair("../../test/data/proxy_server.crt", "../../test/data/proxy_server.key")
 
 	proxyTLSConfig := &tls.Config{
-		Certificates: []tls.Certificate{serverCert},
+		Certificates: []tls.Certificate{proxyCert},
 	}
 
 	// mock CONNECT validator
@@ -362,10 +363,11 @@ func TestTCPListener_Accept_ValidConnectRequest(t *testing.T) {
 		shouldFail: false,
 	}
 
-	tcpListener := &tcpListener{
+	listener = &proxyListener{
 		Listener:         listener,
 		TLSConfig:        proxyTLSConfig,
 		ConnectValidator: mockValidator,
+		logger:           zap.NewNop(),
 	}
 
 	// make client TLS
@@ -413,24 +415,24 @@ func TestTCPListener_Accept_ValidConnectRequest(t *testing.T) {
 		done <- struct{}{}
 	}()
 
-	conn, err := tcpListener.Accept()
+	conn, err := listener.Accept()
 	require.NoError(t, err)
-	assert.NotNil(t, conn)
 
-	proxyConn, ok := conn.(*ProxyConn)
-	assert.True(t, ok)
+	b := make([]byte, 0)
+	_, _ = conn.Read(b)
+
+	<-done
+
+	assert.IsType(t, &ProxyConn{}, conn)
+	proxyConn := conn.(*ProxyConn)
 	assert.Equal(t, "user@acme.com", proxyConn.claims.User.Username)
 	assert.ElementsMatch(t, []string{"Everyone", "Engineering"}, proxyConn.claims.User.Groups)
 	assert.Equal(t, "gat_token", mockValidator.ProxyAuth)
 	assert.Equal(t, "auth_sig", mockValidator.TokenSig)
 	assert.Equal(t, "conn-id-1", mockValidator.ConnID)
-
-	<-done
 }
 
-func TestTCPListener_Accept_FailedValidation(t *testing.T) {
-	log.InitializeLogger("gateway", false)
-
+func TestProxyConn_Read_FailedValidation(t *testing.T) {
 	listener, addr := startMockListener(t)
 	defer listener.Close()
 
@@ -446,10 +448,11 @@ func TestTCPListener_Accept_FailedValidation(t *testing.T) {
 		shouldFail: true,
 	}
 
-	tcpListener := &tcpListener{
+	listener = &proxyListener{
 		Listener:         listener,
 		TLSConfig:        proxyTLSConfig,
 		ConnectValidator: mockValidator,
+		logger:           zap.NewNop(),
 	}
 
 	// make client TLS
@@ -487,16 +490,16 @@ func TestTCPListener_Accept_FailedValidation(t *testing.T) {
 		done <- struct{}{}
 	}()
 
-	conn, err := tcpListener.Accept()
+	conn, err := listener.Accept()
 	require.NoError(t, err)
-	assert.NotNil(t, conn)
+
+	b := make([]byte, 0)
+	_, _ = conn.Read(b)
 
 	<-done
 }
 
 func TestProxy_ForwardRequest(t *testing.T) {
-	log.InitializeLogger("gateway", false)
-
 	// create mock API server (upstream)
 	apiServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// proxy should provide the correct 'Impersonate-User' header


### PR DESCRIPTION
## Changes

`Listener.Accept()` is blocking on `http.Server` main coroutine i.e. only one `CONNECT` message could be processed at a time. Move the logic handling `CONNECT` to `ProxyConn.Read()`

