### PR TITLE
feat: Extend service and deployment templates in Helm Chart

### DIFF
--- a/deploy/gateway/templates/deployment.yaml
+++ b/deploy/gateway/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
               value: {{ .Values.containerPorts.https | quote }}
             - name: TWINGATE_METRICSPORT
               value: {{ .Values.containerPorts.metrics | quote }}
+            {{- with .Values.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: https
               containerPort: {{ .Values.containerPorts.https }}

--- a/deploy/gateway/templates/service.yaml
+++ b/deploy/gateway/templates/service.yaml
@@ -23,5 +23,8 @@ spec:
       port: 443
       targetPort: https
       protocol: TCP
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "gateway.selectorLabels" . | nindent 4 }}

--- a/deploy/gateway/tests/deployment_test.yaml
+++ b/deploy/gateway/tests/deployment_test.yaml
@@ -52,3 +52,14 @@ tests:
           value:
             # sha256 hash of "[]-[my-cluster.int]-" (a custom DNS name is provided)
             checksum/tlsAlternativeNames: fd97b5b8e975253c40e6a8e5702abb9394e3b181d3b47873558d64fdaf8346fa
+  - it: should add extra environment variables
+    set:
+      extraEnvVars:
+        - name: FOO
+          value: "bar"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FOO
+            value: "bar"

--- a/deploy/gateway/tests/service_test.yaml
+++ b/deploy/gateway/tests/service_test.yaml
@@ -37,7 +37,24 @@ tests:
   - it: should not allow other Service type
     set:
       service:
-        type: NodePort
+        type: ExternalName
     asserts:
       - failedTemplate:
-          errorPattern: 'service.type must be one of the following: "ClusterIP", "LoadBalancer"'
+          errorPattern: 'service.type must be one of the following: "ClusterIP", "NodePort", "LoadBalancer"'
+  - it: should support NodePort type with custom nodePort
+    set:
+      service:
+        type: NodePort
+        nodePort: 30000
+    asserts:
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30000
+  - it: should ignore nodePort for ClusterIP type
+    set:
+      service:
+        type: ClusterIP
+        nodePort: 30000
+    asserts:
+      - isNull:
+          path: spec.ports[0].nodePort

--- a/deploy/gateway/values.schema.json
+++ b/deploy/gateway/values.schema.json
@@ -87,7 +87,7 @@
       "required": ["type"],
       "properties": {
         "type": {
-          "enum": ["ClusterIP", "LoadBalancer"],
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"],
           "default": "ClusterIP"
         }
       }

--- a/deploy/gateway/values.yaml
+++ b/deploy/gateway/values.yaml
@@ -82,6 +82,13 @@ tolerations: []
 
 affinity: {}
 
+# Extra environment variables to add to the container.
+#
+# extraEnvVars:
+#   - name: FOO
+#     value: "bar"
+extraEnvVars: []
+
 
 # TLS configuration for the Gateway
 tls:


### PR DESCRIPTION
## Changes

- Support `NodePort` service type
- Support `extraEnvVars` in the deployment template