### PR TITLE
refactor: Generalize SSH conn/channel pair naming from downstream/upstream to source/target

### DIFF
--- a/internal/sshhandler/channel_copier.go
+++ b/internal/sshhandler/channel_copier.go
@@ -109,19 +109,19 @@ func (c *ChannelCopyPair) copy() {
 }
 
 type BidirectionalCopier struct {
-	logger               *zap.Logger
-	DownstreamToUpstream ChannelCopyPair
-	UpstreamToDownstream ChannelCopyPair
+	logger         *zap.Logger
+	SourceToTarget ChannelCopyPair
+	TargetToSource ChannelCopyPair
 }
 
 func (c *BidirectionalCopier) start() {
 	var wg sync.WaitGroup
 
 	wg.Go(func() {
-		c.DownstreamToUpstream.copy()
+		c.SourceToTarget.copy()
 	})
 	wg.Go(func() {
-		c.UpstreamToDownstream.copy()
+		c.TargetToSource.copy()
 	})
 
 	// Wait for both directions to finish

--- a/internal/sshhandler/channel_copier_test.go
+++ b/internal/sshhandler/channel_copier_test.go
@@ -184,80 +184,80 @@ func TestChannelCopyPair_copy_ShutdownTimeout(t *testing.T) {
 
 func TestBidirectionalCopier_start(t *testing.T) {
 	// Create mock channels for both directions
-	downstreamSrc := NewMockChannel()
-	downstreamDst := NewMockChannel()
-	upstreamSrc := NewMockChannel()
-	upstreamDst := NewMockChannel()
+	sourceSrc := NewMockChannel()
+	sourceDst := NewMockChannel()
+	targetSrc := NewMockChannel()
+	targetDst := NewMockChannel()
 
 	// Set up test data
-	downstreamData := []byte("downstream data")
-	upstreamData := []byte("upstream data")
+	sourceData := []byte("source data")
+	targetData := []byte("target data")
 
-	downstreamSrc.SetData(downstreamData)
-	upstreamSrc.SetData(upstreamData)
+	sourceSrc.SetData(sourceData)
+	targetSrc.SetData(targetData)
 
 	// Set up channels
-	downstreamEOFTrigger := make(chan SSHRequestHandlerFlushTrigger, 1)
-	downstreamChannelClosed := make(chan struct{}, 1)
-	upstreamEOFTrigger := make(chan SSHRequestHandlerFlushTrigger, 1)
-	upstreamChannelClosed := make(chan struct{}, 1)
+	sourceEOFTrigger := make(chan SSHRequestHandlerFlushTrigger, 1)
+	sourceChannelClosed := make(chan struct{}, 1)
+	targetEOFTrigger := make(chan SSHRequestHandlerFlushTrigger, 1)
+	targetChannelClosed := make(chan struct{}, 1)
 
 	// Mock expectations
-	downstreamDst.On("CloseWrite").Return(nil)
-	downstreamDst.On("Close").Return(nil)
-	upstreamDst.On("CloseWrite").Return(nil)
-	upstreamDst.On("Close").Return(nil)
+	sourceDst.On("CloseWrite").Return(nil)
+	sourceDst.On("Close").Return(nil)
+	targetDst.On("CloseWrite").Return(nil)
+	targetDst.On("Close").Return(nil)
 
 	copier := &BidirectionalCopier{
 		logger: zap.NewNop(),
-		DownstreamToUpstream: ChannelCopyPair{
+		SourceToTarget: ChannelCopyPair{
 			logger:          zap.NewNop(),
-			Src:             downstreamSrc,
-			Dst:             downstreamDst,
-			EOFTriggerCh:    downstreamEOFTrigger,
-			ChannelClosedCh: downstreamChannelClosed,
+			Src:             sourceSrc,
+			Dst:             sourceDst,
+			EOFTriggerCh:    sourceEOFTrigger,
+			ChannelClosedCh: sourceChannelClosed,
 		},
-		UpstreamToDownstream: ChannelCopyPair{
+		TargetToSource: ChannelCopyPair{
 			logger:          zap.NewNop(),
-			Src:             upstreamSrc,
-			Dst:             upstreamDst,
-			EOFTriggerCh:    upstreamEOFTrigger,
-			ChannelClosedCh: upstreamChannelClosed,
+			Src:             targetSrc,
+			Dst:             targetDst,
+			EOFTriggerCh:    targetEOFTrigger,
+			ChannelClosedCh: targetChannelClosed,
 		},
 	}
 
-	// Initiate shutdown from downstream EOF
-	downstreamSrc.TriggerEOF()
+	// Initiate shutdown from source EOF
+	sourceSrc.TriggerEOF()
 
-	// Handle EOF trigger from downstream
-	downstreamEOFCalled := false
+	// Handle EOF trigger from source
+	sourceEOFCalled := false
 
 	go func() {
-		trigger := <-downstreamEOFTrigger
+		trigger := <-sourceEOFTrigger
 		trigger.cb()
 
-		downstreamEOFCalled = true
+		sourceEOFCalled = true
 
-		// Downstream should have done CloseWrite() at this point, and upstream
+		// Source should have done CloseWrite() at this point, and target
 		// will receive SSH_MSG_CHANNEL_EOF, so simulate this by
-		// starting EOF trigger for upstream
-		upstreamSrc.TriggerEOF()
+		// starting EOF trigger for target
+		targetSrc.TriggerEOF()
 
-		// Now downstream can fully close
-		close(downstreamChannelClosed)
+		// Now source can fully close
+		close(sourceChannelClosed)
 	}()
 
-	// Handle EOF trigger from upstream
-	upstreamEOFCalled := false
+	// Handle EOF trigger from target
+	targetEOFCalled := false
 
 	go func() {
-		trigger := <-upstreamEOFTrigger
+		trigger := <-targetEOFTrigger
 		trigger.cb()
 
-		upstreamEOFCalled = true
+		targetEOFCalled = true
 
-		// Now upstream can fully close after receiving SSH_MSG_CHANNEL_EOF
-		close(upstreamChannelClosed)
+		// Now target can fully close after receiving SSH_MSG_CHANNEL_EOF
+		close(targetChannelClosed)
 	}()
 
 	// Mark time start
@@ -266,16 +266,16 @@ func TestBidirectionalCopier_start(t *testing.T) {
 	elapsed := time.Since(start)
 
 	// EOF triggers should have been called
-	assert.True(t, downstreamEOFCalled)
-	assert.True(t, upstreamEOFCalled)
+	assert.True(t, sourceEOFCalled)
+	assert.True(t, targetEOFCalled)
 
 	// Should complete quickly
 	assert.Less(t, elapsed, 1*time.Second)
 
 	// Verify data was copied in both directions
-	assert.Equal(t, downstreamData, downstreamDst.GetWrittenData())
-	assert.Equal(t, upstreamData, upstreamDst.GetWrittenData())
+	assert.Equal(t, sourceData, sourceDst.GetWrittenData())
+	assert.Equal(t, targetData, targetDst.GetWrittenData())
 
-	downstreamDst.AssertExpectations(t)
-	upstreamDst.AssertExpectations(t)
+	sourceDst.AssertExpectations(t)
+	targetDst.AssertExpectations(t)
 }

--- a/internal/sshhandler/channel_pair.go
+++ b/internal/sshhandler/channel_pair.go
@@ -48,17 +48,22 @@ type SSHChannelPair struct {
 
 	channelType string
 
-	// Downstream SSH channel
-	downstreamChannel ssh.Channel
-	// Downstream SSH channel requests channel
-	downstreamChannelRequests <-chan Request
+	// Source SSH channel
+	sourceChannel ssh.Channel
+	// Source SSH channel requests channel
+	sourceChannelRequests <-chan Request
 
-	// Upstream SSH channel
-	upstreamChannel ssh.Channel
-	// Upstream SSH channel requests channel
-	upstreamChannelRequests <-chan Request
-	// Upstream SSH username (for session recording)
-	upstreamSSHUsername string
+	// Target SSH channel
+	targetChannel ssh.Channel
+	// Target SSH channel requests channel
+	targetChannelRequests <-chan Request
+
+	// SSH username (for session recording)
+	sshUsername string
+
+	// Labels for logging (e.g. "downstream", "upstream")
+	sourceLabel string
+	targetLabel string
 
 	// Factory for creating session recorders
 	recorderFactory SessionRecorderFactory
@@ -67,16 +72,18 @@ type SSHChannelPair struct {
 }
 
 // NewSSHChannelPair creates a new SSHChannelPair with the default factories.
-func NewSSHChannelPair(logger *zap.Logger, upstreamSSHUsername string, downstreamChannel ssh.Channel, downstreamRequests <-chan Request, upstreamChannel ssh.Channel, upstreamRequests <-chan Request, channelType string) *SSHChannelPair {
+func NewSSHChannelPair(logger *zap.Logger, sshUsername string, sourceChannel ssh.Channel, sourceRequests <-chan Request, targetChannel ssh.Channel, targetRequests <-chan Request, channelType string, sourceLabel, targetLabel string) *SSHChannelPair {
 	return &SSHChannelPair{
-		logger:                    logger,
-		upstreamSSHUsername:       upstreamSSHUsername,
-		downstreamChannel:         downstreamChannel,
-		downstreamChannelRequests: downstreamRequests,
-		upstreamChannel:           upstreamChannel,
-		upstreamChannelRequests:   upstreamRequests,
-		recorderFactory:           &DefaultSessionRecorderFactory{},
-		channelType:               channelType,
+		logger:                logger,
+		sshUsername:           sshUsername,
+		sourceChannel:         sourceChannel,
+		sourceChannelRequests: sourceRequests,
+		targetChannel:         targetChannel,
+		targetChannelRequests: targetRequests,
+		recorderFactory:       &DefaultSessionRecorderFactory{},
+		channelType:           channelType,
+		sourceLabel:           sourceLabel,
+		targetLabel:           targetLabel,
 	}
 }
 
@@ -90,16 +97,16 @@ func (c *SSHChannelPair) serve() {
 	asciinemaHeader := sessionrecorder.AsciicastHeader{
 		Version:   2,
 		Timestamp: time.Now().Unix(),
-		User:      c.upstreamSSHUsername,
+		User:      c.sshUsername,
 	}
 
-	// Handle the downstream channel's requests
-	downstreamEOFTrigger := make(chan SSHRequestHandlerFlushTrigger, 1)
-	downstreamRequestHandler := &SSHRequestHandler{
-		logger:            c.logger.With(zap.String("direction", "downstream -> upstream")),
-		flushTrigger:      downstreamEOFTrigger,
-		sourceRequestChan: c.downstreamChannelRequests,
-		targetChannel:     c.upstreamChannel,
+	// Handle the source channel's requests
+	sourceEOFTrigger := make(chan SSHRequestHandlerFlushTrigger, 1)
+	sourceRequestHandler := &SSHRequestHandler{
+		logger:            c.logger.With(zap.String("request_source", c.sourceLabel), zap.String("request_target", c.targetLabel)),
+		flushTrigger:      sourceEOFTrigger,
+		sourceRequestChan: c.sourceChannelRequests,
+		targetChannel:     c.targetChannel,
 		onPtyRequest: func(req ptyReq) {
 			// Set the asciinema header with the pty request details only once
 			c.ptyRequestOnce.Do(func() {
@@ -123,30 +130,30 @@ func (c *SSHChannelPair) serve() {
 			}
 		},
 	}
-	downstreamSessionSignals := downstreamRequestHandler.handleRequests()
+	sourceSessionSignals := sourceRequestHandler.handleRequests()
 
-	// Handle the upstream channel's requests
-	upstreamEOFTrigger := make(chan SSHRequestHandlerFlushTrigger, 1)
-	upstreamRequestHandler := &SSHRequestHandler{
-		logger:            c.logger.With(zap.String("direction", "upstream -> downstream")),
-		flushTrigger:      upstreamEOFTrigger,
-		sourceRequestChan: c.upstreamChannelRequests,
-		targetChannel:     c.downstreamChannel,
+	// Handle the target channel's requests
+	targetEOFTrigger := make(chan SSHRequestHandlerFlushTrigger, 1)
+	targetRequestHandler := &SSHRequestHandler{
+		logger:            c.logger.With(zap.String("request_source", c.targetLabel), zap.String("request_target", c.sourceLabel)),
+		flushTrigger:      targetEOFTrigger,
+		sourceRequestChan: c.targetChannelRequests,
+		targetChannel:     c.sourceChannel,
 		onPtyRequest:      nil,
 		onWindowChange:    nil,
 	}
-	upstreamSessionSignals := upstreamRequestHandler.handleRequests()
+	targetSessionSignals := targetRequestHandler.handleRequests()
 
 	var command string
 
 	if c.channelType == "session" {
-		// Wait for session to start from downstream prior to starting the data copying
+		// Wait for session to start from source prior to starting the data copying
 		select {
-		case command = <-downstreamSessionSignals.started:
-			c.logger.Debug("Downstream session started", zap.String("command", command))
+		case command = <-sourceSessionSignals.started:
+			c.logger.Debug("Source session started", zap.String("command", command))
 			asciinemaHeader.Command = command
 		case <-time.After(sessionStartTimeout):
-			c.logger.Error("Timeout waiting for downstream session to start")
+			c.logger.Error("Timeout waiting for source session to start")
 
 			return
 		}
@@ -166,7 +173,7 @@ func (c *SSHChannelPair) serve() {
 		// Write the asciinema header to the recorder
 		// Note: We are relying on the convention that 'pty-req' will be sent prior to 'shell' requests,
 		// so we should have already set the asciinema header with the pty request details
-		// in the onPtyRequest() callback on the downstreamRequestHandler
+		// in the onPtyRequest() callback on the sourceRequestHandler
 		err := rec.WriteHeader(asciinemaHeader)
 		if err != nil {
 			c.logger.Error("failed to write asciinema header", zap.Error(err))
@@ -177,20 +184,20 @@ func (c *SSHChannelPair) serve() {
 
 	copier := &BidirectionalCopier{
 		logger: c.logger,
-		DownstreamToUpstream: ChannelCopyPair{
-			logger:          c.logger.With(zap.String("direction", "downstream -> upstream")),
-			Src:             c.downstreamChannel,
-			Dst:             c.upstreamChannel,
-			EOFTriggerCh:    downstreamEOFTrigger,
-			ChannelClosedCh: downstreamSessionSignals.finished,
+		SourceToTarget: ChannelCopyPair{
+			logger:          c.logger,
+			Src:             c.sourceChannel,
+			Dst:             c.targetChannel,
+			EOFTriggerCh:    sourceEOFTrigger,
+			ChannelClosedCh: sourceSessionSignals.finished,
 		},
 
-		UpstreamToDownstream: ChannelCopyPair{
-			logger:          c.logger.With(zap.String("direction", "upstream -> downstream")),
-			Src:             c.upstreamChannel,
-			Dst:             c.downstreamChannel,
-			EOFTriggerCh:    upstreamEOFTrigger,
-			ChannelClosedCh: upstreamSessionSignals.finished,
+		TargetToSource: ChannelCopyPair{
+			logger:          c.logger,
+			Src:             c.targetChannel,
+			Dst:             c.sourceChannel,
+			EOFTriggerCh:    targetEOFTrigger,
+			ChannelClosedCh: targetSessionSignals.finished,
 			Tap:             processor,
 		},
 	}

--- a/internal/sshhandler/channel_pair.go
+++ b/internal/sshhandler/channel_pair.go
@@ -72,6 +72,8 @@ type SSHChannelPair struct {
 }
 
 // NewSSHChannelPair creates a new SSHChannelPair with the default factories.
+//
+//nolint:revive // argument-limit: to be addressed when removing the ChannelPairFactory test interface
 func NewSSHChannelPair(logger *zap.Logger, sshUsername string, sourceChannel ssh.Channel, sourceRequests <-chan Request, targetChannel ssh.Channel, targetRequests <-chan Request, channelType string, sourceLabel, targetLabel string) *SSHChannelPair {
 	return &SSHChannelPair{
 		logger:                logger,

--- a/internal/sshhandler/channel_pair.go
+++ b/internal/sshhandler/channel_pair.go
@@ -185,7 +185,7 @@ func (c *SSHChannelPair) serve() {
 	copier := &BidirectionalCopier{
 		logger: c.logger,
 		SourceToTarget: ChannelCopyPair{
-			logger:          c.logger,
+			logger:          c.logger.With(zap.String("channel_source", c.sourceLabel), zap.String("channel_target", c.targetLabel)),
 			Src:             c.sourceChannel,
 			Dst:             c.targetChannel,
 			EOFTriggerCh:    sourceEOFTrigger,
@@ -193,7 +193,7 @@ func (c *SSHChannelPair) serve() {
 		},
 
 		TargetToSource: ChannelCopyPair{
-			logger:          c.logger,
+			logger:          c.logger.With(zap.String("channel_source", c.targetLabel), zap.String("channel_target", c.sourceLabel)),
 			Src:             c.targetChannel,
 			Dst:             c.sourceChannel,
 			EOFTriggerCh:    targetEOFTrigger,

--- a/internal/sshhandler/channel_pair_test.go
+++ b/internal/sshhandler/channel_pair_test.go
@@ -69,12 +69,12 @@ func (m *mockSessionRecorderFactory) NewRecorder(logger *zap.Logger) sessionreco
 func TestSSHChannelPair_serve_Success(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		// Create mock channels
-		downstreamChannel := NewMockChannel()
-		upstreamChannel := NewMockChannel()
+		sourceChannel := NewMockChannel()
+		targetChannel := NewMockChannel()
 
 		// Create mock request channels
-		downstreamRequests := make(chan Request)
-		upstreamRequests := make(chan Request)
+		sourceRequests := make(chan Request)
+		targetRequests := make(chan Request)
 
 		mockRecorderFactory := &mockSessionRecorderFactory{}
 		mockRec := &mockRecorder{}
@@ -99,11 +99,13 @@ func TestSSHChannelPair_serve_Success(t *testing.T) {
 		channelPair := NewSSHChannelPair(
 			zap.NewNop(),
 			"testuser",
-			downstreamChannel,
-			downstreamRequests,
-			upstreamChannel,
-			upstreamRequests,
+			sourceChannel,
+			sourceRequests,
+			targetChannel,
+			targetRequests,
 			"session",
+			"downstream",
+			"upstream",
 		)
 		channelPair.recorderFactory = mockRecorderFactory
 
@@ -124,12 +126,12 @@ func TestSSHChannelPair_serve_Success(t *testing.T) {
 		}
 		ptyRequest.On("Reply", true, []byte(nil)).Return(nil)
 
-		downstreamRequests <- ptyRequest
+		sourceRequests <- ptyRequest
 
-		// Assert that the pty request was sent to upstream
+		// Assert that the pty request was sent to target
 		synctest.Wait()
 
-		requests := upstreamChannel.GetSendRequests()
+		requests := targetChannel.GetSendRequests()
 
 		assert.Len(t, requests, 1)
 		assert.Equal(t, ptyRequest.Type, requests[0].Type)
@@ -144,12 +146,12 @@ func TestSSHChannelPair_serve_Success(t *testing.T) {
 		}
 		shellRequest.On("Reply", true, []byte(nil)).Return(nil)
 
-		downstreamRequests <- shellRequest
+		sourceRequests <- shellRequest
 
-		// Assert that the shell request was sent to upstream
+		// Assert that the shell request was sent to target
 		synctest.Wait()
 
-		requests = upstreamChannel.GetSendRequests()
+		requests = targetChannel.GetSendRequests()
 
 		assert.Len(t, requests, 2)
 		assert.Equal(t, shellRequest.Type, requests[1].Type)
@@ -164,23 +166,23 @@ func TestSSHChannelPair_serve_Success(t *testing.T) {
 		}
 		windowChangeRequest.On("Reply", false, []byte(nil)).Return(nil)
 
-		downstreamRequests <- windowChangeRequest
+		sourceRequests <- windowChangeRequest
 
-		// Assert that the window-change request was sent to upstream
+		// Assert that the window-change request was sent to target
 		synctest.Wait()
 
-		requests = upstreamChannel.GetSendRequests()
+		requests = targetChannel.GetSendRequests()
 
 		assert.Len(t, requests, 3)
 		assert.Equal(t, windowChangeRequest.Type, requests[2].Type)
 		assert.Equal(t, windowChangeRequest.Payload, requests[2].Payload)
 		assert.False(t, requests[2].WantReply)
 
-		// Write data to the upstream channel
-		upstreamChannel.SetData([]byte("filename.txt"))
-		// Assert that the data was copied to the downstream channel
+		// Write data to the target channel
+		targetChannel.SetData([]byte("filename.txt"))
+		// Assert that the data was copied to the source channel
 		synctest.Wait()
-		assert.Equal(t, []byte("filename.txt"), downstreamChannel.GetWrittenData())
+		assert.Equal(t, []byte("filename.txt"), sourceChannel.GetWrittenData())
 
 		// Send exit-status back
 		exitStatus := &mockSSHRequest{
@@ -188,12 +190,12 @@ func TestSSHChannelPair_serve_Success(t *testing.T) {
 			Payload:   []byte{},
 			WantReply: false,
 		}
-		upstreamRequests <- exitStatus
+		targetRequests <- exitStatus
 
-		// Assert that the exit-status request was sent to downstream
+		// Assert that the exit-status request was sent to source
 		synctest.Wait()
 
-		requests = downstreamChannel.GetSendRequests()
+		requests = sourceChannel.GetSendRequests()
 
 		assert.Len(t, requests, 1)
 		assert.Equal(t, exitStatus.Type, requests[0].Type)
@@ -201,13 +203,13 @@ func TestSSHChannelPair_serve_Success(t *testing.T) {
 		assert.False(t, requests[0].WantReply)
 
 		// Close all the channels now
-		_ = upstreamChannel.Close()
+		_ = targetChannel.Close()
 
-		close(upstreamRequests)
+		close(targetRequests)
 
-		_ = downstreamChannel.Close()
+		_ = sourceChannel.Close()
 
-		close(downstreamRequests)
+		close(sourceRequests)
 
 		// Wait for serve to complete
 		<-done
@@ -221,23 +223,25 @@ func TestSSHChannelPair_serve_Success(t *testing.T) {
 func TestSSHChannelPair_serve_NonShellCommand(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		// Create mock channels
-		downstreamChannel := NewMockChannel()
-		upstreamChannel := NewMockChannel()
+		sourceChannel := NewMockChannel()
+		targetChannel := NewMockChannel()
 
 		// Create mock request channels
-		downstreamRequests := make(chan Request)
-		upstreamRequests := make(chan Request)
+		sourceRequests := make(chan Request)
+		targetRequests := make(chan Request)
 
 		mockRecorderFactory := &mockSessionRecorderFactory{}
 
 		channelPair := NewSSHChannelPair(
 			zap.NewNop(),
 			"testuser",
-			downstreamChannel,
-			downstreamRequests,
-			upstreamChannel,
-			upstreamRequests,
+			sourceChannel,
+			sourceRequests,
+			targetChannel,
+			targetRequests,
 			"session",
+			"downstream",
+			"upstream",
 		)
 		channelPair.recorderFactory = mockRecorderFactory
 
@@ -258,12 +262,12 @@ func TestSSHChannelPair_serve_NonShellCommand(t *testing.T) {
 		}
 		subsystemRequest.On("Reply", true, []byte(nil)).Return(nil)
 
-		downstreamRequests <- subsystemRequest
+		sourceRequests <- subsystemRequest
 
-		// Assert that the subsystem request was sent to upstream
+		// Assert that the subsystem request was sent to target
 		synctest.Wait()
 
-		requests := upstreamChannel.GetSendRequests()
+		requests := targetChannel.GetSendRequests()
 
 		assert.Len(t, requests, 1)
 		assert.Equal(t, subsystemRequest.Type, requests[0].Type)
@@ -271,13 +275,13 @@ func TestSSHChannelPair_serve_NonShellCommand(t *testing.T) {
 		assert.Equal(t, subsystemRequest.WantReply, requests[0].WantReply)
 
 		// Close all the channels now
-		_ = upstreamChannel.Close()
+		_ = targetChannel.Close()
 
-		close(upstreamRequests)
+		close(targetRequests)
 
-		_ = downstreamChannel.Close()
+		_ = sourceChannel.Close()
 
-		close(downstreamRequests)
+		close(sourceRequests)
 
 		// Wait for serve to complete
 		<-done
@@ -290,12 +294,12 @@ func TestSSHChannelPair_serve_NonShellCommand(t *testing.T) {
 func TestSSHChannelPair_serve_SessionStartTimeout(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		// Create mock channels
-		downstreamChannel := NewMockChannel()
-		upstreamChannel := NewMockChannel()
+		sourceChannel := NewMockChannel()
+		targetChannel := NewMockChannel()
 
 		// Create mock request channels
-		downstreamRequests := make(chan Request)
-		upstreamRequests := make(chan Request)
+		sourceRequests := make(chan Request)
+		targetRequests := make(chan Request)
 
 		mockRecorderFactory := &mockSessionRecorderFactory{}
 
@@ -305,11 +309,13 @@ func TestSSHChannelPair_serve_SessionStartTimeout(t *testing.T) {
 		channelPair := NewSSHChannelPair(
 			zap.NewNop(),
 			"testuser",
-			downstreamChannel,
-			downstreamRequests,
-			upstreamChannel,
-			upstreamRequests,
+			sourceChannel,
+			sourceRequests,
+			targetChannel,
+			targetRequests,
 			"session",
+			"downstream",
+			"upstream",
 		)
 		channelPair.recorderFactory = mockRecorderFactory
 
@@ -337,13 +343,13 @@ func TestSSHChannelPair_serve_SessionStartTimeout(t *testing.T) {
 		}
 
 		// Close channels for cleanup
-		_ = upstreamChannel.Close()
+		_ = targetChannel.Close()
 
-		close(upstreamRequests)
+		close(targetRequests)
 
-		_ = downstreamChannel.Close()
+		_ = sourceChannel.Close()
 
-		close(downstreamRequests)
+		close(sourceRequests)
 
 		// Verify expectations - recorder should never have been created
 		mockRecorderFactory.AssertExpectations(t)

--- a/internal/sshhandler/conn_pair.go
+++ b/internal/sshhandler/conn_pair.go
@@ -49,7 +49,7 @@ type ChannelPairFactory interface {
 // DefaultChannelPairFactory implements ChannelPairFactory using SSHChannelPair.
 type DefaultChannelPairFactory struct{}
 
-//nolint:ireturn
+//nolint:ireturn,revive // argument-limit: to be addressed when removing the ChannelPairFactory test interface
 func (f *DefaultChannelPairFactory) NewChannelPair(logger *zap.Logger, sshUsername string, sourceChannel ssh.Channel, sourceRequests <-chan *ssh.Request, targetChannel ssh.Channel, targetRequests <-chan *ssh.Request, channelType string, sourceLabel, targetLabel string) ChannelPair {
 	return NewSSHChannelPair(
 		logger,

--- a/internal/sshhandler/conn_pair.go
+++ b/internal/sshhandler/conn_pair.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	dirDownstreamToUpstream = "downstream -> upstream"
-	dirUpstreamToDownstream = "upstream -> downstream"
+	labelDownstream = "downstream"
+	labelUpstream   = "upstream"
 )
 
 // Denylists for channel types per direction (RFC 4254).
@@ -43,22 +43,24 @@ var (
 
 // ChannelPairFactory creates SSH channel pairs.
 type ChannelPairFactory interface {
-	NewChannelPair(logger *zap.Logger, upstreamSSHUsername string, downstreamChannel ssh.Channel, downstreamRequests <-chan *ssh.Request, upstreamChannel ssh.Channel, upstreamRequests <-chan *ssh.Request, channelType string) ChannelPair
+	NewChannelPair(logger *zap.Logger, sshUsername string, sourceChannel ssh.Channel, sourceRequests <-chan *ssh.Request, targetChannel ssh.Channel, targetRequests <-chan *ssh.Request, channelType string, sourceLabel, targetLabel string) ChannelPair
 }
 
 // DefaultChannelPairFactory implements ChannelPairFactory using SSHChannelPair.
 type DefaultChannelPairFactory struct{}
 
 //nolint:ireturn
-func (f *DefaultChannelPairFactory) NewChannelPair(logger *zap.Logger, upstreamSSHUsername string, downstreamChannel ssh.Channel, downstreamRequests <-chan *ssh.Request, upstreamChannel ssh.Channel, upstreamRequests <-chan *ssh.Request, channelType string) ChannelPair {
+func (f *DefaultChannelPairFactory) NewChannelPair(logger *zap.Logger, sshUsername string, sourceChannel ssh.Channel, sourceRequests <-chan *ssh.Request, targetChannel ssh.Channel, targetRequests <-chan *ssh.Request, channelType string, sourceLabel, targetLabel string) ChannelPair {
 	return NewSSHChannelPair(
 		logger,
-		upstreamSSHUsername,
-		downstreamChannel,
-		wrapSSHRequestChannel(downstreamRequests),
-		upstreamChannel,
-		wrapSSHRequestChannel(upstreamRequests),
+		sshUsername,
+		sourceChannel,
+		wrapSSHRequestChannel(sourceRequests),
+		targetChannel,
+		wrapSSHRequestChannel(targetRequests),
 		channelType,
+		sourceLabel,
+		targetLabel,
 	)
 }
 
@@ -107,27 +109,27 @@ func NewSSHConnPair(
 func (c *SSHConnPair) serve() {
 	// Forward global requests in both directions
 	c.wg.Go(func() {
-		c.forwardGlobalRequests(c.downstreamRequestsChan, c.upstreamConn, nil, dirDownstreamToUpstream)
+		c.forwardGlobalRequests(c.downstreamRequestsChan, c.upstreamConn, nil, labelDownstream, labelUpstream)
 	})
 
 	c.wg.Go(func() {
-		c.forwardGlobalRequests(c.upstreamRequestsChan, c.downstreamConn, disallowedUpstreamGlobalRequests, dirUpstreamToDownstream)
+		c.forwardGlobalRequests(c.upstreamRequestsChan, c.downstreamConn, disallowedUpstreamGlobalRequests, labelUpstream, labelDownstream)
 	})
 
 	// Forward channels in both directions
 	c.wg.Go(func() {
-		c.forwardChannels(c.downstreamSSHChannelsChan, c.upstreamConn, disallowedDownstreamChannelTypes, dirDownstreamToUpstream)
+		c.forwardChannels(c.downstreamSSHChannelsChan, c.upstreamConn, disallowedDownstreamChannelTypes, labelDownstream, labelUpstream)
 	})
 
 	c.wg.Go(func() {
-		c.forwardChannels(c.upstreamSSHChannelsChan, c.downstreamConn, disallowedUpstreamChannelTypes, dirUpstreamToDownstream)
+		c.forwardChannels(c.upstreamSSHChannelsChan, c.downstreamConn, disallowedUpstreamChannelTypes, labelUpstream, labelDownstream)
 	})
 
 	c.wg.Wait()
 }
 
-func (c *SSHConnPair) forwardChannels(channels <-chan ssh.NewChannel, targetConn ssh.Conn, disallowedTypes map[string]bool, direction string) {
-	logger := c.logger.With(zap.String("direction", direction))
+func (c *SSHConnPair) forwardChannels(channels <-chan ssh.NewChannel, targetConn ssh.Conn, disallowedTypes map[string]bool, source, target string) {
+	logger := c.logger.With(zap.String("conn_source", source), zap.String("conn_target", target))
 
 	for newChannel := range channels {
 		channelType := newChannel.ChannelType()
@@ -176,6 +178,7 @@ func (c *SSHConnPair) forwardChannels(channels <-chan ssh.NewChannel, targetConn
 			sourceChannel, sourceRequests,
 			targetChannel, targetRequests,
 			channelType,
+			source, target,
 		)
 
 		c.wg.Go(func() {
@@ -184,8 +187,8 @@ func (c *SSHConnPair) forwardChannels(channels <-chan ssh.NewChannel, targetConn
 	}
 }
 
-func (c *SSHConnPair) forwardGlobalRequests(requests <-chan *ssh.Request, dst ssh.Conn, disallowedTypes map[string]bool, direction string) {
-	logger := c.logger.With(zap.String("direction", direction))
+func (c *SSHConnPair) forwardGlobalRequests(requests <-chan *ssh.Request, dst ssh.Conn, disallowedTypes map[string]bool, source, target string) {
+	logger := c.logger.With(zap.String("conn_source", source), zap.String("conn_target", target))
 
 	for req := range requests {
 		if disallowedTypes[req.Type] {

--- a/internal/sshhandler/conn_pair_test.go
+++ b/internal/sshhandler/conn_pair_test.go
@@ -43,7 +43,7 @@ func newMockChannelPairFactory(channelPair ChannelPair) *mockChannelPairFactory 
 	}
 }
 
-//nolint:ireturn
+//nolint:ireturn,revive // argument-limit: to be addressed when removing the ChannelPairFactory test interface
 func (m *mockChannelPairFactory) NewChannelPair(logger *zap.Logger, sshUsername string, sourceChannel ssh.Channel, sourceRequests <-chan *ssh.Request, targetChannel ssh.Channel, targetRequests <-chan *ssh.Request, channelType string, sourceLabel, targetLabel string) ChannelPair {
 	args := m.Called(logger, sshUsername, sourceChannel, sourceRequests, targetChannel, targetRequests, channelType, sourceLabel, targetLabel)
 
@@ -265,7 +265,7 @@ func TestSSHConnPair_serve_DownstreamAcceptFailure(t *testing.T) {
 	upstreamConn.On("OpenChannel", "session", []byte(nil)).Return(targetChannel, (<-chan *ssh.Request)(targetRequests), nil)
 
 	// Source accept fails
-	expectedErr := errors.New("source accept failed")
+	expectedErr := errors.New("downstream accept failed")
 	newChannel.On("Accept").Return((*MockChannel)(nil), (<-chan *ssh.Request)(nil), expectedErr)
 	targetChannel.On("Close").Return(nil)
 

--- a/internal/sshhandler/conn_pair_test.go
+++ b/internal/sshhandler/conn_pair_test.go
@@ -44,8 +44,8 @@ func newMockChannelPairFactory(channelPair ChannelPair) *mockChannelPairFactory 
 }
 
 //nolint:ireturn
-func (m *mockChannelPairFactory) NewChannelPair(logger *zap.Logger, upstreamSSHUsername string, downstreamChannel ssh.Channel, downstreamRequests <-chan *ssh.Request, upstreamChannel ssh.Channel, upstreamRequests <-chan *ssh.Request, channelType string) ChannelPair {
-	args := m.Called(logger, upstreamSSHUsername, downstreamChannel, downstreamRequests, upstreamChannel, upstreamRequests, channelType)
+func (m *mockChannelPairFactory) NewChannelPair(logger *zap.Logger, sshUsername string, sourceChannel ssh.Channel, sourceRequests <-chan *ssh.Request, targetChannel ssh.Channel, targetRequests <-chan *ssh.Request, channelType string, sourceLabel, targetLabel string) ChannelPair {
+	args := m.Called(logger, sshUsername, sourceChannel, sourceRequests, targetChannel, targetRequests, channelType, sourceLabel, targetLabel)
 
 	return args.Get(0).(ChannelPair)
 }
@@ -76,12 +76,12 @@ func TestSSHConnPair_serve_SessionChannelSuccess(t *testing.T) {
 
 	// Create mock channels
 	newChannel := newMockNewChannel("session")
-	downstreamChannel := NewMockChannel()
-	upstreamChannel := NewMockChannel()
+	sourceChannel := NewMockChannel()
+	targetChannel := NewMockChannel()
 
 	// Create request channels
-	downstreamRequests := make(chan *ssh.Request)
-	upstreamRequests := make(chan *ssh.Request)
+	sourceRequests := make(chan *ssh.Request)
+	targetRequests := make(chan *ssh.Request)
 
 	// Create mock channel pair
 	mockChannelPair := newMockChannelPair()
@@ -89,9 +89,9 @@ func TestSSHConnPair_serve_SessionChannelSuccess(t *testing.T) {
 
 	// Set up expectations
 	newChannel.On("ExtraData").Return([]byte(nil))
-	upstreamConn.On("OpenChannel", "session", []byte(nil)).Return(upstreamChannel, (<-chan *ssh.Request)(upstreamRequests), nil)
-	newChannel.On("Accept").Return(downstreamChannel, (<-chan *ssh.Request)(downstreamRequests), nil)
-	mockFactory.On("NewChannelPair", mock.Anything, "upstream-user", downstreamChannel, (<-chan *ssh.Request)(downstreamRequests), upstreamChannel, (<-chan *ssh.Request)(upstreamRequests), "session").Return(mockChannelPair)
+	upstreamConn.On("OpenChannel", "session", []byte(nil)).Return(targetChannel, (<-chan *ssh.Request)(targetRequests), nil)
+	newChannel.On("Accept").Return(sourceChannel, (<-chan *ssh.Request)(sourceRequests), nil)
+	mockFactory.On("NewChannelPair", mock.Anything, "upstream-user", sourceChannel, (<-chan *ssh.Request)(sourceRequests), targetChannel, (<-chan *ssh.Request)(targetRequests), "session", labelDownstream, labelUpstream).Return(mockChannelPair)
 	mockChannelPair.On("serve").Return()
 
 	// Create channel chan with one session channel
@@ -147,12 +147,12 @@ func TestSSHConnPair_serve_DirectTCPIPChannelForwarded(t *testing.T) {
 	// Create mock channel with direct-tcpip type (port forwarding)
 	extraData := []byte("extra-data")
 	newChannel := newMockNewChannel("direct-tcpip")
-	downstreamChannel := NewMockChannel()
-	upstreamChannel := NewMockChannel()
+	sourceChannel := NewMockChannel()
+	targetChannel := NewMockChannel()
 
 	// Create request channels
-	downstreamRequests := make(chan *ssh.Request)
-	upstreamRequests := make(chan *ssh.Request)
+	sourceRequests := make(chan *ssh.Request)
+	targetRequests := make(chan *ssh.Request)
 
 	// Create mock channel pair
 	mockChannelPair := newMockChannelPair()
@@ -160,9 +160,9 @@ func TestSSHConnPair_serve_DirectTCPIPChannelForwarded(t *testing.T) {
 
 	// Set up expectations - channel should be forwarded with original type and extra data
 	newChannel.On("ExtraData").Return(extraData)
-	upstreamConn.On("OpenChannel", "direct-tcpip", extraData).Return(upstreamChannel, (<-chan *ssh.Request)(upstreamRequests), nil)
-	newChannel.On("Accept").Return(downstreamChannel, (<-chan *ssh.Request)(downstreamRequests), nil)
-	mockFactory.On("NewChannelPair", mock.Anything, "upstream-user", downstreamChannel, (<-chan *ssh.Request)(downstreamRequests), upstreamChannel, (<-chan *ssh.Request)(upstreamRequests), "direct-tcpip").Return(mockChannelPair)
+	upstreamConn.On("OpenChannel", "direct-tcpip", extraData).Return(targetChannel, (<-chan *ssh.Request)(targetRequests), nil)
+	newChannel.On("Accept").Return(sourceChannel, (<-chan *ssh.Request)(sourceRequests), nil)
+	mockFactory.On("NewChannelPair", mock.Anything, "upstream-user", sourceChannel, (<-chan *ssh.Request)(sourceRequests), targetChannel, (<-chan *ssh.Request)(targetRequests), "direct-tcpip", labelDownstream, labelUpstream).Return(mockChannelPair)
 	mockChannelPair.On("serve").Return()
 
 	// Create channel chan with one direct-tcpip channel
@@ -254,20 +254,20 @@ func TestSSHConnPair_serve_DownstreamAcceptFailure(t *testing.T) {
 
 	// Create mock channels
 	newChannel := newMockNewChannel("session")
-	upstreamChannel := NewMockChannel()
+	targetChannel := NewMockChannel()
 
 	// Create request channels
-	upstreamRequests := make(chan *ssh.Request)
-	close(upstreamRequests)
+	targetRequests := make(chan *ssh.Request)
+	close(targetRequests)
 
 	// Set up expectations
 	newChannel.On("ExtraData").Return([]byte(nil))
-	upstreamConn.On("OpenChannel", "session", []byte(nil)).Return(upstreamChannel, (<-chan *ssh.Request)(upstreamRequests), nil)
+	upstreamConn.On("OpenChannel", "session", []byte(nil)).Return(targetChannel, (<-chan *ssh.Request)(targetRequests), nil)
 
-	// Downstream accept fails
-	expectedErr := errors.New("downstream accept failed")
+	// Source accept fails
+	expectedErr := errors.New("source accept failed")
 	newChannel.On("Accept").Return((*MockChannel)(nil), (<-chan *ssh.Request)(nil), expectedErr)
-	upstreamChannel.On("Close").Return(nil)
+	targetChannel.On("Close").Return(nil)
 
 	// Create channel chan with one session channel
 	channelChan := createMockChannelChan([]ssh.NewChannel{newChannel})
@@ -291,7 +291,7 @@ func TestSSHConnPair_serve_DownstreamAcceptFailure(t *testing.T) {
 	}
 
 	upstreamConn.AssertExpectations(t)
-	upstreamChannel.AssertExpectations(t)
+	targetChannel.AssertExpectations(t)
 	newChannel.AssertExpectations(t)
 }
 
@@ -304,27 +304,27 @@ func TestSSHConnPair_serve_MultipleChannels(t *testing.T) {
 	directTCPIPChannel := newMockNewChannel("direct-tcpip")
 	sessionChannel2 := newMockNewChannel("session")
 
-	downstreamChannel1 := NewMockChannel()
-	downstreamChannel2 := NewMockChannel()
-	downstreamChannel3 := NewMockChannel()
-	upstreamChannel1 := NewMockChannel()
-	upstreamChannel2 := NewMockChannel()
-	upstreamChannel3 := NewMockChannel()
+	sourceChannel1 := NewMockChannel()
+	sourceChannel2 := NewMockChannel()
+	sourceChannel3 := NewMockChannel()
+	targetChannel1 := NewMockChannel()
+	targetChannel2 := NewMockChannel()
+	targetChannel3 := NewMockChannel()
 
 	// Create request channels
-	downstreamRequests1 := make(chan *ssh.Request)
-	downstreamRequests2 := make(chan *ssh.Request)
-	downstreamRequests3 := make(chan *ssh.Request)
-	upstreamRequests1 := make(chan *ssh.Request)
-	upstreamRequests2 := make(chan *ssh.Request)
-	upstreamRequests3 := make(chan *ssh.Request)
+	sourceRequests1 := make(chan *ssh.Request)
+	sourceRequests2 := make(chan *ssh.Request)
+	sourceRequests3 := make(chan *ssh.Request)
+	targetRequests1 := make(chan *ssh.Request)
+	targetRequests2 := make(chan *ssh.Request)
+	targetRequests3 := make(chan *ssh.Request)
 
-	close(downstreamRequests1)
-	close(downstreamRequests2)
-	close(downstreamRequests3)
-	close(upstreamRequests1)
-	close(upstreamRequests2)
-	close(upstreamRequests3)
+	close(sourceRequests1)
+	close(sourceRequests2)
+	close(sourceRequests3)
+	close(targetRequests1)
+	close(targetRequests2)
+	close(targetRequests3)
 
 	// Create mock channel pairs
 	mockChannelPair1 := newMockChannelPair()
@@ -334,24 +334,24 @@ func TestSSHConnPair_serve_MultipleChannels(t *testing.T) {
 
 	// Set up expectations for session channels
 	sessionChannel1.On("ExtraData").Return([]byte(nil))
-	upstreamConn.On("OpenChannel", "session", []byte(nil)).Return(upstreamChannel1, (<-chan *ssh.Request)(upstreamRequests1), nil).Once()
-	sessionChannel1.On("Accept").Return(downstreamChannel1, (<-chan *ssh.Request)(downstreamRequests1), nil)
-	mockFactory.On("NewChannelPair", mock.Anything, "upstream-user", downstreamChannel1, (<-chan *ssh.Request)(downstreamRequests1), upstreamChannel1, (<-chan *ssh.Request)(upstreamRequests1), "session").Return(mockChannelPair1).Once()
+	upstreamConn.On("OpenChannel", "session", []byte(nil)).Return(targetChannel1, (<-chan *ssh.Request)(targetRequests1), nil).Once()
+	sessionChannel1.On("Accept").Return(sourceChannel1, (<-chan *ssh.Request)(sourceRequests1), nil)
+	mockFactory.On("NewChannelPair", mock.Anything, "upstream-user", sourceChannel1, (<-chan *ssh.Request)(sourceRequests1), targetChannel1, (<-chan *ssh.Request)(targetRequests1), "session", labelDownstream, labelUpstream).Return(mockChannelPair1).Once()
 	mockChannelPair1.On("serve").Return()
 
 	// Set up expectations for direct-tcpip channel (should be forwarded, not rejected)
 	directTCPIPExtraData := []byte("direct-tcpip-data")
 	directTCPIPChannel.On("ExtraData").Return(directTCPIPExtraData)
-	upstreamConn.On("OpenChannel", "direct-tcpip", directTCPIPExtraData).Return(upstreamChannel2, (<-chan *ssh.Request)(upstreamRequests2), nil)
-	directTCPIPChannel.On("Accept").Return(downstreamChannel2, (<-chan *ssh.Request)(downstreamRequests2), nil)
-	mockFactory.On("NewChannelPair", mock.Anything, "upstream-user", downstreamChannel2, (<-chan *ssh.Request)(downstreamRequests2), upstreamChannel2, (<-chan *ssh.Request)(upstreamRequests2), "direct-tcpip").Return(mockChannelPair2).Once()
+	upstreamConn.On("OpenChannel", "direct-tcpip", directTCPIPExtraData).Return(targetChannel2, (<-chan *ssh.Request)(targetRequests2), nil)
+	directTCPIPChannel.On("Accept").Return(sourceChannel2, (<-chan *ssh.Request)(sourceRequests2), nil)
+	mockFactory.On("NewChannelPair", mock.Anything, "upstream-user", sourceChannel2, (<-chan *ssh.Request)(sourceRequests2), targetChannel2, (<-chan *ssh.Request)(targetRequests2), "direct-tcpip", labelDownstream, labelUpstream).Return(mockChannelPair2).Once()
 	mockChannelPair2.On("serve").Return()
 
 	// Set up expectations for second session channel
 	sessionChannel2.On("ExtraData").Return([]byte(nil))
-	upstreamConn.On("OpenChannel", "session", []byte(nil)).Return(upstreamChannel3, (<-chan *ssh.Request)(upstreamRequests3), nil).Once()
-	sessionChannel2.On("Accept").Return(downstreamChannel3, (<-chan *ssh.Request)(downstreamRequests3), nil)
-	mockFactory.On("NewChannelPair", mock.Anything, "upstream-user", downstreamChannel3, (<-chan *ssh.Request)(downstreamRequests3), upstreamChannel3, (<-chan *ssh.Request)(upstreamRequests3), "session").Return(mockChannelPair3).Once()
+	upstreamConn.On("OpenChannel", "session", []byte(nil)).Return(targetChannel3, (<-chan *ssh.Request)(targetRequests3), nil).Once()
+	sessionChannel2.On("Accept").Return(sourceChannel3, (<-chan *ssh.Request)(sourceRequests3), nil)
+	mockFactory.On("NewChannelPair", mock.Anything, "upstream-user", sourceChannel3, (<-chan *ssh.Request)(sourceRequests3), targetChannel3, (<-chan *ssh.Request)(targetRequests3), "session", labelDownstream, labelUpstream).Return(mockChannelPair3).Once()
 	mockChannelPair3.On("serve").Return()
 
 	// Create channel chan with multiple channels
@@ -471,7 +471,7 @@ func TestSSHConnPair_forwardGlobalRequests_ForwardsNonDeniedType(t *testing.T) {
 	close(reqChan)
 
 	connPair := &SSHConnPair{logger: zap.NewNop()}
-	connPair.forwardGlobalRequests(reqChan, targetConn, disallowedUpstreamGlobalRequests, "upstream -> downstream")
+	connPair.forwardGlobalRequests(reqChan, targetConn, disallowedUpstreamGlobalRequests, labelUpstream, labelDownstream)
 
 	targetConn.AssertExpectations(t)
 }
@@ -489,7 +489,7 @@ func TestSSHConnPair_forwardGlobalRequests_BlocksDeniedType(t *testing.T) {
 	close(reqChan)
 
 	connPair := &SSHConnPair{logger: zap.NewNop()}
-	connPair.forwardGlobalRequests(reqChan, targetConn, disallowedUpstreamGlobalRequests, "upstream -> downstream")
+	connPair.forwardGlobalRequests(reqChan, targetConn, disallowedUpstreamGlobalRequests, labelUpstream, labelDownstream)
 
 	// SendRequest should never be called for disallowed types
 	targetConn.AssertNotCalled(t, "SendRequest")
@@ -511,7 +511,7 @@ func TestSSHConnPair_forwardGlobalRequests_ForwardsAllWhenNoDenyList(t *testing.
 	close(reqChan)
 
 	connPair := &SSHConnPair{logger: zap.NewNop()}
-	connPair.forwardGlobalRequests(reqChan, targetConn, nil, "downstream -> upstream")
+	connPair.forwardGlobalRequests(reqChan, targetConn, nil, labelDownstream, labelUpstream)
 
 	targetConn.AssertExpectations(t)
 }


### PR DESCRIPTION
## Changes

- Improve log context by replacing `direction` key with
  + `conn_source` and `conn_target` for channels and global requests
  + `request_source` and `request_target` for channel requests
  + `channel_source` and `channel_target` for channel data
- In `SSHChannelPair`, replace downstream/upstream with source/target


## Notes

Right now, the audit log includes 2 `direction` keys: one for the connection pair ([code](https://github.com/Twingate/kubernetes-access-gateway/blob/master/internal/sshhandler/conn_pair.go#L130)), and the other for the channel request ([code](https://github.com/Twingate/kubernetes-access-gateway/blob/master/internal/sshhandler/channel_pair.go#L99)). For example,
```json
{
  "levelname": "debug",
  "ts": "2026-03-24T16:10:24.570-0700",
  "logger": "gateway.audit",
  "caller": "sshhandler/request_handler.go:119",
  "message": "Channel request",
  "version": "dev",
  "user": {
    "id": "user-1",
    "username": "alex@acme.com",
    "groups": ["Developer", "OnCall"]
  },
  "conn_id": "",
  "session": {
    "client_version": "SSH-2.0-OpenSSH_10.2",
    "id": "1a1a458e6edbfbf7f5017d2e3399206d48e0e7c19425d68fcad5acabec716c51"
  },
  "direction": "downstream -> upstream",  // connection direction
  "channel_pair_id": "53b4633f-886e-4051-864d-3d72204da931",
  "direction": "downstream -> upstream",  // channel request direction
  "type": "pty-req"
}
```