### PR TITLE
fix: Remove fakeControllerURL env var

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   GOLANG_VERSION: 1.24.5
+  CADDY_VERSION: 2.10.0
 
 permissions:
   contents: read
@@ -78,7 +79,7 @@ jobs:
         uses: docker/setup-docker-action@v4
       - name: Install Caddy
         run: |
-          curl -fsSL https://github.com/caddyserver/caddy/releases/download/v2.10.0/caddy_2.10.0_linux_amd64.tar.gz | tar -xzv
+          curl -fsSL https://github.com/caddyserver/caddy/releases/download/v${{ env.CADDY_VERSION }}/caddy_${{ env.CADDY_VERSION }}_linux_amd64.tar.gz | tar -xzv
           sudo mv caddy /usr/local/bin/
           caddy version
       - name: Run Caddy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,10 +84,10 @@ jobs:
           caddy version
       - name: Run Caddy
         run: |
-          sudo caddy run &
-      - name: Map acme.localhost to 127.0.0.1
+          sudo caddy start
+      - name: Map acme.test to 127.0.0.1
         run: |
-          echo "127.0.0.1 acme.localhost" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 acme.test" | sudo tee -a /etc/hosts
       - name: Run Integration Tests
         run: make test-integration-with-coverage
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,11 +73,24 @@ jobs:
       - name: Run Tests
         run: make test-with-coverage
 
+      # Integration tests
       - name: Setup Docker
         uses: docker/setup-docker-action@v4
+      - name: Install Caddy
+        run: |
+          curl -fsSL https://github.com/caddyserver/caddy/releases/download/v2.10.0/caddy_2.10.0_linux_amd64.tar.gz | tar -xzv
+          sudo mv caddy /usr/local/bin/
+          caddy version
+      - name: Run Caddy
+        run: |
+          sudo caddy run &
+      - name: Map acme.localhost to 127.0.0.1
+        run: |
+          echo "127.0.0.1 acme.localhost" | sudo tee -a /etc/hosts
       - name: Run Integration Tests
         run: make test-integration-with-coverage
 
+      # Combined code coverage
       - name: Send coverage to Coveralls
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}

--- a/Caddyfile
+++ b/Caddyfile
@@ -2,6 +2,7 @@
   debug
 }
 
