### PR TITLE
fix: Make `device` claim optional in GAT

### DIFF
--- a/internal/token/gat_claims.go
+++ b/internal/token/gat_claims.go
@@ -41,7 +41,6 @@ func (p GATClaims) Validate() error {
 		{p.ClientPublicKey == (PublicKey{}), "cpk"},
 		{p.User.ID == "", "user.id"},
 		{p.User.Username == "", "user.username"},
-		{p.Device.ID == "", "device.id"},
 		{p.Resource.ID == "", "resource.id"},
 		{p.Resource.Address == "", "resource.address"},
 	}

--- a/internal/token/gat_claims_test.go
+++ b/internal/token/gat_claims_test.go
@@ -88,14 +88,6 @@ func TestGATTokenClaims_Validate(t *testing.T) {
 			expectedErrorMessage: "\"user.username\"",
 		},
 		{
-			name: "Missing device ID",
-			setupFn: func(claims *GATClaims) {
-				claims.Device.ID = ""
-			},
-			expectedError:        jwt.ErrTokenRequiredClaimMissing,
-			expectedErrorMessage: "\"device.id\"",
-		},
-		{
 			name: "Missing resource ID",
 			setupFn: func(claims *GATClaims) {
 				claims.Resource.ID = ""


### PR DESCRIPTION
## Changes

Make GAT's `device` claim optional