### PR TITLE
chore: Update helm unit test

### DIFF
--- a/deploy/gateway/tests/__snapshot__/configmap-grafana-dashboard_test.yaml.snap
+++ b/deploy/gateway/tests/__snapshot__/configmap-grafana-dashboard_test.yaml.snap
@@ -2,7 +2,7 @@ should create Grafana Dashboard:
   1: |
     apiVersion: v1
     data:
-      gateway-dashboard.json: |-
+      gateway-dashboard.json: |
         {
           "annotations": {
             "list": [
@@ -24,6 +24,7 @@ should create Grafana Dashboard:
           "editable": true,
           "fiscalYearStartMonth": 0,
           "graphTooltip": 0,
+          "id": 29,
           "links": [],
           "panels": [
             {
@@ -33,588 +34,6 @@ should create Grafana Dashboard:
                 "w": 24,
                 "x": 0,
                 "y": 0
-              },
-              "id": 31,
-              "panels": [],
-              "title": "Basic Information",
-              "type": "row"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "description": "Build version of the Gateway.",
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 4,
-                "w": 6,
-                "x": 0,
-                "y": 1
-              },
-              "id": 25,
-              "options": {
-                "colorMode": "value",
-                "graphMode": "none",
-                "justifyMode": "center",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "/^version$/",
-                  "limit": 8,
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "pluginVersion": "12.0.2",
-              "targets": [
-                {
-                  "disableTextWrap": false,
-                  "editorMode": "builder",
-                  "exemplar": false,
-                  "expr": "twingate_gateway_build_info",
-                  "format": "table",
-                  "fullMetaSearch": false,
-                  "includeNullMetadata": true,
-                  "instant": true,
-                  "interval": "",
-                  "legendFormat": "{{label_name}}",
-                  "range": false,
-                  "refId": "A",
-                  "useBackend": false
-                }
-              ],
-              "title": "Build Version",
-              "type": "stat"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "description": "Go Version of the Gateway.",
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 4,
-                "w": 5,
-                "x": 6,
-                "y": 1
-              },
-              "id": 28,
-              "options": {
-                "colorMode": "value",
-                "graphMode": "none",
-                "justifyMode": "center",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "/^goversion$/",
-                  "limit": 8,
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "pluginVersion": "12.0.2",
-              "targets": [
-                {
-                  "disableTextWrap": false,
-                  "editorMode": "builder",
-                  "exemplar": false,
-                  "expr": "twingate_gateway_build_info",
-                  "format": "table",
-                  "fullMetaSearch": false,
-                  "includeNullMetadata": true,
-                  "instant": true,
-                  "interval": "",
-                  "legendFormat": "{{label_name}}",
-                  "range": false,
-                  "refId": "A",
-                  "useBackend": false
-                }
-              ],
-              "title": "Go Version",
-              "type": "stat"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "description": "Go OS of the Gateway.",
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 4,
-                "w": 5,
-                "x": 11,
-                "y": 1
-              },
-              "id": 27,
-              "options": {
-                "colorMode": "value",
-                "graphMode": "none",
-                "justifyMode": "center",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "/^goos$/",
-                  "limit": 8,
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "pluginVersion": "12.0.2",
-              "targets": [
-                {
-                  "disableTextWrap": false,
-                  "editorMode": "builder",
-                  "exemplar": false,
-                  "expr": "twingate_gateway_build_info",
-                  "format": "table",
-                  "fullMetaSearch": false,
-                  "includeNullMetadata": true,
-                  "instant": true,
-                  "interval": "",
-                  "legendFormat": "{{label_name}}",
-                  "range": false,
-                  "refId": "A",
-                  "useBackend": false
-                }
-              ],
-              "title": "Go OS",
-              "type": "stat"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "description": "Architecture of the Gateway.",
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      }
-                    ]
-                  }
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 4,
-                "w": 5,
-                "x": 16,
-                "y": 1
-              },
-              "id": 26,
-              "options": {
-                "colorMode": "value",
-                "graphMode": "none",
-                "justifyMode": "center",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "/^goarch$/",
-                  "limit": 8,
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "pluginVersion": "12.0.2",
-              "targets": [
-                {
-                  "disableTextWrap": false,
-                  "editorMode": "builder",
-                  "exemplar": false,
-                  "expr": "twingate_gateway_build_info",
-                  "format": "table",
-                  "fullMetaSearch": false,
-                  "includeNullMetadata": true,
-                  "instant": true,
-                  "interval": "",
-                  "legendFormat": "{{label_name}}",
-                  "range": false,
-                  "refId": "A",
-                  "useBackend": false
-                }
-              ],
-              "title": "Go Architecture",
-              "type": "stat"
-            },
-            {
-              "collapsed": false,
-              "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 5
-              },
-              "id": 8,
-              "panels": [],
-              "title": "Prometheus HTTP",
-              "type": "row"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "description": "Total number of scrapes by HTTP status code.",
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 0,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineStyle": {
-                      "fill": "solid"
-                    },
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "red",
-                        "value": 80
-                      }
-                    ]
-                  },
-                  "unit": "short"
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 6,
-                "w": 8,
-                "x": 0,
-                "y": 6
-              },
-              "id": 1,
-              "options": {
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "pluginVersion": "12.0.2",
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "$datasource"
-                  },
-                  "disableTextWrap": false,
-                  "editorMode": "code",
-                  "exemplar": false,
-                  "expr": "sum by (code) (rate(promhttp_metric_handler_requests_total[5m]))",
-                  "fullMetaSearch": false,
-                  "includeNullMetadata": true,
-                  "instant": false,
-                  "legendFormat": "{{code}}",
-                  "range": true,
-                  "refId": "A",
-                  "useBackend": false
-                }
-              ],
-              "title": "HTTP Status",
-              "type": "timeseries"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "description": "Total number of internal errors encountered by the promhttp metric handler.",
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 0,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "red",
-                        "value": 80
-                      }
-                    ]
-                  },
-                  "unit": "short"
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 6,
-                "w": 9,
-                "x": 8,
-                "y": 6
-              },
-              "id": 3,
-              "options": {
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "pluginVersion": "12.0.2",
-              "targets": [
-                {
-                  "disableTextWrap": false,
-                  "editorMode": "builder",
-                  "exemplar": false,
-                  "expr": "sum by(cause) (rate(promhttp_metric_handler_errors_total{container=\"kubernetes-access-gateway\"}[5m]))",
-                  "fullMetaSearch": false,
-                  "includeNullMetadata": true,
-                  "instant": false,
-                  "legendFormat": "{{cause}}",
-                  "range": true,
-                  "refId": "A",
-                  "useBackend": false
-                }
-              ],
-              "title": "Error",
-              "type": "timeseries"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "description": "Current number of scrapes being served",
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "fieldMinMax": false,
-                  "mappings": [],
-                  "min": 0,
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "yellow",
-                        "value": 4
-                      },
-                      {
-                        "color": "red",
-                        "value": 10
-                      }
-                    ]
-                  },
-                  "unit": "none"
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 6,
-                "w": 7,
-                "x": 17,
-                "y": 6
-              },
-              "id": 2,
-              "options": {
-                "minVizHeight": 75,
-                "minVizWidth": 75,
-                "orientation": "auto",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showThresholdLabels": true,
-                "showThresholdMarkers": true,
-                "sizing": "auto"
-              },
-              "pluginVersion": "12.0.2",
-              "targets": [
-                {
-                  "disableTextWrap": false,
-                  "editorMode": "builder",
-                  "expr": "sum(promhttp_metric_handler_requests_in_flight{container=\"kubernetes-access-gateway\"})",
-                  "fullMetaSearch": false,
-                  "includeNullMetadata": true,
-                  "legendFormat": "",
-                  "range": true,
-                  "refId": "A",
-                  "useBackend": false
-                }
-              ],
-              "title": "Number of active scrapes",
-              "type": "gauge"
-            },
-            {
-              "collapsed": false,
-              "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 12
               },
               "id": 9,
               "panels": [],
