### PR TITLE
feat: Set timeouts during CONNECT message for authentication

### DIFF
--- a/internal/httpproxy/http_proxy.go
+++ b/internal/httpproxy/http_proxy.go
@@ -124,12 +124,11 @@ func (p *ProxyConn) Close() error {
 
 // authenticate sets up TLS and processes the CONNECT message for authentication.
 func (p *ProxyConn) authenticate() error {
-	err := p.SetDeadline(time.Now().Add(defaultTimeout))
-	if err != nil {
-		p.logger.Error("failed to set deadline", zap.Error(err))
+	_ = p.SetDeadline(time.Now().Add(defaultTimeout))
 
-		return err
-	}
+	defer func() {
+		_ = p.SetDeadline(time.Time{})
+	}()
 
 	// Establish TLS connection with the downstream proxy
 	tlsConnectConn := tls.Server(p.Conn, p.TLSConfig)

--- a/internal/httpproxy/http_proxy.go
+++ b/internal/httpproxy/http_proxy.go
@@ -238,15 +238,6 @@ func (p *ProxyConn) authenticate() error {
 	p.Conn = tlsConn
 	p.setConnectInfo(connectInfo)
 	p.isAuthenticated = true
-
-	// Clear the timeouts for long-lived session
-	err = p.SetDeadline(time.Time{})
-	if err != nil {
-		p.logger.Error("failed to reset deadline", zap.Error(err))
-
-		return err
-	}
-
 	return nil
 }
 

--- a/internal/httpproxy/http_proxy.go
+++ b/internal/httpproxy/http_proxy.go
@@ -122,6 +122,9 @@ func (p *ProxyConn) Close() error {
 
 // authenticate sets up TLS and processes the CONNECT message for authentication.
 func (p *ProxyConn) authenticate() error {
+	p.Conn.SetDeadline(time.Now().Add(10 * time.Second))
+	defer p.Conn.SetDeadline(time.Time{})
+
 	// Establish TLS connection with the downstream proxy
 	tlsConnectConn := tls.Server(p.Conn, p.TLSConfig)
 


### PR DESCRIPTION
## Changes
- Set 10-second timeouts in the authentication path during HTTP CONNECT request