### PR TITLE
fix: Remove `zap.AddCallerSkip` in log configuration

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -82,6 +82,8 @@ func start(newProxy ProxyFactory) error {
 
 	metricsPort := viper.GetInt("metricsPort")
 	go func() {
+		logger.Infof("Starting metrics server on: %v", metricsPort)
+
 		err := metrics.Start(metrics.Config{
 			Port: metricsPort,
 		})

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -20,9 +20,7 @@ var destroyFunc func()
 func InitializeLogger(name string, debug bool) {
 	loggingConfig := loggingConfiguration(debug)
 
-	const linesToSkip = 2
-
-	logger, err := loggingConfig.Build(zap.AddCallerSkip(linesToSkip))
+	logger, err := loggingConfig.Build()
 	if err != nil {
 		panic(fmt.Sprintf("failed to initialize logger: %v", err))
 	}


### PR DESCRIPTION
## Changes

We're using zap logger directly without any wrapper so there is no need to use `zap.AddCallerSkip`