### PR TITLE
chore: bump Go toolchain to 1.26.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GOLANG_VERSION: 1.26.0
+  GOLANG_VERSION: 1.26.2
   CADDY_VERSION: 2.10.2
 
 permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 env:
-  GOLANG_VERSION: 1.26.0
+  GOLANG_VERSION: 1.26.2
 
 jobs:
   goreleaser:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.0
+golang 1.26.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Zero-trust access gateway bridging Twingate with L7 resources such as Kubernetes
 
 - **License**: MPL-2.0
 - **Repository**: <https://github.com/Twingate/gateway>
-- **Language**: Go 1.26.0
+- **Language**: Go 1.26.2
 - **Build**: goreleaser, Docker buildx, kind (testing)
 - **Linting**: golangci-lint v2.11.1
 - **Testing**: testify, helm-unittest
@@ -104,7 +104,7 @@ main.go → cmd/start.go → proxy.NewProxy() → proxy.Start()
 ### Setup
 
 ```bash
-asdf install golang 1.26.0
+asdf install golang 1.26.2
 ```
 
 Versions tracked in `.tool-versions`.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gateway
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/MicahParks/jwkset v0.11.0


### PR DESCRIPTION

## Changes

Patch bump of the Go toolchain pin from 1.26.0 → 1.26.2 to pick up upstream fixes. All references to the version live in a small set of files kept in sync:

- `.tool-versions` — asdf golang pin
- `go.mod` — `go` directive
- `.github/workflows/ci.yaml` — `GOLANG_VERSION` env
- `.github/workflows/release.yaml` — `GOLANG_VERSION` env
- `CLAUDE.md` — docs reference

`Makefile`, `.goreleaser.yaml`, and `Dockerfile.goreleaser-debug` pick up the new version automatically (they read from `.tool-versions` / `go.mod`).

## Notes

Patch-only bump — no language or stdlib breaking changes expected. Verified locally with `make lint` (clean) and `make test` (exit 0) against Go 1.26.2.