### PR TITLE
chore(ci): Split `build` job to `build` and `test-e2e`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,13 +138,55 @@ jobs:
         VERSION_PRERELEASE: dev
       run: make build
 
-    # Run e2e tests
+    - name: Save docker images
+      run: |
+        docker images --filter=reference='twingate/kubernetes-access-gateway:*' --format '{{.Repository}}:{{.Tag}}' | \
+        while read image; do
+          filename=$(echo "$image" | sed 's|/|_|g' | sed 's|:|_|g').tar
+          docker save "$image" -o ./dist/"$filename"
+        done
+
+    - name: Upload docker images
+      uses: actions/upload-artifact@v4
+      with:
+        name: docker-images
+        path: dist/*.tar
+
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    needs: [build]
+    env:
+      REGISTRY: ghcr.io/twingate
+      DOCKER_BUILDX_CACHE: --cache-to type=gha,mode=max --cache-from type=gha
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GOLANG_VERSION }}
+
+    - name: Setup Docker
+      uses: docker/setup-docker-action@v4
+
+    - name: Download docker images
+      uses: actions/download-artifact@v4
+      with:
+        name: docker-images
+
+    - name: Load docker images
+      run: |
+        for file in dist/*.tar; do
+          docker load -i "$file"
+        done
+
     - name: Install Caddy
       run: |
         curl -fsSL https://github.com/caddyserver/caddy/releases/download/v${{ env.CADDY_VERSION }}/caddy_${{ env.CADDY_VERSION }}_linux_amd64.tar.gz | tar -xzv
         sudo mv caddy /usr/local/bin/
         caddy version
+
     - name: Run Caddy
       run: sudo caddy start
+      
     - name: Run E2E Tests
       run: make test-e2e


### PR DESCRIPTION
## Changes
- Update `build` job to `make build` and store the built Docker images in [workflow artifacts](https://docs.github.com/en/actions/tutorials/store-and-share-data)
 - Add `test-e2e` job which depends on build job and run e2e test