### PR TITLE
chore: Pin Helm version to latest v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: azure/setup-helm@v4
         with:
-          version: v3.17.3
+          version: v3.19.2
       - name: Install helm-unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest
       - name: Run tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,9 @@ jobs:
         with:
           go-version: ${{ env.GOLANG_VERSION }}
 
-      - uses: azure/setup-helm@v4.3.0
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.19.2
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Changes

Pin Helm version to latest v3 (3.19.2) because Helm Github action pull the Helm v4 and cause some breaking change like https://github.com/Azure/setup-helm/issues/241