### PR TITLE
chore: Fix pre-release Helm chart version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,5 +118,5 @@ cut-release-dev: ##@release Cut a development pre-release (create a version tag 
 		exit 1; \
 	fi
 	echo "🚀 Cutting a new development pre-release - $(shell go tool svu next)"
-	git tag "$(shell go tool svu next --prerelease dev --metadata $(shell git rev-parse --short HEAD))"
+	git tag "$(shell go tool svu next --prerelease dev-$(shell git rev-parse --short HEAD))"
 	git push --tags


### PR DESCRIPTION
## Changes

Change the Git tag for dev (prerelease) version from `0.12.1-dev+ca27a29` to `0.12.1-dev-ca27a29`, which is still a valid semantic version, to be compatible with OCI tag format. 

## Notes

While Helm chart version supports full semantic versioning ([doc](https://helm.sh/docs/v3/topics/charts/#charts-and-versioning)), our Helm charts are distributed via OCI-based Github registry. OCI tag doesn't allow the `+` character ([spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pull)) so installing our Helm chart would run into issues like
```
helm upgrade gateway oci://ghcr.io/twingate/helmcharts/kubernetes-access-gateway:0.12.1-dev+ca27a29 --install --wait -f ./values.yaml                                                                 
Error: invalid reference: invalid tag "0.12.1-dev+ca27a29"
```

A tag with `+` would also cause issues with dependabot for Helm charts.
