### PR TITLE
test: Use `assert.Contains` correctly

### DIFF
--- a/test/integration/concurrent_users_test.go
+++ b/test/integration/concurrent_users_test.go
@@ -172,7 +172,7 @@ func TestConcurrentUsers(t *testing.T) {
 						t.Helper()
 						// `kubectl exec` has sporadic warning message "Unknown stream id 1, discarding message", especially when
 						// there are multiple concurrent streams so we can't `assert.Equal` here.
-						assert.Contains(t, "test-pod\n", string(output))
+						assert.Contains(t, string(output), "test-pod\n")
 					},
 					assertLogFn: func(t *testing.T, logs *observer.ObservedLogs) {
 						t.Helper()


### PR DESCRIPTION
## Changes

https://github.com/Twingate/kubernetes-access-gateway/pull/61 didn't fix the flaky test because the ordering in the `assert.Contains` wasn't used correctly