### PR TITLE
fix: Return proper HTTP headers in the health check response

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -82,8 +82,6 @@ func start(newProxy ProxyFactory) error {
 
 	metricsPort := viper.GetInt("metricsPort")
 	go func() {
-		logger.Infof("Starting metrics server on: %v", metricsPort)
-
 		err := metrics.Start(metrics.Config{
 			Port: metricsPort,
 		})

--- a/internal/httpproxy/http_proxy.go
+++ b/internal/httpproxy/http_proxy.go
@@ -136,7 +136,7 @@ func (p *ProxyConn) authenticate() error {
 
 	// Health check request
 	if req.Method == http.MethodGet && req.URL.Path == healthCheckPath {
-		responseStr := "HTTP/1.1 200 OK\r\n\r\n"
+		responseStr := "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
 
 		_, writeErr := tlsConnectConn.Write([]byte(responseStr))
 		if writeErr != nil {

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -259,9 +259,16 @@ func TestProxyConn_Read_HealthCheck(t *testing.T) {
 		// send a healthcheck request
 		fmt.Fprintf(proxyTLSConn, "GET /healthz HTTP/1.1\r\n\r\n")
 
-		resp, err := bufio.NewReader(proxyTLSConn).ReadString('\n')
+		buf := bufio.NewReader(proxyTLSConn)
+		resp, err := buf.ReadString('\n')
 		assert.NoError(t, err)
 		assert.Equal(t, "HTTP/1.1 200 OK\r\n", resp)
+		resp, err = buf.ReadString('\n')
+		assert.NoError(t, err)
+		assert.Equal(t, "Content-Length: 0\r\n", resp)
+		resp, err = buf.ReadString('\n')
+		assert.NoError(t, err)
+		assert.Equal(t, "Connection: close\r\n", resp)
 
 		done <- struct{}{}
 	}()


### PR DESCRIPTION

## Changes

Return proper HTTP headers (`Content-Length` and `Connection`) in the health check response so the client knows to close the connection