### PR TITLE
feat: Add public key fallback for SSH host key negotiation

### DIFF
--- a/internal/sshhandler/config.go
+++ b/internal/sshhandler/config.go
@@ -161,6 +161,8 @@ func (c *Config) GetDownstreamConfig(ctx context.Context) (*ssh.ServerConfig, er
 	}()
 
 	downstreamSSHConfig.AddHostKey(hostCertSigner)
+	// Add the public key as a fallback for clients that don't support certificate-based host key algorithms.
+	downstreamSSHConfig.AddHostKey(hostCertSigner.keySigner)
 
 	return downstreamSSHConfig, nil
 }


### PR DESCRIPTION
## Changes
- Register the gateway's public key as a fallback host key in `GetDownstreamConfig`, alongside the existing certificate-based host key
- Allows SSH clients that don't support certificate-based host key algorithms (e.g. Claude Desktop) to connect using public key verification