### PR TITLE
fix: Join multiple `command` query parameters with `" "` in asciicast header

### DIFF
--- a/internal/wsproxy/hijacker.go
+++ b/internal/wsproxy/hijacker.go
@@ -60,7 +60,7 @@ func (h *WsHijacker) startRecording(conn net.Conn) net.Conn {
 	query := h.request.URL.Query()
 
 	tty := strings.Join(query["tty"], "")
-	command := strings.Join(query["command"], "")
+	command := strings.Join(query["command"], " ")
 	container := strings.Join(query["container"], "")
 
 	asciicastHeader := AsciicastHeader{

--- a/internal/wsproxy/hijacker_test.go
+++ b/internal/wsproxy/hijacker_test.go
@@ -173,7 +173,7 @@ func TestHijacker_AsciicastHeaderCreation(t *testing.T) {
 
 	mockConn := &mockHijackerConn{}
 
-	u, _ := url.Parse("/namespaces/default/pods/test-pod/exec?container=test-container&command=bash&tty=true")
+	u, _ := url.Parse("/namespaces/default/pods/test-pod/exec?container=test-container&command=cat&command=%2Fetc%2Fhostname&tty=true")
 	req := &http.Request{
 		URL: u,
 	}
@@ -195,7 +195,7 @@ func TestHijacker_AsciicastHeaderCreation(t *testing.T) {
 
 	assert.Equal(t, 2, capturedHeader.Version)
 	assert.Equal(t, "testuser", capturedHeader.User)
-	assert.Equal(t, "bash", capturedHeader.Command)
+	assert.Equal(t, "cat /etc/hostname", capturedHeader.Command)
 	assert.NotEmpty(t, capturedHeader.K8sMetadata)
 	assert.Equal(t, "test-pod", capturedHeader.K8sMetadata.PodName)
 	assert.Equal(t, "default", capturedHeader.K8sMetadata.Namespace)

--- a/test/integration/concurrent_users_test.go
+++ b/test/integration/concurrent_users_test.go
@@ -170,7 +170,7 @@ func TestConcurrentUsers(t *testing.T) {
 							Width:     0,
 							Height:    0,
 							Timestamp: 0,
-							Command:   "sleep2",
+							Command:   "sleep 2",
 							User:      user.Username,
 							K8sMetadata: &wsproxy.K8sMetadata{
 								PodName:   testutil.TestPodName,
@@ -205,7 +205,7 @@ func TestConcurrentUsers(t *testing.T) {
 							Width:     0,
 							Height:    0,
 							Timestamp: 0,
-							Command:   "cat/etc/hostname",
+							Command:   "cat /etc/hostname",
 							User:      user.Username,
 							K8sMetadata: &wsproxy.K8sMetadata{
 								PodName:   testutil.TestPodName,

--- a/test/integration/single_user_test.go
+++ b/test/integration/single_user_test.go
@@ -125,7 +125,7 @@ func TestSingleUser(t *testing.T) {
 		Width:     0,
 		Height:    0,
 		Timestamp: 0,
-		Command:   "cat/etc/hostname",
+		Command:   "cat /etc/hostname",
 		User:      expectedUser["username"].(string),
 		K8sMetadata: &wsproxy.K8sMetadata{
 			PodName:   "test-pod",


### PR DESCRIPTION
## Changes
- Add space `" "` when joining multiple `command` query parameters in asciicast header