### PR TITLE
docs: Fix testing guidance in CLAUDE.md to align with Go conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ tests := []struct {
 }{ /* cases */ }
 ```
 
-Use `require` for assertions (fails fast). Mocks via mockery.
+Use `testify/assert` for assertions (keep going). Use `testify/require` only for preconditions where continuing would panic or be meaningless. Write mocks with `testify/mock`.
 
 ### Linting
 


### PR DESCRIPTION
## Related Tickets & Documents

- N/A

## Changes

- Update assertion guidance: prefer `assert` over `require`, use `require` only for preconditions where continuing would panic or be meaningless (per [Go wiki TestComments](https://go.dev/wiki/TestComments#keep-going))
- Fix mock tooling documentation: the codebase uses hand-written mocks via `testify/mock`, not mockery (code generator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)