### PR TITLE
fix: Remove unused `env` asciicast header

### DIFF
--- a/internal/wsproxy/recorder.go
+++ b/internal/wsproxy/recorder.go
@@ -48,14 +48,13 @@ type k8sMetadata struct {
 }
 
 type asciinemaHeader struct {
-	Version     int               `json:"version"`
-	Width       int               `json:"width"`
-	Height      int               `json:"height"`
-	Timestamp   int64             `json:"timestamp"`
-	Command     string            `json:"command,omitempty"`
-	Env         map[string]string `json:"env"`
-	User        string            `json:"user"`
-	K8sMetadata *k8sMetadata      `json:"kubernetes,omitempty"`
+	Version     int          `json:"version"`
+	Width       int          `json:"width"`
+	Height      int          `json:"height"`
+	Timestamp   int64        `json:"timestamp"`
+	Command     string       `json:"command,omitempty"`
+	User        string       `json:"user"`
+	K8sMetadata *k8sMetadata `json:"kubernetes,omitempty"`
 }
 
 type Recorder interface {

--- a/internal/wsproxy/recorder_test.go
+++ b/internal/wsproxy/recorder_test.go
@@ -80,7 +80,6 @@ func TestRecorder_WriteHeader(t *testing.T) {
 		Height:    24,
 		Timestamp: time.Now().Unix(),
 		Command:   "/bin/bash",
-		Env:       map[string]string{"TERM": "xterm-256color"},
 		User:      "testuser",
 		K8sMetadata: &k8sMetadata{
 			PodName:   "test-pod",


### PR DESCRIPTION
## Changes
- Remove unused `env` asciicast header
