### PR TITLE
chore: Ignore `net.ErrClosed` when closing SSH connections

### DIFF
--- a/internal/sshhandler/conn_pair.go
+++ b/internal/sshhandler/conn_pair.go
@@ -240,13 +240,11 @@ func (c *SSHConnPair) forwardGlobalRequests(requests <-chan *ssh.Request, dst ss
 }
 
 func (c *SSHConnPair) close() {
-	err := c.downstreamConn.Close()
-	if err != nil {
+	if err := c.downstreamConn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
 		c.logger.Error("Failed to close downstream connection", zap.Error(err))
 	}
 
-	err = c.upstreamConn.Close()
-	if err != nil {
+	if err := c.upstreamConn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
 		c.logger.Error("Failed to close upstream connection", zap.Error(err))
 	}
 }


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #246 

## Changes

Ignore `net.ErrClosed` when closing SSH connections