### PR TITLE
feat: Add `extraObjects` to Helm values file to render custom k8s manifests

### DIFF
--- a/deploy/gateway/templates/extra-objects.yaml
+++ b/deploy/gateway/templates/extra-objects.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraObjects }}
+---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
+{{ tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}

--- a/deploy/gateway/tests/__snapshot__/extra-objects_test.yaml.snap
+++ b/deploy/gateway/tests/__snapshot__/extra-objects_test.yaml.snap
@@ -1,0 +1,33 @@
+should render a single inline manifest and interpolate release values via tpl:
+  1: |
+    apiVersion: v1
+    data:
+      key: value
+    kind: ConfigMap
+    metadata:
+      name: my-config
+      namespace: my-gateway-ns
+should render multiple inline manifests:
+  1: |
+    apiVersion: v1
+    data:
+      key: value
+    kind: ConfigMap
+    metadata:
+      name: cm-one
+  2: |
+    apiVersion: v1
+    data:
+      key: value
+    kind: ConfigMap
+    metadata:
+      name: cm-two
+should render string-form entries and interpolate release values via tpl:
+  1: |
+    apiVersion: v1
+    data:
+      key: value
+    kind: ConfigMap
+    metadata:
+      name: cm-from-string
+      namespace: my-gateway-ns

--- a/deploy/gateway/tests/__snapshot__/extra-objects_test.yaml.snap
+++ b/deploy/gateway/tests/__snapshot__/extra-objects_test.yaml.snap
@@ -7,6 +7,19 @@ should render a single inline manifest and interpolate release values via tpl:
     metadata:
       name: my-config
       namespace: my-gateway-ns
+should render multi-document string-form entries:
+  1: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cm-multi-one
+      namespace: my-gateway-ns
+  2: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cm-multi-two
+      namespace: my-gateway-ns
 should render multiple inline manifests:
   1: |
     apiVersion: v1
@@ -22,12 +35,3 @@ should render multiple inline manifests:
     kind: ConfigMap
     metadata:
       name: cm-two
-should render string-form entries and interpolate release values via tpl:
-  1: |
-    apiVersion: v1
-    data:
-      key: value
-    kind: ConfigMap
-    metadata:
-      name: cm-from-string
-      namespace: my-gateway-ns

--- a/deploy/gateway/tests/extra-objects_test.yaml
+++ b/deploy/gateway/tests/extra-objects_test.yaml
@@ -37,7 +37,7 @@ tests:
             key: value
     asserts:
       - matchSnapshot: {}
-  - it: should render string-form entries and interpolate release values via tpl
+  - it: should render multi-document string-form entries
     release:
       namespace: my-gateway-ns
     set:
@@ -46,9 +46,13 @@ tests:
           apiVersion: v1
           kind: ConfigMap
           metadata:
-            name: cm-from-string
+            name: cm-multi-one
             namespace: {{ .Release.Namespace }}
-          data:
-            key: value
+          ---
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: cm-multi-two
+            namespace: {{ .Release.Namespace }}
     asserts:
       - matchSnapshot: {}

--- a/deploy/gateway/tests/extra-objects_test.yaml
+++ b/deploy/gateway/tests/extra-objects_test.yaml
@@ -1,0 +1,54 @@
+suite: Extra Objects
+templates:
+  - extra-objects.yaml
+tests:
+  - it: should not render any document by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should render a single inline manifest and interpolate release values via tpl
+    release:
+      namespace: my-gateway-ns
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: my-config
+            namespace: '{{ .Release.Namespace }}'
+          data:
+            key: value
+    asserts:
+      - matchSnapshot: {}
+  - it: should render multiple inline manifests
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: cm-one
+          data:
+            key: value
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: cm-two
+          data:
+            key: value
+    asserts:
+      - matchSnapshot: {}
+  - it: should render string-form entries and interpolate release values via tpl
+    release:
+      namespace: my-gateway-ns
+    set:
+      extraObjects:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: cm-from-string
+            namespace: {{ .Release.Namespace }}
+          data:
+            key: value
+    asserts:
+      - matchSnapshot: {}

--- a/deploy/gateway/values.schema.json
+++ b/deploy/gateway/values.schema.json
@@ -594,6 +594,22 @@
         }
       },
       "additionalProperties": false
+    },
+    "extraObjects": {
+      "type": "array",
+      "description": "Extra Kubernetes manifests to render alongside the chart's resources. Each entry may be a YAML object or a string (multi-document YAML); both are passed through `tpl` so release values are interpolated.",
+      "default": [],
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "additionalProperties": true
+          },
+          {
+            "type": "string"
+          }
+        ]
+      }
     }
   }
 }

--- a/deploy/gateway/values.yaml
+++ b/deploy/gateway/values.yaml
@@ -315,3 +315,12 @@ metrics:
       #     severity: warning
       #   annotations:
       #     description: Twingate Gateway authentication failure rate is {{ $value | humanizePercentage }} over the last 2 minutes.
+
+# Extra Kubernetes manifests to render alongside the chart's resources.
+# Each entry is rendered through `tpl`, so release values such as
+# {{ .Release.Namespace }} or {{ .Values.<key> }} are interpolated.
+extraObjects: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: '{{ template "gateway.fullname" . }}-extra'


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: https://github.com/Twingate/gateway/issues/278

## Changes

Add `extraObjects` to Helm values file to render custom k8s manifests