### PR TITLE
chore: Add license header to Go files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,10 @@ linters:
           - err113
           - gosec
   settings:
+    goheader:
+      template: |
+        Copyright (c) Twingate Inc.
+        SPDX-License-Identifier: MPL-2.0
     nestif:
       min-complexity: 7
     revive:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,7 @@ linters:
           - gosec
   settings:
     goheader:
-      template: |
+      template: |-
         Copyright (c) Twingate Inc.
         SPDX-License-Identifier: MPL-2.0
     nestif:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package cmd
 
 import (

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package cmd
 
 import (

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package cmd
 
 import (

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package cmd
 
 import (

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package cmd
 
 import (

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package cmd
 
 import (

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package cmd
 
 import (

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package cmd
 
 import (

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package cmd
 
 import (

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package cmd
 
 import (

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package connect
 
 import (

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package connect
 
 import (

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package connect
 
 import (

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package connect
 
 import (

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package connect
 
 import (

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package connect
 
 import (

--- a/internal/httpproxy/audit_middleware.go
+++ b/internal/httpproxy/audit_middleware.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package httpproxy
 
 import (

--- a/internal/httpproxy/audit_middleware.go
+++ b/internal/httpproxy/audit_middleware.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package httpproxy
 
 import (

--- a/internal/httpproxy/audit_middleware.go
+++ b/internal/httpproxy/audit_middleware.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package httpproxy
 
 import (

--- a/internal/httpproxy/audit_middleware_test.go
+++ b/internal/httpproxy/audit_middleware_test.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package httpproxy
 
 import (

--- a/internal/httpproxy/audit_middleware_test.go
+++ b/internal/httpproxy/audit_middleware_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package httpproxy
 
 import (

--- a/internal/httpproxy/audit_middleware_test.go
+++ b/internal/httpproxy/audit_middleware_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package httpproxy
 
 import (

--- a/internal/httpproxy/http_proxy.go
+++ b/internal/httpproxy/http_proxy.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package httpproxy
 
 import (

--- a/internal/httpproxy/http_proxy.go
+++ b/internal/httpproxy/http_proxy.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package httpproxy
 
 import (

--- a/internal/httpproxy/http_proxy.go
+++ b/internal/httpproxy/http_proxy.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package httpproxy
 
 import (

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package httpproxy
 
 import (

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package httpproxy
 
 import (

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package httpproxy
 
 import (

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package log
 
 import (

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package log
 
 import (

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package log
 
 import (

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package metrics
 
 import (

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package metrics
 
 import (

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package metrics
 
 import (

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package metrics
 
 import (

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package metrics
 
 import (

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package metrics
 
 import (

--- a/internal/token/bearer_token_parser.go
+++ b/internal/token/bearer_token_parser.go
@@ -1,4 +1,7 @@
-// Package token manages the parsing of bearer tokens
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package token
 
 import (

--- a/internal/token/bearer_token_parser.go
+++ b/internal/token/bearer_token_parser.go
@@ -1,7 +1,4 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
+// Package token manages the parsing of bearer tokens
 package token
 
 import (

--- a/internal/token/bearer_token_parser.go
+++ b/internal/token/bearer_token_parser.go
@@ -1,4 +1,6 @@
-// Package token manages the parsing of bearer tokens
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package token
 
 import (

--- a/internal/token/bearer_token_parser_test.go
+++ b/internal/token/bearer_token_parser_test.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package token
 
 import (

--- a/internal/token/bearer_token_parser_test.go
+++ b/internal/token/bearer_token_parser_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package token
 
 import (

--- a/internal/token/bearer_token_parser_test.go
+++ b/internal/token/bearer_token_parser_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package token
 
 import (

--- a/internal/token/gat_claims.go
+++ b/internal/token/gat_claims.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package token
 
 import (

--- a/internal/token/gat_claims.go
+++ b/internal/token/gat_claims.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package token
 
 import (

--- a/internal/token/gat_claims.go
+++ b/internal/token/gat_claims.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package token
 
 import (

--- a/internal/token/gat_claims_test.go
+++ b/internal/token/gat_claims_test.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package token
 
 import (

--- a/internal/token/gat_claims_test.go
+++ b/internal/token/gat_claims_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package token
 
 import (

--- a/internal/token/gat_claims_test.go
+++ b/internal/token/gat_claims_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package token
 
 import (

--- a/internal/token/parser.go
+++ b/internal/token/parser.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package token
 
 import (

--- a/internal/token/parser.go
+++ b/internal/token/parser.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package token
 
 import (

--- a/internal/token/parser.go
+++ b/internal/token/parser.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package token
 
 import (

--- a/internal/token/parser_test.go
+++ b/internal/token/parser_test.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package token
 
 import (

--- a/internal/token/parser_test.go
+++ b/internal/token/parser_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package token
 
 import (

--- a/internal/token/parser_test.go
+++ b/internal/token/parser_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package token
 
 import (

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package version
 
 var (

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package version
 
 var (

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package version
 
 var (

--- a/internal/wsproxy/conn.go
+++ b/internal/wsproxy/conn.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/conn.go
+++ b/internal/wsproxy/conn.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package wsproxy
 
 import (

--- a/internal/wsproxy/conn.go
+++ b/internal/wsproxy/conn.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/conn_test.go
+++ b/internal/wsproxy/conn_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/conn_test.go
+++ b/internal/wsproxy/conn_test.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package wsproxy
 
 import (

--- a/internal/wsproxy/conn_test.go
+++ b/internal/wsproxy/conn_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/hijacker.go
+++ b/internal/wsproxy/hijacker.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/hijacker.go
+++ b/internal/wsproxy/hijacker.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package wsproxy
 
 import (

--- a/internal/wsproxy/hijacker.go
+++ b/internal/wsproxy/hijacker.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/hijacker_test.go
+++ b/internal/wsproxy/hijacker_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/hijacker_test.go
+++ b/internal/wsproxy/hijacker_test.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package wsproxy
 
 import (

--- a/internal/wsproxy/hijacker_test.go
+++ b/internal/wsproxy/hijacker_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/msg.go
+++ b/internal/wsproxy/msg.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/msg.go
+++ b/internal/wsproxy/msg.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package wsproxy
 
 import (

--- a/internal/wsproxy/msg.go
+++ b/internal/wsproxy/msg.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/msg_test.go
+++ b/internal/wsproxy/msg_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/msg_test.go
+++ b/internal/wsproxy/msg_test.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package wsproxy
 
 import (

--- a/internal/wsproxy/msg_test.go
+++ b/internal/wsproxy/msg_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/recorder.go
+++ b/internal/wsproxy/recorder.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/recorder.go
+++ b/internal/wsproxy/recorder.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package wsproxy
 
 import (

--- a/internal/wsproxy/recorder.go
+++ b/internal/wsproxy/recorder.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/recorder_test.go
+++ b/internal/wsproxy/recorder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package wsproxy
 
 import (

--- a/internal/wsproxy/recorder_test.go
+++ b/internal/wsproxy/recorder_test.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package wsproxy
 
 import (

--- a/internal/wsproxy/recorder_test.go
+++ b/internal/wsproxy/recorder_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package wsproxy
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package main
 
 import "k8sgateway/cmd"

--- a/main.go
+++ b/main.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package main
 
 import "k8sgateway/cmd"

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package main
 
 import "k8sgateway/cmd"

--- a/test/fake/client.go
+++ b/test/fake/client.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package fake
 
 import (

--- a/test/fake/client.go
+++ b/test/fake/client.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package fake
 
 import (

--- a/test/fake/client.go
+++ b/test/fake/client.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package fake
 
 import (

--- a/test/fake/controller.go
+++ b/test/fake/controller.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package fake
 
 import (

--- a/test/fake/controller.go
+++ b/test/fake/controller.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package fake
 
 import (

--- a/test/fake/controller.go
+++ b/test/fake/controller.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package fake
 
 import (

--- a/test/fake/eckey.go
+++ b/test/fake/eckey.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package fake
 
 import (

--- a/test/fake/eckey.go
+++ b/test/fake/eckey.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package fake
 
 import (

--- a/test/fake/eckey.go
+++ b/test/fake/eckey.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package fake
 
 import (

--- a/test/integration/authentication_test.go
+++ b/test/integration/authentication_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package integration
 
 import (

--- a/test/integration/authentication_test.go
+++ b/test/integration/authentication_test.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package integration
 
 import (

--- a/test/integration/authentication_test.go
+++ b/test/integration/authentication_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package integration
 
 import (

--- a/test/integration/kubectl.go
+++ b/test/integration/kubectl.go
@@ -1,3 +1,7 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+
 package integration
 
 import (

--- a/test/integration/kubectl.go
+++ b/test/integration/kubectl.go
@@ -1,7 +1,3 @@
-// Copyright (c) Twingate Inc.
-// SPDX-License-Identifier: MPL-2.0
-//
-
 package integration
 
 import (

--- a/test/integration/kubectl.go
+++ b/test/integration/kubectl.go
@@ -1,3 +1,6 @@
+// Copyright (c) Twingate Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package integration
 
 import (


### PR DESCRIPTION
## Changes

Add `goheader` to golangci-lint with out license header
