### PR TITLE
feat: Validate GAT `ver` claim supported version

### DIFF
--- a/internal/token/gat_claims.go
+++ b/internal/token/gat_claims.go
@@ -16,8 +16,11 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+const supportedVersion = "1"
+
 var (
-	errInvalidPublicKey = errors.New("not a valid public key")
+	errInvalidPublicKey   = errors.New("not a valid public key")
+	errUnsupportedVersion = errors.New("unsupported version")
 )
 
 type GATClaims struct {
@@ -49,6 +52,10 @@ func (p GATClaims) Validate() error {
 		if v.condition {
 			return fmt.Errorf("%w \"%s\"", jwt.ErrTokenRequiredClaimMissing, v.fieldName)
 		}
+	}
+
+	if p.Version != supportedVersion {
+		return fmt.Errorf("%w: %w %q", jwt.ErrTokenInvalidClaims, errUnsupportedVersion, p.Version)
 	}
 
 	return nil

--- a/internal/token/gat_claims_test.go
+++ b/internal/token/gat_claims_test.go
@@ -104,6 +104,14 @@ func TestGATTokenClaims_Validate(t *testing.T) {
 			expectedError:        jwt.ErrTokenRequiredClaimMissing,
 			expectedErrorMessage: "\"resource.address\"",
 		},
+		{
+			name: "Unsupported version",
+			setupFn: func(claims *GATClaims) {
+				claims.Version = "2"
+			},
+			expectedError:        jwt.ErrTokenInvalidClaims,
+			expectedErrorMessage: "unsupported version \"2\"",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes
- Validate that the GAT `ver` claim equals `"1"` in `GATClaims.Validate()`, returning `jwt.ErrTokenInvalidClaims` for unsupported versions