### PR TITLE
chore: Use `embed` directive in all tests

### DIFF
--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -167,7 +167,8 @@ func TestProxyConn_Read_BadRequest(t *testing.T) {
 	defer listener.Close()
 
 	// make proxy TLS
-	serverCert, _ := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
+	serverCert, err := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
+	require.NoError(t, err)
 
 	proxyTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
@@ -240,7 +241,8 @@ func TestProxyConn_Read_HealthCheck(t *testing.T) {
 	defer listener.Close()
 
 	// make proxy TLS
-	serverCert, _ := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
+	serverCert, err := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
+	require.NoError(t, err)
 
 	proxyTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
@@ -312,7 +314,8 @@ func TestProxyConn_Read_ValidConnectRequest(t *testing.T) {
 	listener, addr := startMockListener(t)
 	defer listener.Close()
 
-	proxyCert, _ := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
+	proxyCert, err := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
+	require.NoError(t, err)
 
 	proxyTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{proxyCert},
@@ -403,7 +406,8 @@ func TestProxyConn_Read_FailedValidation(t *testing.T) {
 	defer listener.Close()
 
 	// make proxy TLS
-	serverCert, _ := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
+	serverCert, err := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
+	require.NoError(t, err)
 
 	proxyTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
@@ -486,7 +490,8 @@ func TestProxy_ForwardRequest(t *testing.T) {
 	}))
 
 	// load certs for mock API server
-	serverCert, _ := tls.X509KeyPair(data.ServerCert, data.ServerKey)
+	serverCert, err := tls.X509KeyPair(data.ServerCert, data.ServerKey)
+	require.NoError(t, err)
 
 	apiServerTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},

--- a/internal/httpproxy/http_proxy_test.go
+++ b/internal/httpproxy/http_proxy_test.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -28,6 +27,7 @@ import (
 
 	"k8sgateway/internal/connect"
 	"k8sgateway/internal/token"
+	"k8sgateway/test/data"
 )
 
 type mockConn struct {
@@ -167,7 +167,7 @@ func TestProxyConn_Read_BadRequest(t *testing.T) {
 	defer listener.Close()
 
 	// make proxy TLS
-	serverCert, _ := tls.LoadX509KeyPair("../../test/data/proxy/tls.crt", "../../test/data/proxy/tls.key")
+	serverCert, _ := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
 
 	proxyTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
@@ -188,9 +188,8 @@ func TestProxyConn_Read_BadRequest(t *testing.T) {
 	}
 
 	// make client TLS
-	caCert, _ := os.ReadFile("../../test/data/proxy/tls.crt")
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
+	caCertPool.AppendCertsFromPEM(data.ProxyCert)
 
 	clientTLSConfig := &tls.Config{
 		ServerName: "127.0.0.1",
@@ -241,7 +240,7 @@ func TestProxyConn_Read_HealthCheck(t *testing.T) {
 	defer listener.Close()
 
 	// make proxy TLS
-	serverCert, _ := tls.LoadX509KeyPair("../../test/data/proxy/tls.crt", "../../test/data/proxy/tls.key")
+	serverCert, _ := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
 
 	proxyTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
@@ -255,9 +254,8 @@ func TestProxyConn_Read_HealthCheck(t *testing.T) {
 	}
 
 	// make client TLS
-	caCert, _ := os.ReadFile("../../test/data/proxy/tls.crt")
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
+	caCertPool.AppendCertsFromPEM(data.ProxyCert)
 
 	clientTLSConfig := &tls.Config{
 		ServerName: "127.0.0.1",
@@ -314,7 +312,7 @@ func TestProxyConn_Read_ValidConnectRequest(t *testing.T) {
 	listener, addr := startMockListener(t)
 	defer listener.Close()
 
-	proxyCert, _ := tls.LoadX509KeyPair("../../test/data/proxy/tls.crt", "../../test/data/proxy/tls.key")
+	proxyCert, _ := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
 
 	proxyTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{proxyCert},
@@ -335,9 +333,8 @@ func TestProxyConn_Read_ValidConnectRequest(t *testing.T) {
 	}
 
 	// make client TLS
-	caCert, _ := os.ReadFile("../../test/data/proxy/tls.crt")
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
+	caCertPool.AppendCertsFromPEM(data.ProxyCert)
 
 	clientTLSConfig := &tls.Config{
 		ServerName: "127.0.0.1",
@@ -406,7 +403,7 @@ func TestProxyConn_Read_FailedValidation(t *testing.T) {
 	defer listener.Close()
 
 	// make proxy TLS
-	serverCert, _ := tls.LoadX509KeyPair("../../test/data/proxy/tls.crt", "../../test/data/proxy/tls.key")
+	serverCert, _ := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
 
 	proxyTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
@@ -427,9 +424,8 @@ func TestProxyConn_Read_FailedValidation(t *testing.T) {
 	}
 
 	// make client TLS
-	caCert, _ := os.ReadFile("../../test/data/proxy/tls.crt")
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
+	caCertPool.AppendCertsFromPEM(data.ProxyCert)
 
 	clientTLSConfig := &tls.Config{
 		ServerName: "127.0.0.1",
@@ -490,7 +486,7 @@ func TestProxy_ForwardRequest(t *testing.T) {
 	}))
 
 	// load certs for mock API server
-	serverCert, _ := tls.LoadX509KeyPair("../../test/data/api_server/tls.crt", "../../test/data/api_server/tls.key")
+	serverCert, _ := tls.X509KeyPair(data.ServerCert, data.ServerKey)
 
 	apiServerTLSConfig := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
@@ -531,9 +527,8 @@ func TestProxy_ForwardRequest(t *testing.T) {
 	<-ready
 
 	// downstream proxy and client certs
-	caCert, _ := os.ReadFile("../../test/data/proxy/tls.crt")
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
+	caCertPool.AppendCertsFromPEM(data.ProxyCert)
 
 	tlsConfig := &tls.Config{
 		ServerName: "127.0.0.1",

--- a/test/data/data.go
+++ b/test/data/data.go
@@ -15,3 +15,12 @@ var ControllerKey []byte
 
 //go:embed proxy/tls.crt
 var ProxyCert []byte
+
+//go:embed proxy/tls.key
+var ProxyKey []byte
+
+//go:embed api_server/tls.crt
+var ServerCert []byte
+
+//go:embed api_server/tls.key
+var ServerKey []byte

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -20,6 +19,7 @@ import (
 	kindcmd "sigs.k8s.io/kind/pkg/cmd"
 
 	"k8sgateway/internal/token"
+	"k8sgateway/test/data"
 	"k8sgateway/test/fake"
 	"k8sgateway/test/integration/testutil"
 )
@@ -202,14 +202,10 @@ tls:
 func deployHelmChart(t *testing.T, clusterName, imageTag string) {
 	t.Helper()
 
-	tlsCert, err := os.ReadFile("../data/proxy/tls.crt")
-	require.NoError(t, err, "failed to read TLS certificate")
-
+	tlsCert := data.ProxyCert
 	tlsCertStr := strconv.Quote(string(tlsCert))
 
-	tlsKey, err := os.ReadFile("../data/proxy/tls.key")
-	require.NoError(t, err, "failed to read TLS key")
-
+	tlsKey := data.ProxyKey
 	tlsKeyStr := strconv.Quote(string(tlsKey))
 
 	hostIP := getKindHostAccessIP(t, clusterName)


### PR DESCRIPTION
## Changes
- Update e2e test and `http_proxy` unit test to use `embed` directive instead of `os.ReadFile`
