### PR TITLE
feat: Support `kube-prometheus-stack` (formerly `prometheus-operator`) subchart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,6 +170,9 @@ jobs:
       run: |
         docker load -i kubernetes-access-gateway-images.tar
 
+    - name: Build helm dependencies
+      run: helm dependency build ./deploy/gateway
+
     - name: Install Caddy
       run: |
         curl -fsSL https://github.com/caddyserver/caddy/releases/download/v${{ env.CADDY_VERSION }}/caddy_${{ env.CADDY_VERSION }}_linux_amd64.tar.gz | tar -xzv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,8 @@ jobs:
           version: v3.17.3
       - name: Install helm-unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest
+      - name: Build helm dependencies
+        run: helm dependency build ./deploy/gateway
       - name: Run tests
         run: helm unittest deploy/gateway
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /deploy/gateway/values.local.yaml
+/deploy/gateway/charts
 
 # macOS filesystem metadata
 *.DS_Store

--- a/deploy/gateway/Chart.lock
+++ b/deploy/gateway/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: kube-prometheus-stack
   repository: oci://ghcr.io/prometheus-community/charts
   version: 75.15.1
-digest: sha256:2b7248b073143be405c4c686a40d349ab3c7224af3c4d30ba9c396eda6f8af2e
-generated: "2025-07-31T22:09:58.669759+08:00"
+digest: sha256:df638044a4413bdc334b508c92d1ab7a47b89f6ff67744887366586b9bb734d3
+generated: "2025-08-01T00:06:54.098251+08:00"

--- a/deploy/gateway/Chart.lock
+++ b/deploy/gateway/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kube-prometheus-stack
+  repository: oci://ghcr.io/prometheus-community/charts
+  version: 75.15.1
+digest: sha256:2b7248b073143be405c4c686a40d349ab3c7224af3c4d30ba9c396eda6f8af2e
+generated: "2025-07-31T22:09:58.669759+08:00"

--- a/deploy/gateway/Chart.yaml
+++ b/deploy/gateway/Chart.yaml
@@ -5,3 +5,9 @@ type: application
 version: 0.1.0
 appVersion: "0.1.0"
 home: https://twingate.com
+
+dependencies:
+  - name: kube-prometheus-stack
+    version: "75.15.1"
+    repository: oci://ghcr.io/prometheus-community/charts
+    condition: kube-prometheus-stack.enabled

--- a/deploy/gateway/tests/__snapshot__/kube-prometheus-stack_test.yaml.snap
+++ b/deploy/gateway/tests/__snapshot__/kube-prometheus-stack_test.yaml.snap
@@ -1,0 +1,82 @@
+should enable Kube Prometheus Stack:
+  1: |
+    apiVersion: monitoring.coreos.com/v1
+    kind: Prometheus
+    metadata:
+      labels:
+        app: kube-prometheus-stack-prometheus
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: kube-prometheus-stack
+        app.kubernetes.io/version: 1.0.0
+        chart: kube-prometheus-stack-1.0.0
+        heritage: Helm
+        release: RELEASE-NAME
+      name: RELEASE-NAME-kube-promethe-prometheus
+      namespace: NAMESPACE
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - prometheus
+                    - key: app.kubernetes.io/instance
+                      operator: In
+                      values:
+                        - RELEASE-NAME-kube-promethe-prometheus
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      alerting:
+        alertmanagers:
+          - apiVersion: v2
+            name: RELEASE-NAME-kube-promethe-alertmanager
+            namespace: NAMESPACE
+            pathPrefix: /
+            port: http-web
+      automountServiceAccountToken: true
+      enableAdminAPI: false
+      enableOTLPReceiver: false
+      externalUrl: http://RELEASE-NAME-kube-promethe-prometheus.NAMESPACE:9090
+      hostNetwork: false
+      image: quay.io/prometheus/prometheus:v3.5.0
+      imagePullPolicy: IfNotPresent
+      listenLocal: false
+      logFormat: logfmt
+      logLevel: info
+      paused: false
+      podMonitorNamespaceSelector: {}
+      podMonitorSelector: {}
+      portName: http-web
+      probeNamespaceSelector: {}
+      probeSelector:
+        matchLabels:
+          release: RELEASE-NAME
+      replicas: 1
+      retention: 10d
+      routePrefix: /
+      ruleNamespaceSelector: {}
+      ruleSelector: {}
+      scrapeConfigNamespaceSelector: {}
+      scrapeConfigSelector:
+        matchLabels:
+          release: RELEASE-NAME
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: RELEASE-NAME-kube-promethe-prometheus
+      serviceMonitorNamespaceSelector: {}
+      serviceMonitorSelector: {}
+      shards: 1
+      tsdb:
+        outOfOrderTimeWindow: 0s
+      version: v3.5.0
+      walCompression: true

--- a/deploy/gateway/tests/kube-prometheus-stack_test.yaml
+++ b/deploy/gateway/tests/kube-prometheus-stack_test.yaml
@@ -1,0 +1,15 @@
+suite: Kube Prometheus Stack
+templates:
+  - charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+tests:
+  - it: should enable Kube Prometheus Stack
+    # Hardcode the chart version and app version to ensure that the snapshot is stable
+    # when upgrading Kube Prometheus Stack subchart
+    chart:
+      version: 1.0.0
+      appVersion: 1.0.0
+    set:
+      kube-prometheus-stack:
+        enabled: true
+    asserts:
+      - matchSnapshot: {}

--- a/deploy/gateway/values.yaml
+++ b/deploy/gateway/values.yaml
@@ -193,3 +193,18 @@ metrics:
       #     severity: warning
       #   annotations:
       #     description: Twingate Gateway authentication failure rate is {{ $value | humanizePercentage }} over the last 2 minutes.
+
+# Kube Prometheus Stack (formerly Prometheus Operator) subchart configuration
+# For more information checkout: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack
+kube-prometheus-stack:
+  enabled: false
+  
+  # Prometheus configuration
+  prometheus:
+    prometheusSpec:
+      # Allow Prometheus to discover all PodMonitors, ServiceMonitors, and PrometheusRules within its namespace
+      # For more information checkout: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#prometheusioscrape
+      serviceMonitorSelectorNilUsesHelmValues: false
+      podMonitorSelectorNilUsesHelmValues: false
+      ruleSelectorNilUsesHelmValues: false
+    


### PR DESCRIPTION
## Changes
- Add [`kube-prometheus-stack`](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#kube-prometheus-stack) (formerly `prometheus-operator`) as Helm subchart
