### PR TITLE
chore: Upgrade golangci-lint to v2.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.6
+        version: v2.8
         only-new-issues: true
 
   test-helm:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - noctx
     - nonamedreturns
     - paralleltest
+    - prealloc  # Not recommended without performance profiling
     - testpackage
     - varnamelen
     - wrapcheck


### PR DESCRIPTION
## Changes

- Upgrade golangci-lint to v2.8
- Disable new linter `prealloc`. golangci-lint doesn't recommend to turn on this linter ([doc](https://golangci-lint.run/docs/linters/configuration/#prealloc)). All violations are in test anyway.
  ```
  # IMPORTANT: we don't recommend using this linter before doing performance profiling.
  # For most programs usage of prealloc will be a premature optimization.
  ```