### PR TITLE
feat: Add HTTP Prometheus metrics 

### DIFF
--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -475,6 +476,7 @@ func TestProxy_ForwardRequest(t *testing.T) {
 		K8sAPIServerToken: "mock-token",
 		ConnectValidator:  mockValidator,
 		Port:              45678,
+		Registry:          prometheus.NewRegistry(),
 	}
 
 	// create and start the proxy

--- a/internal/metrics/http_middleware.go
+++ b/internal/metrics/http_middleware.go
@@ -1,0 +1,56 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	httpRequestsTotal     *prometheus.CounterVec
+	httpRequestSizeBytes  *prometheus.HistogramVec
+	httpResponseSizeBytes *prometheus.HistogramVec
+)
+
+func initHTTPMetrics(reg *prometheus.Registry) {
+	httpRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "http_requests_total",
+		Help:      "Total number of HTTP requests processed",
+	}, []string{"method", "code"})
+
+	httpRequestSizeBytes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "http_request_size_bytes",
+		Help:      "Size of incoming HTTP request in bytes",
+		Buckets:   []float64{100, 1_000, 10_000, 100_000, 1000_000, 1_0000_000},
+	}, []string{"method", "code"})
+
+	httpResponseSizeBytes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "http_response_size_bytes",
+		Help:      "Size of outgoing HTTP response in bytes (only for audited requests)",
+		Buckets:   []float64{100, 1_000, 10_000, 100_000, 1000_000, 1_0000_000},
+	}, []string{"method", "code"},
+	)
+
+	reg.MustRegister(httpRequestsTotal, httpRequestSizeBytes, httpResponseSizeBytes)
+}
+
+func HTTPMetricsMiddleware(reg *prometheus.Registry, handler http.Handler) http.HandlerFunc {
+	initHTTPMetrics(reg)
+
+	base := promhttp.InstrumentHandlerCounter(
+		httpRequestsTotal,
+		promhttp.InstrumentHandlerRequestSize(
+			httpRequestSizeBytes,
+			promhttp.InstrumentHandlerResponseSize(
+				httpResponseSizeBytes,
+				handler,
+			),
+		),
+	)
+
+	return base.ServeHTTP
+}

--- a/internal/metrics/http_middleware.go
+++ b/internal/metrics/http_middleware.go
@@ -24,14 +24,14 @@ func initHTTPMetrics(reg *prometheus.Registry) {
 		Namespace: namespace,
 		Name:      "http_request_size_bytes",
 		Help:      "Size of incoming HTTP request in bytes",
-		Buckets:   []float64{100, 1_000, 10_000, 100_000, 1000_000, 1_0000_000},
+		Buckets:   []float64{100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000},
 	}, []string{"method", "code"})
 
 	httpResponseSizeBytes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Name:      "http_response_size_bytes",
 		Help:      "Size of outgoing HTTP response in bytes (only for audited requests)",
-		Buckets:   []float64{100, 1_000, 10_000, 100_000, 1000_000, 1_0000_000},
+		Buckets:   []float64{100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000},
 	}, []string{"method", "code"},
 	)
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -16,17 +16,17 @@ import (
 const namespace = "twingate_gateway"
 
 type Config struct {
-	Port int
+	Port     int
+	Registry *prometheus.Registry
 }
 
 func Start(config Config) error {
-	registry := prometheus.NewRegistry()
-	initMetricCollectors(registry)
-
+	initMetricCollectors(config.Registry)
+	
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.InstrumentMetricHandler(
-		registry,
-		promhttp.HandlerFor(registry, promhttp.HandlerOpts{Registry: registry}),
+		config.Registry,
+		promhttp.HandlerFor(config.Registry, promhttp.HandlerOpts{Registry: config.Registry}),
 	))
 
 	server := &http.Server{


### PR DESCRIPTION
## Changes
- Create `HTTPMetricsMiddleware` to instrument incoming HTTP requests with Prometheus metrics 
- Add `Registry` field to `Config` struct to store the Prometheus registry