### PR TITLE
fix: Empty `namespace` and `podname` asciiheader in `kubectl attach` session recording

### DIFF
--- a/internal/httpproxy/http_proxy.go
+++ b/internal/httpproxy/http_proxy.go
@@ -390,6 +390,7 @@ func NewProxy(cfg Config) (*Proxy, error) {
 	})
 	mux.Handle("/", handler)
 	mux.Handle("GET /api/v1/namespaces/{namespace}/pods/{pod}/exec", handler)
+	mux.Handle("GET /api/v1/namespaces/{namespace}/pods/{pod}/attach", handler)
 
 	return p, nil
 }


### PR DESCRIPTION
## Changes 
- When running `kubectl attach <podname> -it`, the asciiheader for `namespace` and `podname` are empty because the `mux` handler does not match the `namespace` and `podname` pattern for `/attach` endpoint