@@ -673,7 +92,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       },
                       {
                         "color": "red",
@@ -689,7 +109,7 @@ should create Grafana Dashboard:
                 "h": 7,
                 "w": 19,
                 "x": 0,
-                "y": 13
+                "y": 1
               },
               "id": 4,
               "options": {
@@ -705,7 +125,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "disableTextWrap": false,
@@ -742,7 +162,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   }
@@ -753,7 +174,7 @@ should create Grafana Dashboard:
                 "h": 7,
                 "w": 5,
                 "x": 19,
-                "y": 13
+                "y": 1
               },
               "id": 5,
               "options": {
@@ -773,7 +194,7 @@ should create Grafana Dashboard:
                 "textMode": "auto",
                 "wideLayout": true
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "disableTextWrap": false,
@@ -795,7 +216,7 @@ should create Grafana Dashboard:
                 "type": "prometheus",
                 "uid": "$datasource"
               },
-              "description": "Percentile latency of HTTP requests between Client and Gateway, grouped by request type.",
+              "description": "Percentile duration of HTTP requests between Client and Gateway, grouped by request type.",
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -839,7 +260,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   },
@@ -851,7 +273,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 20
+                "y": 8
               },
               "id": 6,
               "options": {
@@ -867,7 +289,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "datasource": {
@@ -915,7 +337,7 @@ should create Grafana Dashboard:
                   "useBackend": false
                 }
               ],
