### PR TITLE
fix: Populate the k8s in-cluster upstream when `twingate.resource` is enabled in Helm values file

### DIFF
--- a/deploy/gateway/templates/_helpers.tpl
+++ b/deploy/gateway/templates/_helpers.tpl
@@ -125,6 +125,17 @@ Create the name of the SSH Vault AppRole secret ID secret to use
 
 
 {{/*
+Get the name for the auto-created in-cluster Kubernetes upstream
+*/}}
+{{- define "gateway.resourceInClusterUpstreamName" -}}
+{{- if and .Values.twingate.resource .Values.twingate.resource.enabled .Values.twingate.resource.extraAnnotations }}
+{{- default "Local Kubernetes Cluster" (get .Values.twingate.resource.extraAnnotations "resource.twingate.com/name") }}
+{{- else }}
+{{- "Local Kubernetes Cluster" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Get the alias of the resource
 */}}
 {{- define "gateway.resourceAlias" -}}

--- a/deploy/gateway/templates/gateway-configmap.yaml
+++ b/deploy/gateway/templates/gateway-configmap.yaml
@@ -25,12 +25,21 @@ data:
       certificateFile: "/etc/gateway/tls/tls.crt"
       privateKeyFile: "/etc/gateway/tls/tls.key"
 
-    {{ with .Values.kubernetes -}}
-    {{ if and .enabled .upstreams -}}
+    {{- $resourceEnabled := and .Values.twingate.resource .Values.twingate.resource.enabled -}}
+    {{- $k8sEnabled := and .Values.kubernetes .Values.kubernetes.enabled -}}
+    {{- $k8sUpstreams := list -}}
+    {{- if $resourceEnabled -}}
+      {{- $resourceUpstream := dict "name" (include "gateway.resourceInClusterUpstreamName" .) "inCluster" true -}}
+      {{- $k8sUpstreams = append $k8sUpstreams $resourceUpstream -}}
+    {{- end -}}
+    {{- if and $k8sEnabled .Values.kubernetes.upstreams -}}
+      {{- $k8sUpstreams = concat $k8sUpstreams .Values.kubernetes.upstreams -}}
+    {{- end }}
+
+    {{ if $k8sUpstreams -}}
     kubernetes:
       upstreams:
-        {{- .upstreams | toYaml | nindent 8 }}
-    {{ end -}}
+        {{- $k8sUpstreams | toYaml | nindent 8 }}
     {{ end -}}
 
     {{ with .Values.ssh -}}

--- a/deploy/gateway/tests/gateway-configmap_test.yaml
+++ b/deploy/gateway/tests/gateway-configmap_test.yaml
@@ -151,6 +151,143 @@ tests:
       - failedTemplate:
           errorPattern: "at '/kubernetes/upstreams/0': missing property 'caFile'"
 ---
+suite: Gateway configmap with Resource
+templates:
+  - gateway-configmap.yaml
+set:
+  twingate:
+    network: "acme"
+tests:
+  - it: should auto-create inCluster upstream when resource is enabled
+    set:
+      twingate:
+        resource:
+          enabled: true
+    asserts:
+      - equal:
+          path: data["config.yaml"]
+          value: |-
+            twingate:
+              network: "acme"
+              host: "twingate.com"
+
+            port: 8443
+            metricsPort: 9090
+
+            auditLog:
+              flushInterval: 5m
+              flushSizeThreshold: 1e+06
+
+            tls:
+              certificateFile: "/etc/gateway/tls/tls.crt"
+              privateKeyFile: "/etc/gateway/tls/tls.key"
+
+            kubernetes:
+              upstreams:
+                - inCluster: true
+                  name: Local Kubernetes Cluster
+  - it: should use resource.twingate.com/name from extraAnnotations as upstream name
+    set:
+      twingate:
+        resource:
+          enabled: true
+          extraAnnotations:
+            resource.twingate.com/name: "My K8s Cluster"
+    asserts:
+      - equal:
+          path: data["config.yaml"]
+          value: |-
+            twingate:
+              network: "acme"
+              host: "twingate.com"
+
+            port: 8443
+            metricsPort: 9090
+
+            auditLog:
+              flushInterval: 5m
+              flushSizeThreshold: 1e+06
+
+            tls:
+              certificateFile: "/etc/gateway/tls/tls.crt"
+              privateKeyFile: "/etc/gateway/tls/tls.key"
+
+            kubernetes:
+              upstreams:
+                - inCluster: true
+                  name: My K8s Cluster
+  - it: should prepend inCluster upstream before manual upstreams
+    set:
+      twingate:
+        resource:
+          enabled: true
+      kubernetes:
+        enabled: true
+        upstreams:
+          - name: "External Cluster"
+            inCluster: false
+            address: "https://api.k8s.int:443"
+            bearerToken: "token"
+            caFile: "/ca.crt"
+    asserts:
+      - equal:
+          path: data["config.yaml"]
+          value: |-
+            twingate:
+              network: "acme"
+              host: "twingate.com"
+
+            port: 8443
+            metricsPort: 9090
+
+            auditLog:
+              flushInterval: 5m
+              flushSizeThreshold: 1e+06
+
+            tls:
+              certificateFile: "/etc/gateway/tls/tls.crt"
+              privateKeyFile: "/etc/gateway/tls/tls.key"
+
+            kubernetes:
+              upstreams:
+                - inCluster: true
+                  name: Local Kubernetes Cluster
+                - address: https://api.k8s.int:443
+                  bearerToken: token
+                  caFile: /ca.crt
+                  inCluster: false
+                  name: External Cluster
+  - it: should auto-enable kubernetes even when kubernetes.enabled is false
+    set:
+      twingate:
+        resource:
+          enabled: true
+      kubernetes:
+        enabled: false
+    asserts:
+      - equal:
+          path: data["config.yaml"]
+          value: |-
+            twingate:
+              network: "acme"
+              host: "twingate.com"
+
+            port: 8443
+            metricsPort: 9090
+
+            auditLog:
+              flushInterval: 5m
+              flushSizeThreshold: 1e+06
+
+            tls:
+              certificateFile: "/etc/gateway/tls/tls.crt"
+              privateKeyFile: "/etc/gateway/tls/tls.key"
+
+            kubernetes:
+              upstreams:
+                - inCluster: true
+                  name: Local Kubernetes Cluster
+---
 suite: Gateway configmap with SSH
 templates:
   - gateway-configmap.yaml


### PR DESCRIPTION
## Changes

Populate the k8s in-cluster upstream when `twingate.resource` is enabled in Helm values file