### PR TITLE
feat: Rename asciinema log fields

### DIFF
--- a/internal/wsproxy/recorder.go
+++ b/internal/wsproxy/recorder.go
@@ -292,8 +292,8 @@ func (r *AsciinemaRecorder) flush(isFinal bool) {
 
 	r.flushCount++
 	r.config.logger.Info(message,
-		zap.String("asciinema_data", strings.Join(append([]string{r.header}, r.recordedLines...), "\n")),
-		zap.Int("asciinema_sequence_num", r.flushCount),
+		zap.String("asciicast", strings.Join(append([]string{r.header}, r.recordedLines...), "\n")),
+		zap.Int("asciicast_sequence_num", r.flushCount),
 	)
 
 	r.recordedLines = r.recordedLines[:0]

--- a/internal/wsproxy/recorder_test.go
+++ b/internal/wsproxy/recorder_test.go
@@ -153,8 +153,8 @@ func TestRecorder_Stop(t *testing.T) {
 	assert.Equal(t, 1, logs.Len(), "Should have one log entry")
 	log := logs.All()[0]
 	assert.Equal(t, "session finished", log.Message)
-	assert.Contains(t, log.ContextMap()["asciinema_data"], "test")
-	assert.Equal(t, int64(1), log.ContextMap()["asciinema_sequence_num"])
+	assert.Contains(t, log.ContextMap()["asciicast"], "test")
+	assert.Equal(t, int64(1), log.ContextMap()["asciicast_sequence_num"])
 
 	// Check that the duration metric is recorded
 	metricFamilies, err := testRegistry.Gather()
@@ -195,8 +195,8 @@ func TestRecorder_PeriodicFlush(t *testing.T) {
 	assert.Equal(t, 1, logs.Len(), "Should have one log entry")
 	log := logs.TakeAll()[0]
 	assert.Equal(t, "session recording", log.Message)
-	assert.Contains(t, log.ContextMap()["asciinema_data"], "a")
-	assert.Equal(t, int64(1), log.ContextMap()["asciinema_sequence_num"])
+	assert.Contains(t, log.ContextMap()["asciicast"], "a")
+	assert.Equal(t, int64(1), log.ContextMap()["asciicast_sequence_num"])
 
 	// 2nd interval
 	// Advance time to trigger flush
@@ -223,8 +223,8 @@ func TestRecorder_PeriodicFlush(t *testing.T) {
 	assert.Equal(t, 1, logs.Len(), "Should have one log entry")
 	log = logs.TakeAll()[0]
 	assert.Equal(t, "session recording", log.Message)
-	assert.Contains(t, log.ContextMap()["asciinema_data"], "b")
-	assert.Equal(t, int64(2), log.ContextMap()["asciinema_sequence_num"])
+	assert.Contains(t, log.ContextMap()["asciicast"], "b")
+	assert.Equal(t, int64(2), log.ContextMap()["asciicast_sequence_num"])
 }
 
 func TestRecorderFlow(t *testing.T) {
@@ -322,7 +322,7 @@ func TestRecorder_WriteJSON_FlushLogsWhenExceedingSizeThreshold(t *testing.T) {
 
 	log := logs.TakeAll()[0]
 	assert.Equal(t, "session recording", log.Message)
-	assert.Equal(t, int64(1), log.ContextMap()["asciinema_sequence_num"])
+	assert.Equal(t, int64(1), log.ContextMap()["asciicast_sequence_num"])
 
 	_ = r.writeJSON([]any{0, "o", "c"}) // 11 bytes
 
@@ -338,7 +338,7 @@ func TestRecorder_WriteJSON_FlushLogsWhenExceedingSizeThreshold(t *testing.T) {
 
 	log = logs.TakeAll()[0]
 	assert.Equal(t, "session finished", log.Message)
-	assert.Equal(t, int64(2), log.ContextMap()["asciinema_sequence_num"])
+	assert.Equal(t, int64(2), log.ContextMap()["asciicast_sequence_num"])
 }
 
 func TestRecorder_WriteJSON_Error(t *testing.T) {

--- a/test/integration/testutil/assertions.go
+++ b/test/integration/testutil/assertions.go
@@ -65,7 +65,7 @@ func AssertLogsForExec(t *testing.T, logs *observer.ObservedLogs, expectedURL, e
 	firstLog := expectedLogs[0]
 	assert.Equal(t, "session finished", firstLog.Message)
 	assert.Equal(t, expectedUser, firstLog.ContextMap()["user"])
-	assert.Contains(t, firstLog.ContextMap()["asciinema_data"], expectedOutput)
+	assert.Contains(t, firstLog.ContextMap()["asciicast"], expectedOutput)
 
 	secondLog := expectedLogs[1]
 	assert.Equal(t, "API request completed", secondLog.Message)


### PR DESCRIPTION
## Changes

Rename log fields from `asciinema` to `asciicast` because [`asciicast`](https://docs.asciinema.org/manual/asciicast/v2/#asciicast-v2) is the name of the file format. Asciiname refers to the software suite around this `asciicast` format.