-              "title": "Request Latency",
+              "title": "Request Duration",
               "type": "timeseries"
             },
             {
@@ -970,7 +392,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   },
@@ -982,7 +405,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 20
+                "y": 8
               },
               "id": 7,
               "options": {
@@ -998,7 +421,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "disableTextWrap": false,
@@ -1064,7 +487,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   },
@@ -1076,7 +500,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 28
+                "y": 16
               },
               "id": 13,
               "options": {
@@ -1092,7 +516,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "datasource": {
@@ -1184,7 +608,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   },
@@ -1196,7 +621,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 28
+                "y": 16
               },
               "id": 12,
               "options": {
@@ -1212,7 +637,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "disableTextWrap": false,
@@ -1278,7 +703,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   },
@@ -1290,7 +716,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 36
+                "y": 24
               },
               "id": 20,
               "options": {
@@ -1306,7 +732,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "datasource": {
@@ -1403,7 +829,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   },
@@ -1415,7 +842,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 36
+                "y": 24
               },
               "id": 21,
               "options": {
@@ -1431,7 +858,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "disableTextWrap": false,
@@ -1454,7 +881,7 @@ should create Grafana Dashboard:
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 44
+                "y": 32
               },
               "id": 17,
               "panels": [],
@@ -1513,7 +940,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       },
                       {
                         "color": "red",
@@ -1529,7 +957,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 19,
                 "x": 0,
-                "y": 45
+                "y": 33
               },
               "id": 15,
               "options": {
@@ -1545,7 +973,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "disableTextWrap": false,
@@ -1582,7 +1010,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   }
@@ -1593,7 +1022,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 5,
                 "x": 19,
-                "y": 45
+                "y": 33
               },
               "id": 16,
               "options": {
@@ -1613,7 +1042,7 @@ should create Grafana Dashboard:
                 "textMode": "auto",
                 "wideLayout": true
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "disableTextWrap": false,
@@ -1635,7 +1064,7 @@ should create Grafana Dashboard:
                 "type": "prometheus",
                 "uid": "$datasource"
               },
-              "description": "Percentile latency of HTTP requests to Kubernetes API Server, grouped by request type.",
+              "description": "Percentile duration of HTTP requests to Kubernetes API Server, grouped by request type.",
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -1679,7 +1108,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   },
@@ -1691,7 +1121,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 53
+                "y": 41
               },
               "id": 18,
               "options": {
@@ -1707,7 +1137,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "datasource": {
@@ -1803,7 +1233,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   },
@@ -1815,7 +1246,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 53
+                "y": 41
               },
               "id": 22,
               "options": {
@@ -1831,7 +1262,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "disableTextWrap": false,
@@ -1854,7 +1285,7 @@ should create Grafana Dashboard:
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 61
+                "y": 49
               },
               "id": 23,
               "panels": [],
@@ -1866,7 +1297,7 @@ should create Grafana Dashboard:
                 "type": "prometheus",
                 "uid": "$datasource"
               },