-acme.localhost {
+acme.test {
+    tls internal
     reverse_proxy localhost:8080
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,7 @@
+{
+  debug
+}
+
+acme.localhost {
+    reverse_proxy localhost:8080
+}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Twingate Kubernetes Access enables secure, zero-trust access to your Kubernetes 
 ### Integration testing
 
 - Integration tests are located in `test/integration` directory. The test would setup [a KinD cluster](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) and use [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) CLI to run the tests. Make sure you have Docker runtime so that the KinD cluster can be created automatically.
+- Install [Caddy](https://caddyserver.com/docs/install) to run a local reverse proxy. Run `sudo caddy run` to start the server.
+- In `/etc/hosts`, add the following line: `127.0.0.1 acme.localhost`.
 - Run `make test-integration` to run integration tests.
 
 ### Helm testing

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Twingate Kubernetes Access enables secure, zero-trust access to your Kubernetes 
 
 - Integration tests are located in `test/integration` directory. The test would setup [a KinD cluster](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) and use [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) CLI to run the tests. Make sure you have Docker runtime so that the KinD cluster can be created automatically.
 - Install [Caddy](https://caddyserver.com/docs/install) to run a local reverse proxy. Run `sudo caddy run` to start the server.
-- In `/etc/hosts`, add the following line: `127.0.0.1 acme.localhost`.
+- In `/etc/hosts`, add the following line: `127.0.0.1 acme.test`.
 - Run `make test-integration` to run integration tests.
 
 ### Helm testing

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -53,7 +53,6 @@ func start(newProxy ProxyFactory) error {
 	parser, err := token.NewParser(token.ParserConfig{
 		Network: network,
 		Host:    viper.GetString("host"),
-		URL:     viper.GetString("fakeControllerURL"),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create token parser %w", err)
@@ -140,7 +139,6 @@ func init() { //nolint:gochecknoinits
 
 	// Misc flags
 	flags.BoolP("debug", "d", false, "Run in debug mode")
-	flags.String("fakeControllerURL", "", "URL of fake Controller which issues and verifies GAT. Used for testing")
 
 	if err := viper.BindPFlags(flags); err != nil {
 		panic(fmt.Sprintf("failed to bind flags: %v", err))

--- a/internal/token/parser.go
+++ b/internal/token/parser.go
@@ -16,7 +16,7 @@ var errInvalidTokenType = errors.New("token type is invalid")
 var allowedSigningMethods = []string{jwt.SigningMethodES256.Alg()}
 
 var allowedIssuerByHost = map[string]string{
-	"localhost":     "twingate-local",
+	"test":          "twingate-local",
 	"dev.opstg.com": "twingate-dev",
 	"stg.opstg.com": "twingate-stg",
 	"twingate.com":  "twingate",

--- a/internal/token/parser.go
+++ b/internal/token/parser.go
@@ -16,7 +16,7 @@ var errInvalidTokenType = errors.New("token type is invalid")
 var allowedSigningMethods = []string{jwt.SigningMethodES256.Alg()}
 
 var allowedIssuerByHost = map[string]string{
-	"test.local":    "twingate-local",
+	"localhost":     "twingate-local",
 	"dev.opstg.com": "twingate-dev",
 	"stg.opstg.com": "twingate-stg",
 	"twingate.com":  "twingate",
@@ -31,8 +31,6 @@ type ParserConfig struct {
 	Network string
 	// Twingate service domain
 	Host string
-	// URL which issues JWKs to verify token. Default to `https://<Network>.<Host>`
-	URL string
 	// Keyfunc to verify token. Default to using remote JWKs
 	Keyfunc jwt.Keyfunc
 }
@@ -44,11 +42,7 @@ type Parser struct {
 
 func NewParser(config ParserConfig) (*Parser, error) {
 	if config.Keyfunc == nil {
-		if config.URL == "" {
-			config.URL = fmt.Sprintf("https://%s.%s", config.Network, config.Host)
-		}
-
-		jwkURL := config.URL + "/api/v1/jwk/ec"
+		jwkURL := fmt.Sprintf("https://%s.%s/api/v1/jwk/ec", config.Network, config.Host)
 
 		jwks, err := keyfunc.NewDefault([]string{jwkURL})
 		if err != nil {

--- a/test/fake/controller.go
+++ b/test/fake/controller.go
@@ -117,7 +117,7 @@ func NewController(network string, port int) *httptest.Server {
 		logger.Info("JWT generated")
 	})
 
-	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		logger.Error("Failed to listen on port", zap.Error(err))
 
@@ -127,7 +127,6 @@ func NewController(network string, port int) *httptest.Server {
 	server := httptest.NewUnstartedServer(mux)
 	server.Listener = listener
 	server.Start()
-	logger.Info("Controller started")
 
 	return server
 }

--- a/test/fake/controller.go
+++ b/test/fake/controller.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -33,7 +35,7 @@ type requestBody struct {
 // It has two endpoints:
 // - /api/v1/jwk/ec: Returns the JWK Set that is used to verify GAT tokens.
 // - /api/v1/gat: Returns a GAT token for a client.
-func NewController(network string) *httptest.Server {
+func NewController(network string, port int) *httptest.Server {
 	logger := zap.Must(zap.NewDevelopment()).Named("controller")
 
 	controllerKey, _ := ReadECKey("../data/controller/key.pem")
@@ -115,7 +117,19 @@ func NewController(network string) *httptest.Server {
 		logger.Info("JWT generated")
 	})
 
-	return httptest.NewServer(mux)
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		logger.Error("Failed to listen on port", zap.Error(err))
+
+		return nil
+	}
+
+	server := httptest.NewUnstartedServer(mux)
+	server.Listener = listener
+	server.Start()
+	logger.Info("Controller started")
+
+	return server
 }
 
 func createJWKSet(controllerKey *ecdsa.PrivateKey) (json.RawMessage, error) {

--- a/test/integration/concurrent_users_test.go
+++ b/test/integration/concurrent_users_test.go
@@ -53,7 +53,7 @@ func TestConcurrentUsers(t *testing.T) {
 			"--port",
 			strconv.Itoa(gatewayPort),
 			"--host",
-			"localhost",
+			"test",
 			"--network",
 			network,
 			"--tlsKey",

--- a/test/integration/concurrent_users_test.go
+++ b/test/integration/concurrent_users_test.go
@@ -40,7 +40,7 @@ func TestConcurrentUsers(t *testing.T) {
 	require.NoError(t, err, "failed to parse API server URL")
 
 	// Start the Controller
-	controller := fake.NewController(network)
+	controller := fake.NewController(network, 8080)
 	defer controller.Close()
 
 	t.Log("Controller is serving at", controller.URL)
@@ -53,7 +53,7 @@ func TestConcurrentUsers(t *testing.T) {
 			"--port",
 			strconv.Itoa(gatewayPort),
 			"--host",
-			"twingate.local",
+			"localhost",
 			"--network",
 			network,
 			"--tlsKey",
@@ -66,8 +66,6 @@ func TestConcurrentUsers(t *testing.T) {
 			"../data/api_server/tls.crt",
 			"--k8sAPIServerToken",
 			kindBearerToken,
-			"--fakeControllerURL",
-			controller.URL,
 			"--metricsPort",
 			"0",
 		})

--- a/test/integration/single_user_test.go
+++ b/test/integration/single_user_test.go
@@ -48,7 +48,7 @@ func TestSingleUser(t *testing.T) {
 			"--port",
 			strconv.Itoa(gatewayPort),
 			"--host",
-			"localhost",
+			"test",
 			"--network",
 			network,
 			"--tlsKey",

--- a/test/integration/single_user_test.go
+++ b/test/integration/single_user_test.go
@@ -35,7 +35,7 @@ func TestSingleUser(t *testing.T) {
 	require.NoError(t, err, "failed to parse API server URL")
 
 	// Start the Controller
-	controller := fake.NewController(network)
+	controller := fake.NewController(network, 8080)
 	defer controller.Close()
 
 	t.Log("Controller is serving at", controller.URL)
@@ -48,7 +48,7 @@ func TestSingleUser(t *testing.T) {
 			"--port",
 			strconv.Itoa(gatewayPort),
 			"--host",
-			"twingate.local",
+			"localhost",
 			"--network",
 			network,
 			"--tlsKey",
@@ -61,8 +61,6 @@ func TestSingleUser(t *testing.T) {
 			"../data/api_server/tls.crt",
 			"--k8sAPIServerToken",
 			kindBearerToken,
-			"--fakeControllerURL",
-			controller.URL,
 			"--metricsPort",
 			"0",
 		})


### PR DESCRIPTION
## Changes

- Remove `fakeControllerURL` environment variable. 
- Rework integration setup to wire Gateway to fake Controller server running locally.
  + Fake controller runs at `http://localhost:8080`
  + Gateway would talk to fake Controller at `https://acme.test`
  + Use [Caddy reverse proxy](https://caddyserver.com/docs/quick-starts/reverse-proxy) to route `https://acme.test` to `http://localhost:8080`. Caddy would handle TLS cert generation.
  + Add `127.0.0.1 acme.test` entry to `/etc/hosts`

## Notes

This setup has a limitation that Caddy expects fake Controller to run at port `8080` so only 1 fake Controller could run at any time. Hence, integration tests run sequentially.