### PR TITLE
feat: Add validation that allows only one in-cluster K8s upstream

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ var (
 	ErrRequired          = errors.New("required field is missing")
 	ErrInvalidPort       = errors.New("invalid port number")
 	ErrDuplicateUpstream = errors.New("duplicate upstream name")
+	ErrMultipleInCluster = errors.New("only one in-cluster upstream is allowed")
 	ErrInvalidAddress    = errors.New("invalid address format")
 	ErrInvalidSSHKeyType = errors.New("invalid SSH key type")
 	ErrNegativeTTL       = errors.New("TTL must be non-negative")
@@ -252,8 +253,9 @@ func (k *KubernetesConfig) Validate() error {
 		return fmt.Errorf("%w: at least one upstream is required", ErrRequired)
 	}
 
-	// Check for duplicate upstream names within kubernetes
+	// Check for duplicate upstream names and multiple in-cluster upstreams
 	upstreamNames := make(map[string]struct{})
+	hasInCluster := false
 
 	for i, upstream := range k.Upstreams {
 		if err := upstream.Validate(); err != nil {
@@ -265,6 +267,14 @@ func (k *KubernetesConfig) Validate() error {
 		}
 
 		upstreamNames[upstream.Name] = struct{}{}
+
+		if upstream.InCluster {
+			if hasInCluster {
+				return ErrMultipleInCluster
+			}
+
+			hasInCluster = true
+		}
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -270,7 +270,7 @@ func (k *KubernetesConfig) Validate() error {
 
 		if upstream.InCluster {
 			if hasInCluster {
-				return ErrMultipleInCluster
+				return fmt.Errorf("%w: %q", ErrMultipleInCluster, upstream.Name)
 			}
 
 			hasInCluster = true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -400,6 +400,27 @@ func TestKubernetesConfig_Validate(t *testing.T) {
 			wantErr:     true,
 			errContains: "\"prod-k8s\"",
 		},
+		{
+			name: "multiple in-cluster upstreams",
+			k8s: KubernetesConfig{
+				Upstreams: []KubernetesUpstream{
+					{Name: "cluster-a", InCluster: true},
+					{Name: "cluster-b", InCluster: true},
+				},
+			},
+			wantErr:     true,
+			errContains: "only one in-cluster upstream is allowed",
+		},
+		{
+			name: "mixed in-cluster and external",
+			k8s: KubernetesConfig{
+				Upstreams: []KubernetesUpstream{
+					{Name: "local", InCluster: true},
+					{Name: "remote", Address: "10.0.0.1:443", BearerToken: "token"},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -409,10 +409,10 @@ func TestKubernetesConfig_Validate(t *testing.T) {
 				},
 			},
 			wantErr:     true,
-			errContains: "only one in-cluster upstream is allowed",
+			errContains: "only one in-cluster upstream is allowed: \"cluster-b\"",
 		},
 		{
-			name: "mixed in-cluster and external",
+			name: "mixed in-cluster and external cluster",
 			k8s: KubernetesConfig{
 				Upstreams: []KubernetesUpstream{
 					{Name: "local", InCluster: true},


### PR DESCRIPTION
## Changes

- Add `ErrMultipleInCluster` sentinel error
- Add validation in `KubernetesConfig.Validate()` to reject configs with more than one `inCluster: true` upstream
- Add test cases for multiple in-cluster upstreams (error) and mixed in-cluster + external (valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)