### PR TITLE
fix: Use `ProxyConn.Close()` to close healthcheck TLS connection

### DIFF
--- a/internal/httpproxy/http_proxy.go
+++ b/internal/httpproxy/http_proxy.go
@@ -151,12 +151,8 @@ func (p *ProxyConn) authenticate() error {
 		if writeErr != nil {
 			p.logger.Error("failed to write response", zap.Error(writeErr))
 
-			_ = tlsConnectConn.Close()
-
 			return writeErr
 		}
-
-		_ = tlsConnectConn.Close()
 
 		return io.EOF
 	}


### PR DESCRIPTION
## Changes
This is a follow-up PR for https://github.com/Twingate/kubernetes-access-gateway/pull/45, we should let `ProxyConn.Close()` to handle closing the TLS connection instead of closing it manually