### PR TITLE
fix: Add `resourceAlias` to the DNS list in TLS cert only when it is not an empty string

### DIFF
--- a/deploy/gateway/templates/tls-secret.yaml
+++ b/deploy/gateway/templates/tls-secret.yaml
@@ -25,7 +25,10 @@ data:
   {{- $serviceName := include "gateway.fullname" . }}
   {{- include "gateway.generateCA" .}}
   {{- $ca := .Values._generatedCA }}
-  {{- $dnsNames := concat .Values.tls.dnsNames (list "kubernetes" "kubernetes.default" "kubernetes.default.svc" (printf "kubernetes.default.svc.%s" .Values.clusterDomain)) (list $resourceAlias) }}
+  {{- $dnsNames := concat .Values.tls.dnsNames (list "kubernetes" "kubernetes.default" "kubernetes.default.svc" (printf "kubernetes.default.svc.%s" .Values.clusterDomain)) }}
+  {{- if ne $resourceAlias "" }}
+  {{- $dnsNames = append $dnsNames $resourceAlias }}
+  {{- end }}
   {{- $tls := genSignedCert $serviceName .Values.tls.ipAddresses $dnsNames 365 $ca }}
   tls.crt: {{ $tls.Cert | b64enc }}
   tls.key: {{ $tls.Key | b64enc }}


### PR DESCRIPTION
## Changes

When `resourceAlias` is not set (Gateway is deployed using Helm), it is included as an empty string in TLS cert e.g.
```
X509v3 Subject Alternative Name:
    DNS:my-k8s-cluster.int, DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.cluster.local, DNS:
```

Go 1.25.2 no longer allows such entry (see [similar issue](https://github.com/kubernetes-sigs/external-dns/issues/5896)).