-              "description": "Percentile latency of the recorded session.",
+              "description": "Percentile duration of the recorded session.",
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -1910,7 +1341,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   },
@@ -1922,7 +1354,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 62
+                "y": 50
               },
               "id": 29,
               "options": {
@@ -1938,7 +1370,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "datasource": {
@@ -2034,7 +1466,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   },
@@ -2046,7 +1479,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 62
+                "y": 50
               },
               "id": 30,
               "options": {
@@ -2062,7 +1495,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "disableTextWrap": false,
@@ -2085,7 +1518,7 @@ should create Grafana Dashboard:
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 70
+                "y": 58
               },
               "id": 32,
               "panels": [],
@@ -2144,7 +1577,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       },
                       {
                         "color": "red",
@@ -2160,7 +1594,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 19,
                 "x": 0,
-                "y": 71
+                "y": 59
               },
               "id": 33,
               "options": {
@@ -2176,7 +1610,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "disableTextWrap": false,
@@ -2213,7 +1647,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   }
@@ -2224,7 +1659,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 5,
                 "x": 19,
-                "y": 71
+                "y": 59
               },
               "id": 34,
               "options": {
@@ -2244,7 +1679,7 @@ should create Grafana Dashboard:
                 "textMode": "auto",
                 "wideLayout": true
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "disableTextWrap": false,
@@ -2266,7 +1701,7 @@ should create Grafana Dashboard:
                 "type": "prometheus",
                 "uid": "$datasource"
               },
-              "description": "Percentile latency of Client TCP connections to Gateway, grouped by connection category.",
+              "description": "Percentile duration of Client TCP connections to Gateway, grouped by connection category.",
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -2310,7 +1745,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   },
@@ -2322,7 +1758,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 79
+                "y": 67
               },
               "id": 35,
               "options": {
@@ -2338,7 +1774,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "datasource": {
@@ -2434,7 +1870,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   },
@@ -2446,7 +1883,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 79
+                "y": 67
               },
               "id": 36,
               "options": {
@@ -2462,7 +1899,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "disableTextWrap": false,
@@ -2485,7 +1922,7 @@ should create Grafana Dashboard:
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 87
+                "y": 75
               },
               "id": 40,
               "panels": [],
@@ -2544,7 +1981,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       },
                       {
                         "color": "red",
@@ -2560,7 +1998,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 24,
                 "x": 0,
-                "y": 88
+                "y": 76
               },
               "id": 37,
               "options": {
@@ -2576,7 +2014,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "disableTextWrap": false,
@@ -2598,7 +2036,7 @@ should create Grafana Dashboard:
                 "type": "prometheus",
                 "uid": "$datasource"
               },
-              "description": "Percentile latency of HTTP Connect authentication attempts.",
+              "description": "Percentile duration of HTTP Connect authentication attempts.",
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -2642,7 +2080,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   },
@@ -2654,7 +2093,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 96
+                "y": 84
               },
               "id": 38,
               "options": {
@@ -2670,7 +2109,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "datasource": {
@@ -2766,7 +2205,8 @@ should create Grafana Dashboard:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       }
                     ]
                   },
@@ -2778,7 +2218,7 @@ should create Grafana Dashboard:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 96
+                "y": 84
               },
               "id": 39,
               "options": {
@@ -2794,7 +2234,7 @@ should create Grafana Dashboard:
                   "sort": "none"
                 }
               },
-              "pluginVersion": "12.0.2",
+              "pluginVersion": "12.1.0",
               "targets": [
                 {
                   "disableTextWrap": false,
@@ -2839,6 +2279,7 @@ should create Grafana Dashboard:
           "timepicker": {},
           "timezone": "browser",
           "title": "Twingate Kubernetes Access Gateway",
+          "uid": "63804d24-275c-4d8b-9d3c-7408d6898259",
           "version": 1
         }
     kind: ConfigMap


### PR DESCRIPTION
## Changes
- Fix `configmap-grafana-dashboard` snapshot test

## Notes
Unfortunately, `helm-unittest@v1.0.0` is having a [known issue](https://github.com/helm-unittest/helm-unittest/issues/712) with `matchSnapshot`, that is why the `test-helm` CI did not fail in this [PR](https://github.com/Twingate/kubernetes-access-gateway/pull/104). I only found this issue locally because I was using an `helm-unittest` older version.