### PR TITLE
chore: Upgrade `golangci-lint` to v2.2.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8
       with:
-        version: v2.1
+        version: v2.2
         only-new-issues: true
 
   test-helm:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - testpackage
     - varnamelen
     - wrapcheck
+    - noinlineerr
   exclusions:
     presets:
       - comments

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,6 +65,9 @@ linters:
             - allowRegex: "^_"
         - name: unused-receiver
           disabled: true
+        - name: unhandled-error
+          arguments:
+            - "bytes.Buffer.Write"
 
 formatters:
   enable:

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -84,6 +84,7 @@ func start(newProxy ProxyFactory) error {
 	}
 
 	metricsPort := viper.GetInt("metricsPort")
+
 	go func() {
 		logger.Infof("Starting metrics server on: %v", metricsPort)
 

--- a/internal/httpproxy/audit_middleware.go
+++ b/internal/httpproxy/audit_middleware.go
@@ -20,6 +20,7 @@ var (
 
 type responseWriter struct {
 	http.ResponseWriter
+
 	headerWritten bool
 	statusCode    int
 	headers       http.Header

--- a/internal/httpproxy/audit_middleware_test.go
+++ b/internal/httpproxy/audit_middleware_test.go
@@ -136,6 +136,7 @@ func TestAuditMiddleware(t *testing.T) {
 					// Recover if handler panics
 					_ = recover()
 				}()
+
 				auditMiddleware(config{
 					next:   mockHandler.serveHTTP,
 					logger: logger,

--- a/internal/httpproxy/http_proxy.go
+++ b/internal/httpproxy/http_proxy.go
@@ -67,6 +67,7 @@ type Config struct {
 // upgrades: with downstream proxy and then with downstream client e.g. `kubectl`.
 type ProxyConn struct {
 	net.Conn
+
 	TLSConfig        *tls.Config
 	ConnectValidator connect.Validator
 	logger           *zap.Logger
@@ -233,6 +234,7 @@ func ExportKeyingMaterial(conn *tls.Conn) ([]byte, error) {
 
 type proxyListener struct {
 	net.Listener
+
 	TLSConfig        *tls.Config
 	ConnectValidator connect.Validator
 	logger           *zap.Logger
@@ -267,7 +269,7 @@ func NewProxy(cfg Config) (*Proxy, error) {
 	logger := zap.S()
 
 	if cfg.ConnectValidator == nil {
-		logger.Fatalf("connect validator is nil")
+		logger.Fatal("connect validator is nil")
 	}
 
 	// create TLS configuration for downstream
@@ -292,7 +294,7 @@ func NewProxy(cfg Config) (*Proxy, error) {
 
 	caCertPool := x509.NewCertPool()
 	if ok := caCertPool.AppendCertsFromPEM(caCert); !ok {
-		logger.Fatalf("failed to append K8sAPIServerCA cert to pool")
+		logger.Fatal("failed to append K8sAPIServerCA cert to pool")
 	}
 
 	logger.Infof("loaded upstream K8sAPIServerCA cert")

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -203,7 +203,8 @@ func TestProxyConn_Read_BadRequest(t *testing.T) {
 		}
 
 		// send a malformed request
-		fmt.Fprint(proxyTLSConn, "invalid-request\r\n\r\n")
+		_, err = fmt.Fprint(proxyTLSConn, "invalid-request\r\n\r\n")
+		assert.NoError(t, err)
 
 		resp, err := bufio.NewReader(proxyTLSConn).ReadString('\n')
 		assert.NoError(t, err)
@@ -266,7 +267,8 @@ func TestProxyConn_Read_HealthCheck(t *testing.T) {
 		}
 
 		// send a healthcheck request
-		fmt.Fprint(proxyTLSConn, "GET /healthz HTTP/1.1\r\n\r\n")
+		_, err = fmt.Fprint(proxyTLSConn, "GET /healthz HTTP/1.1\r\n\r\n")
+		assert.NoError(t, err)
 
 		buf := bufio.NewReader(proxyTLSConn)
 		resp, err := buf.ReadString('\n')
@@ -342,8 +344,9 @@ func TestProxyConn_Read_ValidConnectRequest(t *testing.T) {
 		}
 
 		// send a valid CONNECT request
-		fmt.Fprintf(proxyTLSConn, "CONNECT example.com:443 HTTP/1.1\r\n%s: gat_token\r\n%s: auth_sig\r\n%s: conn-id-1\r\n\r\n",
+		_, err = fmt.Fprintf(proxyTLSConn, "CONNECT example.com:443 HTTP/1.1\r\n%s: gat_token\r\n%s: auth_sig\r\n%s: conn-id-1\r\n\r\n",
 			connect.AuthHeaderKey, connect.AuthSignatureHeaderKey, connect.ConnIDHeaderKey)
+		assert.NoError(t, err)
 
 		// expect 200 Connection Established back
 		resp, err := bufio.NewReader(proxyTLSConn).ReadString('\n')
@@ -429,8 +432,9 @@ func TestProxyConn_Read_FailedValidation(t *testing.T) {
 			return
 		}
 
-		fmt.Fprintf(proxyTLSConn, "CONNECT example.com:443 HTTP/1.1\r\n%s: bad_token\r\n%s: auth_sig\r\n%s: conn-id-1\r\n\r\n",
+		_, err = fmt.Fprintf(proxyTLSConn, "CONNECT example.com:443 HTTP/1.1\r\n%s: bad_token\r\n%s: auth_sig\r\n%s: conn-id-1\r\n\r\n",
 			connect.AuthHeaderKey, connect.AuthSignatureHeaderKey, connect.ConnIDHeaderKey)
+		assert.NoError(t, err)
 
 		resp, err := bufio.NewReader(proxyTLSConn).ReadString('\n')
 		assert.NoError(t, err)

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -29,6 +29,7 @@ import (
 
 type mockConn struct {
 	net.Conn
+
 	isClosed atomic.Bool
 }
 
@@ -184,10 +185,12 @@ func TestProxyConn_Read_BadRequest(t *testing.T) {
 	}
 
 	done := make(chan struct{})
+
 	go func() {
 		// open TCP connection
 		conn, err := net.Dial("tcp", addr)
 		assert.NoError(t, err)
+
 		defer conn.Close()
 
 		// establish TLS (as downstream proxy)
@@ -199,7 +202,7 @@ func TestProxyConn_Read_BadRequest(t *testing.T) {
 		}
 
 		// send a malformed request
-		fmt.Fprintf(proxyTLSConn, "invalid-request\r\n\r\n")
+		fmt.Fprint(proxyTLSConn, "invalid-request\r\n\r\n")
 
 		resp, err := bufio.NewReader(proxyTLSConn).ReadString('\n')
 		assert.NoError(t, err)
@@ -245,10 +248,12 @@ func TestProxyConn_Read_HealthCheck(t *testing.T) {
 	}
 
 	done := make(chan struct{})
+
 	go func() {
 		// open TCP connection
 		conn, err := net.Dial("tcp", addr)
 		assert.NoError(t, err)
+
 		defer conn.Close()
 
 		// establish TLS (as downstream proxy)
@@ -260,7 +265,7 @@ func TestProxyConn_Read_HealthCheck(t *testing.T) {
 		}
 
 		// send a healthcheck request
-		fmt.Fprintf(proxyTLSConn, "GET /healthz HTTP/1.1\r\n\r\n")
+		fmt.Fprint(proxyTLSConn, "GET /healthz HTTP/1.1\r\n\r\n")
 
 		buf := bufio.NewReader(proxyTLSConn)
 		resp, err := buf.ReadString('\n')
@@ -319,10 +324,12 @@ func TestProxyConn_Read_ValidConnectRequest(t *testing.T) {
 	}
 
 	done := make(chan struct{})
+
 	go func() {
 		// open TCP connection
 		conn, err := net.Dial("tcp", addr)
 		assert.NoError(t, err)
+
 		defer conn.Close()
 
 		// establish TLS (as downstream proxy)
@@ -405,10 +412,12 @@ func TestProxyConn_Read_FailedValidation(t *testing.T) {
 	}
 
 	done := make(chan struct{})
+
 	go func() {
 		// open TCP connection
 		conn, err := net.Dial("tcp", addr)
 		assert.NoError(t, err)
+
 		defer conn.Close()
 
 		// establish TLS (as downstream proxy)
@@ -485,9 +494,11 @@ func TestProxy_ForwardRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	ready := make(chan struct{})
+
 	go func() {
 		proxy.Start(ready)
 	}()
+
 	<-ready
 
 	// downstream proxy and client certs
@@ -504,6 +515,7 @@ func TestProxy_ForwardRequest(t *testing.T) {
 	// HTTPS CONNECT (downstream proxy) then HTTPS requests (client)
 	conn, err := net.Dial("tcp", "127.0.0.1:45678")
 	require.NoError(t, err, "Failed to connect to proxy")
+
 	defer conn.Close()
 
 	// perform Proxy TLS handshake
@@ -524,6 +536,7 @@ func TestProxy_ForwardRequest(t *testing.T) {
 	// read response
 	connectResp, err := http.ReadResponse(bufio.NewReader(proxyTLSConn), connectReq)
 	require.NoError(t, err, "Failed to read CONNECT response")
+
 	defer connectResp.Body.Close()
 
 	// check 200 response
@@ -549,6 +562,7 @@ func TestProxy_ForwardRequest(t *testing.T) {
 	// send request
 	getResp, err := client.Do(getReq)
 	require.NoError(t, err, "Failed to send request")
+
 	defer getResp.Body.Close()
 
 	// check 200 response

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -41,6 +41,7 @@ func InitializeLogger(name string, debug bool) {
 		defer func() {
 			err = logger.Sync()
 		}()
+
 		undoGlobals()
 		undoStd()
 	}

--- a/internal/metrics/http_middleware_test.go
+++ b/internal/metrics/http_middleware_test.go
@@ -112,6 +112,7 @@ func TestHTTPMiddleware(t *testing.T) {
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err, "failed to send request")
+
 			defer resp.Body.Close()
 
 			metricFamilies, err := testRegistry.Gather()

--- a/internal/token/gat_claims_test.go
+++ b/internal/token/gat_claims_test.go
@@ -164,6 +164,7 @@ func TestPublicKey_UnmarshalJSON(t *testing.T) {
 		jsonBytes := []byte("\"LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFelBCVWRDUVRDTC85eWhPUzI3S1AyWTN1cjR5aApYd1N6enhZOGJhT3hESlIyVHYzL3pMOW1JWExZSld0NzlHeE5hL0h2MWFJRi9SS2hZdHRPc0JvaUZnPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg==\"")
 
 		var publicKey PublicKey
+
 		err := publicKey.UnmarshalJSON(jsonBytes)
 		require.NoError(t, err)
 
@@ -214,6 +215,7 @@ func TestPublicKey_UnmarshalJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var publicKey PublicKey
+
 			err := publicKey.UnmarshalJSON(tt.json)
 
 			require.ErrorIs(t, err, tt.expectedError)

--- a/internal/wsproxy/conn.go
+++ b/internal/wsproxy/conn.go
@@ -273,10 +273,10 @@ func (c *conn) Write(data []byte) (int, error) {
 
 func (c *conn) Close() error {
 	c.readMutex.Lock()
+	defer c.readMutex.Unlock()
 
 	c.writeMutex.Lock()
 	defer c.writeMutex.Unlock()
-	defer c.readMutex.Unlock()
 
 	c.recorder.Stop() // stop recording
 

--- a/internal/wsproxy/conn.go
+++ b/internal/wsproxy/conn.go
@@ -36,6 +36,7 @@ func NewConn(c net.Conn, recorder Recorder, asciinemaHeader asciinemaHeader, ses
 // creating an asciinema recording of a kubernetes ssh session.
 type conn struct {
 	net.Conn
+
 	recorder        Recorder        // asciinema recording
 	asciinemaHeader asciinemaHeader // header for the asciinema recording
 
@@ -72,7 +73,6 @@ func (c *conn) Read(data []byte) (int, error) {
 	defer c.readMutex.Unlock()
 
 	bytesRead, readErr := c.Conn.Read(data)
-
 	if readErr != nil {
 		// since this connection can be a hijacked connection from the HTTP server
 		// we could be dealing with a tls.Conn or some other wrapper around net.Conn, which
@@ -273,9 +273,11 @@ func (c *conn) Write(data []byte) (int, error) {
 
 func (c *conn) Close() error {
 	c.readMutex.Lock()
+
 	c.writeMutex.Lock()
 	defer c.writeMutex.Unlock()
 	defer c.readMutex.Unlock()
+
 	c.recorder.Stop() // stop recording
 
 	return c.Conn.Close()

--- a/internal/wsproxy/hijacker.go
+++ b/internal/wsproxy/hijacker.go
@@ -22,6 +22,7 @@ type ConnFactory func(net.Conn, Recorder, asciinemaHeader, bool) net.Conn
 
 type WsHijacker struct {
 	http.ResponseWriter
+
 	request     *http.Request
 	user        string
 	newRecorder RecorderFactory

--- a/internal/wsproxy/hijacker_test.go
+++ b/internal/wsproxy/hijacker_test.go
@@ -21,6 +21,7 @@ import (
 
 type mockHijackerResponseWriter struct {
 	httptest.ResponseRecorder
+
 	conn net.Conn
 	rw   *bufio.ReadWriter
 	err  error
@@ -32,6 +33,7 @@ func (m *mockHijackerResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, erro
 
 type mockHijackerConn struct {
 	net.Conn
+
 	writeData []byte
 }
 

--- a/internal/wsproxy/recorder.go
+++ b/internal/wsproxy/recorder.go
@@ -109,6 +109,7 @@ func NewRecorder(logger *zap.Logger, opts ...RecorderOption) *AsciinemaRecorder 
 	}
 
 	r.flushWg.Add(1)
+
 	go r.flushLoop()
 
 	return r
@@ -171,6 +172,7 @@ func (r *AsciinemaRecorder) IsHeaderWritten() bool {
 
 func (r *AsciinemaRecorder) Stop() {
 	r.mu.Lock()
+
 	if r.stopped {
 		r.mu.Unlock()
 

--- a/internal/wsproxy/recorder_test.go
+++ b/internal/wsproxy/recorder_test.go
@@ -29,6 +29,7 @@ func TestRecorder_WriteOutputEvent(t *testing.T) {
 	assert.Len(t, r.recordedLines, 1, "Recorder should have one event")
 
 	var event []any
+
 	err = json.Unmarshal([]byte(r.recordedLines[0]), &event)
 	require.NoError(t, err, "Event should be valid JSON")
 	require.Len(t, event, 3, "Event should have three elements")
@@ -53,6 +54,7 @@ func TestRecorder_WriteResizeEvent(t *testing.T) {
 	assert.Len(t, r.recordedLines, 1, "Recorder should have one event")
 
 	var event []any
+
 	err = json.Unmarshal([]byte(r.recordedLines[0]), &event)
 	require.NoError(t, err, "Event should be valid JSON")
 	require.Len(t, event, 3, "Event should have three elements")
@@ -90,6 +92,7 @@ func TestRecorder_WriteHeader(t *testing.T) {
 	require.NoError(t, err, "WriteHeader should not return an error")
 
 	var recordedHeader asciinemaHeader
+
 	err = json.Unmarshal([]byte(r.header), &recordedHeader)
 	require.NoError(t, err, "Header should be valid JSON")
 	assert.Equal(t, header, recordedHeader)
@@ -114,12 +117,14 @@ func TestRecorder_MultipleEvents(t *testing.T) {
 
 	// Validate header
 	var recordedHeader asciinemaHeader
+
 	err := json.Unmarshal([]byte(r.header), &recordedHeader)
 	require.NoError(t, err)
 	assert.Equal(t, header.Version, recordedHeader.Version)
 
 	// Validate second output event
 	var lastEvent []any
+
 	err = json.Unmarshal([]byte(r.recordedLines[2]), &lastEvent)
 	require.NoError(t, err)
 	assert.Equal(t, "o", lastEvent[1])

--- a/test/fake/client.go
+++ b/test/fake/client.go
@@ -109,6 +109,7 @@ func (c *Client) serve(ctx context.Context) {
 		}
 
 		c.wg.Add(1)
+
 		go c.handleConnection(ctx, clientConn, gat)
 	}
 }

--- a/test/fake/client.go
+++ b/test/fake/client.go
@@ -83,7 +83,11 @@ func NewClient(user *token.User, proxyAddress, controllerURL, apiServerURL strin
 // connection is not properly closed.
 func (c *Client) Close() {
 	c.cancel()
-	c.Listener.Close()
+
+	if err := c.Listener.Close(); err != nil {
+		c.logger.Error("Failed to close listener", zap.Error(err))
+	}
+
 	c.wg.Wait()
 }
 

--- a/test/integration/authentication_test.go
+++ b/test/integration/authentication_test.go
@@ -53,6 +53,7 @@ func TestKubernetesAuthentication(t *testing.T) {
 	// Start the Controller
 	controller := fake.NewController(network)
 	defer controller.Close()
+
 	t.Log("Controller is serving at", controller.URL)
 
 	// Start the Gateway
@@ -337,6 +338,7 @@ func assertWhoAmI(t *testing.T, output []byte, expectedUsername string, expected
 	t.Helper()
 
 	var whoami authv1.SelfSubjectReview
+
 	err := json.Unmarshal(output, &whoami)
 
 	require.NoError(t, err, "failed to parse kubectl auth whoami output")

--- a/test/integration/authentication_test.go
+++ b/test/integration/authentication_test.go
@@ -318,14 +318,16 @@ func gatewayHealthCheck(t *testing.T) {
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		resp, err := client.Get(gatewayURL)
 		if err == nil && resp.StatusCode == http.StatusOK {
-			resp.Body.Close()
+			err := resp.Body.Close()
+			require.NoError(t, err)
 			t.Log("Gateway is ready at", "127.0.0.1:8443")
 
 			break
 		}
 
 		if resp != nil {
-			resp.Body.Close()
+			err := resp.Body.Close()
+			require.NoError(t, err)
 		}
 
 		require.NotEqual(t, maxAttempts, attempt, "Gateway failed to start after %d attempts", maxAttempts)


### PR DESCRIPTION
## Changes
- `golangci-lint@v2.2` added [`noinlineerr`](https://github.com/AlwxSin/noinlineerr), [`embeddedstructfieldcheck`](https://github.com/manuelarte/embeddedstructfieldcheck) and [`wsl_v5`](https://github.com/bombsimon/wsl) (see full [changelog](https://golangci-lint.run/product/changelog/#v220)), which causes `make lint` to fail locally. We did not see it in our CI because it is still using `golangci-lint@v2.1`.
- Fix `wsl_v5` lint error
- Fix `embeddedstructfieldcheck` lint error
- Disable `noinlineerr` to allow inline errors
- Fix `revive`'s `unhandled-error` rule lint error and ignore the rule for `bytes.Buffer.Write` function