### PR TITLE
chore: Upgrade to Go 1.25.0 and golangci-lint to 2.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8
       with:
-        version: v2.3
+        version: v2.4
         only-new-issues: true
 
   test-helm:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GOLANG_VERSION: 1.24.6
+  GOLANG_VERSION: 1.25.0
   CADDY_VERSION: 2.10.0
 
 permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 env:
-  GOLANG_VERSION: 1.24.6
+  GOLANG_VERSION: 1.25.0
 
 jobs:
   goreleaser:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.24.6
+golang 1.25.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8sgateway
 
-go 1.24.6
+go 1.25.0
 
 require (
 	github.com/MicahParks/jwkset v0.9.6


### PR DESCRIPTION
## Changes

- Upgrade to Go 1.25.0
- Upgrade golangci-lint to [2.4](https://github.com/golangci/golangci-lint/releases) which is needed to support new Go version 