### PR TITLE
chore: Add unit suffix to `ptyReq` and `windowChangeReq` terminal size variable fields

### DIFF
--- a/internal/sshhandler/channel_pair.go
+++ b/internal/sshhandler/channel_pair.go
@@ -101,8 +101,8 @@ func (c *SSHChannelPair) serve() {
 		onPtyRequest: func(req ptyReq) {
 			// Set the asciinema header with the pty request details only once
 			c.ptyRequestOnce.Do(func() {
-				asciinemaHeader.Width = int(req.Columns)
-				asciinemaHeader.Height = int(req.Rows)
+				asciinemaHeader.Width = int(req.WidthColumns)
+				asciinemaHeader.Height = int(req.HeightRows)
 			})
 		},
 		onWindowChange: func(req windowChangeReq) {
@@ -116,7 +116,7 @@ func (c *SSHChannelPair) serve() {
 				return
 			}
 
-			if err := r.WriteResizeEvent(int(req.Columns), int(req.Rows)); err != nil {
+			if err := r.WriteResizeEvent(int(req.WidthColumns), int(req.HeightRows)); err != nil {
 				c.logger.Error("failed to write resize event", zap.Error(err))
 			}
 		},

--- a/internal/sshhandler/channel_pair_test.go
+++ b/internal/sshhandler/channel_pair_test.go
@@ -119,7 +119,7 @@ func TestSSHChannelPair_serve_Success(t *testing.T) {
 		// Send pty-req request
 		ptyRequest := &mockSSHRequest{
 			Type:      "pty-req",
-			Payload:   ssh.Marshal(ptyReq{Columns: 80, Rows: 24}),
+			Payload:   ssh.Marshal(ptyReq{WidthColumns: 80, HeightRows: 24}),
 			WantReply: true,
 		}
 		ptyRequest.On("Reply", true, []byte(nil)).Return(nil)
@@ -159,7 +159,7 @@ func TestSSHChannelPair_serve_Success(t *testing.T) {
 		// Send window-change request
 		windowChangeRequest := &mockSSHRequest{
 			Type:      "window-change",
-			Payload:   ssh.Marshal(windowChangeReq{Columns: 100, Rows: 44}),
+			Payload:   ssh.Marshal(windowChangeReq{WidthColumns: 100, HeightRows: 44}),
 			WantReply: false,
 		}
 		windowChangeRequest.On("Reply", false, []byte(nil)).Return(nil)

--- a/internal/sshhandler/request_handler.go
+++ b/internal/sshhandler/request_handler.go
@@ -72,12 +72,12 @@ type SSHRequestHandlerFlushTrigger struct {
 // SSH pty request structure
 // see: https://datatracker.ietf.org/doc/html/rfc4254#section-6.2
 type ptyReq struct {
-	Term     string
-	Columns  uint32
-	Rows     uint32
-	Width    uint32
-	Height   uint32
-	Modelist string
+	Term         string
+	WidthColumns uint32
+	HeightRows   uint32
+	WidthPixels  uint32
+	HeightPixels uint32
+	Modelist     string
 }
 
 // SSH exec request structure
@@ -95,10 +95,10 @@ type subsystemReq struct {
 // SSH window-change request structure
 // see: https://datatracker.ietf.org/doc/html/rfc4254#section-6.7
 type windowChangeReq struct {
-	Columns uint32
-	Rows    uint32
-	Width   uint32
-	Height  uint32
+	WidthColumns uint32
+	HeightRows   uint32
+	WidthPixels  uint32
+	HeightPixels uint32
 }
 
 // RequestHandler defines the interface for handling SSH channel requests.

--- a/internal/sshhandler/request_handler_test.go
+++ b/internal/sshhandler/request_handler_test.go
@@ -18,12 +18,12 @@ import (
 
 func createPtyRequestPayload() []byte {
 	ptyReq := ptyReq{
-		Term:     "xterm-256color",
-		Columns:  80,
-		Rows:     24,
-		Width:    640,
-		Height:   480,
-		Modelist: "",
+		Term:         "xterm-256color",
+		WidthColumns: 80,
+		HeightRows:   24,
+		WidthPixels:  640,
+		HeightPixels: 480,
+		Modelist:     "",
 	}
 	payload := ssh.Marshal(ptyReq)
 
@@ -50,10 +50,10 @@ func createSubsystemRequestPayload(name string) []byte {
 
 func createWindowChangeRequestPayload() []byte {
 	windowChangeReq := windowChangeReq{
-		Columns: 80,
-		Rows:    24,
-		Width:   640,
-		Height:  480,
+		WidthColumns: 80,
+		HeightRows:   24,
+		WidthPixels:  640,
+		HeightPixels: 480,
 	}
 	payload := ssh.Marshal(windowChangeReq)
 
@@ -106,8 +106,8 @@ func TestSSHRequestHandler_handleRequests_PtyRequest(t *testing.T) {
 
 	// Verify pty request was processed
 	assert.Equal(t, "xterm-256color", capturedPtyReq.Term)
-	assert.Equal(t, uint32(80), capturedPtyReq.Columns)
-	assert.Equal(t, uint32(24), capturedPtyReq.Rows)
+	assert.Equal(t, uint32(80), capturedPtyReq.WidthColumns)
+	assert.Equal(t, uint32(24), capturedPtyReq.HeightRows)
 
 	mockChannel.AssertExpectations(t)
 
@@ -305,8 +305,8 @@ func TestSSHRequestHandler_handleRequests_WindowChangeRequest(t *testing.T) {
 	<-signals.finished
 
 	// Verify window-change request was processed
-	assert.Equal(t, uint32(80), capturedWindowChangeReq.Columns)
-	assert.Equal(t, uint32(24), capturedWindowChangeReq.Rows)
+	assert.Equal(t, uint32(80), capturedWindowChangeReq.WidthColumns)
+	assert.Equal(t, uint32(24), capturedWindowChangeReq.HeightRows)
 
 	// Assert that Reply was NOT called since WantReply is false
 	mockReq.AssertNotCalled(t, "Reply")


### PR DESCRIPTION
## Changes
- Rename `ptyReq` and `windowChangeReq` terminal size variable fields to make units explicit per [RFC4254](https://datatracker.ietf.org/doc/html/rfc4254#section-6.7)