### PR TITLE
fix: Fix failing helm unittest

### DIFF
--- a/deploy/gateway/tests/service_test.yaml
+++ b/deploy/gateway/tests/service_test.yaml
@@ -33,14 +33,14 @@ tests:
         type: null
     asserts:
       - failedTemplate:
-          errorPattern: 'service: type is required'
+          errorPattern: "at '/service': missing property 'type'"
   - it: should not allow other Service type
     set:
       service:
         type: ExternalName
     asserts:
       - failedTemplate:
-          errorPattern: 'service.type must be one of the following: "ClusterIP", "NodePort", "LoadBalancer"'
+          errorPattern: "at '/service/type': value must be one of 'ClusterIP', 'NodePort', 'LoadBalancer'"
   - it: should support NodePort type with custom nodePort
     set:
       service:


### PR DESCRIPTION
## Changes
- `helm-unittest@v1.0.1` is currently failing ([example](https://github.com/Twingate/kubernetes-access-gateway/actions/runs/17634898633/job/50109192470?pr=132)) because it upgrades its Helm dependency to `v3.18.6` ([commit](https://github.com/helm-unittest/helm-unittest/commit/765b3e961a876404035a66f015a5e8b03ca6ee52)), which introduces a breaking change.
-  Starting with [`Helm@v3.18.5`](https://github.com/helm/helm/releases/tag/v3.18.5), Helm updated its JSON schema validator to a new [module](https://github.com/santhosh-tekuri/jsonschema/tree/32784e992ee32ae73891b165b1319dd0bca87437) in this [commit](https://github.com/helm/helm/commit/cb8595bc650e2ec7459427d2b0430599431a3dbe#diff-929b9984065c6f793c00345747910f6659be3db59b3f2574415119c89a4ec996L24-L26), which returns different error messages for failed schema validation.

## To reproduce locally
Upgrade your `helm-unittest` to `v1.0.1` and run `make test-helm`