### PR TITLE
fix: Remove exclusion presets that disable some gosec rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,14 +27,11 @@ linters:
   exclusions:
     presets:
       - comments
-      - common-false-positives
-      - legacy
       - std-error-handling
     rules:
       - path: '_test\.go'
         linters:
           - err113
-          - gosec
   settings:
     goheader:
       template: |-

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -161,6 +161,7 @@ func TestProxyConn_Read_BadRequest(t *testing.T) {
 
 	proxyTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
+		MinVersion:   tls.VersionTLS13,
 	}
 
 	// mock CONNECT validator
@@ -183,6 +184,7 @@ func TestProxyConn_Read_BadRequest(t *testing.T) {
 	clientTLSConfig := &tls.Config{
 		ServerName: "127.0.0.1",
 		RootCAs:    caCertPool,
+		MinVersion: tls.VersionTLS13,
 	}
 
 	done := make(chan struct{})
@@ -232,6 +234,7 @@ func TestProxyConn_Read_HealthCheck(t *testing.T) {
 
 	proxyTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
+		MinVersion:   tls.VersionTLS13,
 	}
 
 	listener = &proxyListener{
@@ -247,6 +250,7 @@ func TestProxyConn_Read_HealthCheck(t *testing.T) {
 	clientTLSConfig := &tls.Config{
 		ServerName: "127.0.0.1",
 		RootCAs:    caCertPool,
+		MinVersion: tls.VersionTLS13,
 	}
 
 	done := make(chan struct{})
@@ -302,6 +306,7 @@ func TestProxyConn_Read_ValidConnectRequest(t *testing.T) {
 
 	proxyTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{proxyCert},
+		MinVersion:   tls.VersionTLS13,
 	}
 
 	// mock CONNECT validator
@@ -324,6 +329,7 @@ func TestProxyConn_Read_ValidConnectRequest(t *testing.T) {
 	clientTLSConfig := &tls.Config{
 		ServerName: "127.0.0.1",
 		RootCAs:    caCertPool,
+		MinVersion: tls.VersionTLS13,
 	}
 
 	done := make(chan struct{})
@@ -391,6 +397,7 @@ func TestProxyConn_Read_FailedValidation(t *testing.T) {
 
 	proxyTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
+		MinVersion:   tls.VersionTLS13,
 	}
 
 	// mock CONNECT validator
@@ -413,6 +420,7 @@ func TestProxyConn_Read_FailedValidation(t *testing.T) {
 	clientTLSConfig := &tls.Config{
 		ServerName: "127.0.0.1",
 		RootCAs:    caCertPool,
+		MinVersion: tls.VersionTLS13,
 	}
 
 	done := make(chan struct{})
@@ -472,6 +480,7 @@ func TestProxy_ForwardRequest(t *testing.T) {
 
 	apiServerTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
+		MinVersion:   tls.VersionTLS13,
 	}
 	apiServer.TLS = apiServerTLSConfig
 
@@ -515,6 +524,7 @@ func TestProxy_ForwardRequest(t *testing.T) {
 	tlsConfig := &tls.Config{
 		ServerName: "127.0.0.1",
 		RootCAs:    caCertPool,
+		MinVersion: tls.VersionTLS13,
 	}
 
 	// manually create a TCP connection to be able to reuse for

--- a/test/fake/eckey.go
+++ b/test/fake/eckey.go
@@ -8,9 +8,12 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"os"
+	"path/filepath"
 )
 
 func ReadECKey(filename string) (*ecdsa.PrivateKey, error) {
+	filename = filepath.Clean(filename)
+
 	privateKeyBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err

--- a/test/integration/testutil/gateway.go
+++ b/test/integration/testutil/gateway.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func GatewayHealthCheck(t *testing.T, port int) {
@@ -32,14 +34,17 @@ func GatewayHealthCheck(t *testing.T, port int) {
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		resp, err := client.Get(gatewayURL)
 		if err == nil && resp.StatusCode == http.StatusOK {
-			resp.Body.Close()
+			err := resp.Body.Close()
+			require.NoError(t, err)
+
 			t.Log("Gateway is ready at", gatewayURL)
 
 			break
 		}
 
 		if resp != nil {
-			resp.Body.Close()
+			err := resp.Body.Close()
+			require.NoError(t, err)
 		}
 
 		if attempt == maxAttempts {


### PR DESCRIPTION
## Changes

Remove golangci-lint's `legacy` and `common-false-positives` exclusion presets ([doc](https://golangci-lint.run/usage/false-positives/)) because they disable some gosec rules.
