### PR TITLE
feat: Use the address in the HTTP connect message as the upstream address

### DIFF
--- a/deploy/gateway/templates/gateway-configmap.yaml
+++ b/deploy/gateway/templates/gateway-configmap.yaml
@@ -26,24 +26,19 @@ data:
       privateKeyFile: "/etc/gateway/tls/tls.key"
 
     {{- $resourceEnabled := and .Values.twingate.resource .Values.twingate.resource.enabled -}}
-    {{- $k8sEnabled := and .Values.kubernetes .Values.kubernetes.enabled -}}
-    {{- $k8sUpstreams := list -}}
-    {{- if $resourceEnabled -}}
-      {{- $resourceUpstream := dict "name" (include "gateway.resourceInClusterUpstreamName" .) "inCluster" true -}}
-      {{- $k8sUpstreams = append $k8sUpstreams $resourceUpstream -}}
-    {{- end -}}
-    {{- if and $k8sEnabled .Values.kubernetes.upstreams -}}
-      {{- $k8sUpstreams = concat $k8sUpstreams .Values.kubernetes.upstreams -}}
-    {{- end }}
+    {{- $k8sEnabled := and .Values.kubernetes .Values.kubernetes.enabled }}
 
-    {{ if $k8sUpstreams -}}
+    {{ if or $resourceEnabled $k8sEnabled -}}
     kubernetes:
+      {{- if and $k8sEnabled .Values.kubernetes.upstreams }}
       upstreams:
-        {{- $k8sUpstreams | toYaml | nindent 8 }}
+        {{- .Values.kubernetes.upstreams | toYaml | nindent 8 }}
+      {{- else }} {}
+      {{- end }}
     {{ end -}}
 
     {{ with .Values.ssh -}}
-    {{ if and .enabled .upstreams -}}
+    {{ if .enabled -}}
     ssh:
       {{- with .gateway }}
       gateway:
@@ -58,14 +53,14 @@ data:
         userCertificate:
           ttl: {{ .userCertificate.ttl | quote }}
       {{- end }}
+      {{- if and .ca .ca.manual }}
 
-      {{ if and .ca .ca.manual -}}
       ca:
         manual:
           privateKeyFile: "/etc/gateway/ssh/ca-private-key"
-      {{ end -}}
+      {{- end }}
+      {{- if and .ca .ca.vault }}
 
-      {{ if and .ca .ca.vault -}}
       ca:
         vault:
           address: {{ .ca.vault.address | quote }}
@@ -105,9 +100,6 @@ data:
             mount: {{ . | quote }}
             {{- end }}
           {{- end }}
-      {{ end -}}
-
-      upstreams:
-        {{- .upstreams | toYaml | nindent 8 }}
+      {{- end }}
     {{ end -}}
     {{ end -}}

--- a/deploy/gateway/templates/gateway-configmap.yaml
+++ b/deploy/gateway/templates/gateway-configmap.yaml
@@ -28,13 +28,12 @@ data:
     {{- $resourceEnabled := and .Values.twingate.resource .Values.twingate.resource.enabled -}}
     {{- $k8sEnabled := and .Values.kubernetes .Values.kubernetes.enabled }}
 
-    {{ if or $resourceEnabled $k8sEnabled -}}
+    {{ if and $k8sEnabled .Values.kubernetes.upstreams -}}
     kubernetes:
-      {{- if and $k8sEnabled .Values.kubernetes.upstreams }}
       upstreams:
         {{- .Values.kubernetes.upstreams | toYaml | nindent 8 }}
-      {{- else }} {}
-      {{- end }}
+    {{ else if or $resourceEnabled $k8sEnabled -}}
+    kubernetes: {}
     {{ end -}}
 
     {{ with .Values.ssh -}}

--- a/deploy/gateway/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/deploy/gateway/tests/__snapshot__/snapshot_test.yaml.snap
@@ -126,10 +126,7 @@ should render with Kubernetes enabled:
           certificateFile: "/etc/gateway/tls/tls.crt"
           privateKeyFile: "/etc/gateway/tls/tls.key"
 
-        kubernetes:
-          upstreams:
-            - inCluster: true
-              name: k8s api server
+        kubernetes: {}
     kind: ConfigMap
     metadata:
       labels:
@@ -309,10 +306,6 @@ should render with SSH enabled:
               ttl: "24h"
             userCertificate:
               ttl: "5m"
-
-          upstreams:
-            - address: 10.0.0.1:22
-              name: ssh-server
     kind: ConfigMap
     metadata:
       labels:

--- a/deploy/gateway/tests/gateway-configmap_test.yaml
+++ b/deploy/gateway/tests/gateway-configmap_test.yaml
@@ -48,13 +48,7 @@ set:
   kubernetes:
     enabled: true
 tests:
-  - it: should include Kubernetes settings with in-cluster upstream
-    set:
-      kubernetes:
-        enabled: true
-        upstreams:
-          - name: "k8s api server"
-            inCluster: true
+  - it: should render empty kubernetes block (in-cluster mode)
     asserts:
       - equal:
           path: data["config.yaml"]
@@ -74,18 +68,13 @@ tests:
               certificateFile: "/etc/gateway/tls/tls.crt"
               privateKeyFile: "/etc/gateway/tls/tls.key"
 
-            kubernetes:
-              upstreams:
-                - inCluster: true
-                  name: k8s api server
-  - it: should include Kubernetes settings with out-of-cluster upstream
+            kubernetes: {}
+  - it: should include kubernetes upstream creds when provided (external mode for testing)
     set:
       kubernetes:
         enabled: true
         upstreams:
-          - name: "k8s api server"
-            inCluster: false
-            address: "10.0.0.1:443"
+          - name: "external"
             bearerTokenFile: "/token"
             caFile: "/ca.crt"
     asserts:
@@ -109,47 +98,29 @@ tests:
 
             kubernetes:
               upstreams:
-                - address: 10.0.0.1:443
-                  bearerTokenFile: /token
+                - bearerTokenFile: /token
                   caFile: /ca.crt
-                  inCluster: false
-                  name: k8s api server
-  - it: should error when out-of-cluster Kubernetes upstream doesn't have address
+                  name: external
+  - it: should error when external Kubernetes upstream doesn't have bearer token nor bearer token file
     set:
       kubernetes:
         enabled: true
         upstreams:
-          - name: "k8s api server"
-            inCluster: false
-            bearerToken: "token"
+          - name: "external"
             caFile: "/ca.crt"
     asserts:
       - failedTemplate:
-          errorPattern: "at '/kubernetes/upstreams/0': missing property 'address'"
-  - it: should error when out-of-cluster Kubernetes upstream doesn't have bearer token nor bearer token file
+          errorPattern: "'oneOf' failed"
+  - it: should error when external Kubernetes upstream doesn't have CA file
     set:
       kubernetes:
         enabled: true
         upstreams:
-          - name: "k8s api server"
-            inCluster: false
-            address: "10.0.0.1:443"
-            caFile: "/ca.crt"
-    asserts:
-      - failedTemplate:
-          errorPattern: "at '/kubernetes/upstreams/0': missing property 'bearerToken'"
-  - it: should error when out-of-cluster Kubernetes upstream doesn't have CA file
-    set:
-      kubernetes:
-        enabled: true
-        upstreams:
-          - name: "k8s api server"
-            inCluster: false
-            address: "10.0.0.1:443"
+          - name: "external"
             bearerToken: "token"
     asserts:
       - failedTemplate:
-          errorPattern: "at '/kubernetes/upstreams/0': missing property 'caFile'"
+          errorPattern: "missing property 'caFile'"
 ---
 suite: Gateway configmap with Resource
 templates:
@@ -158,7 +129,7 @@ set:
   twingate:
     network: "acme"
 tests:
-  - it: should auto-create inCluster upstream when resource is enabled
+  - it: should render kubernetes block when resource is enabled
     set:
       twingate:
         resource:
@@ -182,82 +153,8 @@ tests:
               certificateFile: "/etc/gateway/tls/tls.crt"
               privateKeyFile: "/etc/gateway/tls/tls.key"
 
-            kubernetes:
-              upstreams:
-                - inCluster: true
-                  name: Local Kubernetes Cluster
-  - it: should use resource.twingate.com/name from extraAnnotations as upstream name
-    set:
-      twingate:
-        resource:
-          enabled: true
-          extraAnnotations:
-            resource.twingate.com/name: "My K8s Cluster"
-    asserts:
-      - equal:
-          path: data["config.yaml"]
-          value: |-
-            twingate:
-              network: "acme"
-              host: "twingate.com"
-
-            port: 8443
-            metricsPort: 9090
-
-            auditLog:
-              flushInterval: 5m
-              flushSizeThreshold: 1e+06
-
-            tls:
-              certificateFile: "/etc/gateway/tls/tls.crt"
-              privateKeyFile: "/etc/gateway/tls/tls.key"
-
-            kubernetes:
-              upstreams:
-                - inCluster: true
-                  name: My K8s Cluster
-  - it: should prepend inCluster upstream before manual upstreams
-    set:
-      twingate:
-        resource:
-          enabled: true
-      kubernetes:
-        enabled: true
-        upstreams:
-          - name: "External Cluster"
-            inCluster: false
-            address: "https://api.k8s.int:443"
-            bearerToken: "token"
-            caFile: "/ca.crt"
-    asserts:
-      - equal:
-          path: data["config.yaml"]
-          value: |-
-            twingate:
-              network: "acme"
-              host: "twingate.com"
-
-            port: 8443
-            metricsPort: 9090
-
-            auditLog:
-              flushInterval: 5m
-              flushSizeThreshold: 1e+06
-
-            tls:
-              certificateFile: "/etc/gateway/tls/tls.crt"
-              privateKeyFile: "/etc/gateway/tls/tls.key"
-
-            kubernetes:
-              upstreams:
-                - inCluster: true
-                  name: Local Kubernetes Cluster
-                - address: https://api.k8s.int:443
-                  bearerToken: token
-                  caFile: /ca.crt
-                  inCluster: false
-                  name: External Cluster
-  - it: should auto-enable kubernetes even when kubernetes.enabled is false
+            kubernetes: {}
+  - it: should still render kubernetes block when kubernetes.enabled is false and resource is enabled
     set:
       twingate:
         resource:
@@ -283,10 +180,7 @@ tests:
               certificateFile: "/etc/gateway/tls/tls.crt"
               privateKeyFile: "/etc/gateway/tls/tls.key"
 
-            kubernetes:
-              upstreams:
-                - inCluster: true
-                  name: Local Kubernetes Cluster
+            kubernetes: {}
 ---
 suite: Gateway configmap with SSH
 templates:
@@ -298,9 +192,6 @@ set:
     enabled: true
     gateway:
       username: "gateway"
-    upstreams:
-      - name: "ssh-server"
-        address: "10.0.0.1:22"
 tests:
   - it: should include SSH without any CA (using auto-generated CA)
     asserts:
@@ -331,10 +222,6 @@ tests:
                   ttl: "24h"
                 userCertificate:
                   ttl: "5m"
-
-              upstreams:
-                - address: 10.0.0.1:22
-                  name: ssh-server
   - it: should include SSH with manual CA
     set:
       ssh:
@@ -373,9 +260,6 @@ tests:
               ca:
                 manual:
                   privateKeyFile: "/etc/gateway/ssh/ca-private-key"
-              upstreams:
-                - address: 10.0.0.1:22
-                  name: ssh-server
   - it: should include SSH with Vault CA
     set:
       ssh:
@@ -443,9 +327,6 @@ tests:
                     role: "gateway-user"
                   upstreamHostCA:
                     mount: "ssh-upstream-host"
-              upstreams:
-                - address: 10.0.0.1:22
-                  name: ssh-server
   - it: should include SSH with Vault AppRole auth
     set:
       ssh:
@@ -497,9 +378,6 @@ tests:
                       secretIDFile: "/etc/gateway/vault/approle/secretId"
                   mount: "ssh-gateway"
                   role: "gateway"
-              upstreams:
-                - address: 10.0.0.1:22
-                  name: ssh-server
   - it: should error when SSH Gateway username is empty
     set:
       ssh:
@@ -517,19 +395,3 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "at '/ssh/ca': maxProperties: got 2, want 1"
-  - it: should error when SSH upstream doesn't have name
-    set:
-      ssh:
-        upstreams:
-          - address: "10.0.0.1:22"
-    asserts:
-      - failedTemplate:
-          errorPattern: "at '/ssh/upstreams/0': missing property 'name'"
-  - it: should error when SSH upstream doesn't have address
-    set:
-      ssh:
-        upstreams:
-          - name: "ssh-server"
-    asserts:
-      - failedTemplate:
-          errorPattern: "at '/ssh/upstreams/0': missing property 'address'"

--- a/deploy/gateway/tests/snapshot_test.yaml
+++ b/deploy/gateway/tests/snapshot_test.yaml
@@ -11,9 +11,6 @@ tests:
     set:
       kubernetes:
         enabled: true
-        upstreams:
-          - name: "k8s api server"
-            inCluster: true
     asserts:
       - matchSnapshot: {}
   - it: should render with SSH enabled
@@ -22,8 +19,5 @@ tests:
         enabled: true
         gateway:
           username: "test"
-        upstreams:
-          - name: "ssh-server"
-            address: "10.0.0.1:22"
     asserts:
       - matchSnapshot: {}

--- a/deploy/gateway/values.schema.json
+++ b/deploy/gateway/values.schema.json
@@ -63,23 +63,14 @@
         },
         "upstreams": {
           "type": "array",
-          "description": "List of Kubernetes API server upstreams.",
+          "description": "External-cluster credentials (testing only). Leave empty to use the pod's service account.",
           "items": {
             "type": "object",
-            "required": ["name"],
+            "required": ["name", "caFile"],
             "properties": {
               "name": {
                 "type": "string",
                 "description": "Name of the upstream."
-              },
-              "inCluster": {
-                "type": "boolean",
-                "description": "Use in-cluster service account for authentication to the local Kubernetes API server.",
-                "default": false
-              },
-              "address": {
-                "type": "string",
-                "description": "Address of the Kubernetes API server (host:port)."
               },
               "bearerToken": {
                 "type": "string",
@@ -94,18 +85,10 @@
                 "description": "Path to CA certificate file for verifying the Kubernetes API server's TLS certificate."
               }
             },
-            "if": {
-              "properties": {
-                "inCluster": { "const": false }
-              }
-            },
-            "then": {
-              "required": ["address", "caFile"],
-              "oneOf": [
-                {"required": ["bearerToken"]},
-                {"required": ["bearerTokenFile"]}
-              ]
-            },
+            "oneOf": [
+              {"required": ["bearerToken"]},
+              {"required": ["bearerTokenFile"]}
+            ],
             "additionalProperties": false
           }
         }
@@ -126,7 +109,7 @@
           "properties": {
             "username": {
               "type": "string",
-              "description": "Default username for upstream SSH connections (can be overridden per-upstream)."
+              "description": "Username used for all upstream SSH connections."
             },
             "key": {
               "type": "object",
@@ -318,29 +301,6 @@
           },
           "maxProperties": 1,
           "additionalProperties": false
-        },
-        "upstreams": {
-          "type": "array",
-          "description": "List of SSH server upstreams.",
-          "items": {
-            "type": "object",
-            "required": ["name", "address"],
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "Name of the upstream."
-              },
-              "address": {
-                "type": "string",
-                "description": "Address of the SSH server (host:port)."
-              },
-              "user": {
-                "type": "string",
-                "description": "Optional username override for this upstream."
-              }
-            },
-            "additionalProperties": false
-          }
         }
       },
       "additionalProperties": false

--- a/deploy/gateway/values.yaml
+++ b/deploy/gateway/values.yaml
@@ -21,15 +21,10 @@ auditLog:
 kubernetes:
   enabled: false
 
+  # External-cluster credentials (testing only). Leave empty to use the pod's
+  # service account (in-cluster mode). Upstream routing always comes from the GAT.
   upstreams: []
-    # # API server of the same cluster (uses service account credentials)
-    # - name: "Local Kubernetes Cluster"
-    #   inCluster: true
-    #
-    # # External API server (requires explicit credentials)
     # - name: "External Kubernetes Cluster"
-    #   inCluster: false
-    #   address: "https://api.k8s.int:443"
     #   # Use bearerToken OR bearerTokenFile
     #   bearerToken: "eyJhbGciOiJSUzI1NiIsImtpZCI6..."
     #   bearerTokenFile: "/var/run/secrets/k8s-token/token"
@@ -39,7 +34,7 @@ ssh:
   enabled: false
 
   gateway:
-    # Default username for upstream SSH connections (can be overridden per-upstream)
+    # Username used for all upstream SSH connections
     username: ""
     key:
       # Key type: ed25519, ecdsa, rsa
@@ -96,11 +91,6 @@ ssh:
     #     role: ""
     #   upstreamHostCA:
     #     mount: ""
-
-  upstreams: []
-    # - name: "SSH Server"
-    #   address: "10.128.0.105:22"
-    #   username: "ubuntu"  # Optional: override gateway.username for this upstream
 
 clusterDomain: cluster.local
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,7 +61,6 @@ type KubernetesConfig struct {
 
 type KubernetesUpstream struct {
 	Name            string `yaml:"name"`
-	Address         string `yaml:"address,omitempty"`
 	BearerToken     string `yaml:"bearerToken,omitempty"`
 	BearerTokenFile string `yaml:"bearerTokenFile,omitempty"`
 	CAFile          string `yaml:"caFile,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"strings"
 	"time"
@@ -19,8 +18,6 @@ var (
 	ErrRequired          = errors.New("required field is missing")
 	ErrInvalidPort       = errors.New("invalid port number")
 	ErrDuplicateUpstream = errors.New("duplicate upstream name")
-	ErrMultipleInCluster = errors.New("only one in-cluster upstream is allowed")
-	ErrInvalidAddress    = errors.New("invalid address format")
 	ErrInvalidSSHKeyType = errors.New("invalid SSH key type")
 	ErrNegativeTTL       = errors.New("TTL must be non-negative")
 )
@@ -64,7 +61,6 @@ type KubernetesConfig struct {
 
 type KubernetesUpstream struct {
 	Name            string `yaml:"name"`
-	InCluster       bool   `yaml:"inCluster,omitempty"`
 	Address         string `yaml:"address,omitempty"`
 	BearerToken     string `yaml:"bearerToken,omitempty"`
 	BearerTokenFile string `yaml:"bearerTokenFile,omitempty"`
@@ -72,9 +68,8 @@ type KubernetesUpstream struct {
 }
 
 type SSHConfig struct {
-	Gateway   SSHGatewayConfig `yaml:"gateway"`
-	CA        SSHCAConfig      `yaml:"ca"`
-	Upstreams []SSHUpstream    `yaml:"upstreams"`
+	Gateway SSHGatewayConfig `yaml:"gateway"`
+	CA      SSHCAConfig      `yaml:"ca"`
 }
 
 type SSHGatewayConfig struct {
@@ -164,12 +159,6 @@ type SSHCAVaultAWSConfig struct {
 	Nonce         string `yaml:"nonce,omitempty"`
 }
 
-type SSHUpstream struct {
-	Name     string `yaml:"name"`
-	Address  string `yaml:"address"`
-	Username string `yaml:"user,omitempty"` // Optional override for username
-}
-
 func newDefaultConfig() *Config {
 	return &Config{
 		Port:        defaultPort,
@@ -249,13 +238,7 @@ func (t *TLSConfig) Validate() error {
 }
 
 func (k *KubernetesConfig) Validate() error {
-	if len(k.Upstreams) == 0 {
-		return fmt.Errorf("%w: at least one upstream is required", ErrRequired)
-	}
-
-	// Check for duplicate upstream names and multiple in-cluster upstreams
 	upstreamNames := make(map[string]struct{})
-	hasInCluster := false
 
 	for i, upstream := range k.Upstreams {
 		if err := upstream.Validate(); err != nil {
@@ -267,14 +250,6 @@ func (k *KubernetesConfig) Validate() error {
 		}
 
 		upstreamNames[upstream.Name] = struct{}{}
-
-		if upstream.InCluster {
-			if hasInCluster {
-				return fmt.Errorf("%w: %q", ErrMultipleInCluster, upstream.Name)
-			}
-
-			hasInCluster = true
-		}
 	}
 
 	return nil
@@ -285,12 +260,8 @@ func (k *KubernetesUpstream) Validate() error {
 		return fmt.Errorf("%w: name", ErrRequired)
 	}
 
-	if !k.InCluster && k.Address == "" {
-		return fmt.Errorf("%w: address is required when inCluster is false", ErrRequired)
-	}
-
-	if !k.InCluster && k.BearerToken == "" && k.BearerTokenFile == "" {
-		return fmt.Errorf("%w: either bearerToken or bearerTokenFile is required when inCluster is false", ErrRequired)
+	if k.BearerToken == "" && k.BearerTokenFile == "" {
+		return fmt.Errorf("%w: either bearerToken or bearerTokenFile is required", ErrRequired)
 	}
 
 	return nil
@@ -303,25 +274,6 @@ func (s *SSHConfig) Validate() error {
 
 	if err := s.CA.Validate(); err != nil {
 		return fmt.Errorf("ca: %w", err)
-	}
-
-	if len(s.Upstreams) == 0 {
-		return fmt.Errorf("%w: at least one upstream is required", ErrRequired)
-	}
-
-	// Check for duplicate upstream names within ssh
-	upstreamNames := make(map[string]struct{})
-
-	for i, upstream := range s.Upstreams {
-		if err := upstream.Validate(); err != nil {
-			return fmt.Errorf("upstreams[%d] (name: %q): %w", i, upstream.Name, err)
-		}
-
-		if _, exists := upstreamNames[upstream.Name]; exists {
-			return fmt.Errorf("%w: %q", ErrDuplicateUpstream, upstream.Name)
-		}
-
-		upstreamNames[upstream.Name] = struct{}{}
 	}
 
 	return nil
@@ -656,43 +608,10 @@ func (v *SSHCAVaultConfig) GetUpstreamHostCAMount() string {
 	return defaultVaultSSHMount
 }
 
-func (s *SSHUpstream) Validate() error {
-	if s.Name == "" {
-		return fmt.Errorf("%w: name", ErrRequired)
-	}
-
-	if s.Address == "" {
-		return fmt.Errorf("%w: address", ErrRequired)
-	}
-
-	if err := validateAddress(s.Address); err != nil {
-		return fmt.Errorf("address: %w", err)
-	}
-
-	return nil
-}
-
 func validatePort(port int, fieldName string) error {
 	// Allow port 0 for dynamic port assignment in testing.
 	if port < 0 || port > 65535 {
 		return fmt.Errorf("%w: %s must be between 0 and 65535", ErrInvalidPort, fieldName)
-	}
-
-	return nil
-}
-
-func validateAddress(address string) error {
-	host, port, err := net.SplitHostPort(address)
-	if err != nil {
-		return fmt.Errorf("%w: %w", ErrInvalidAddress, err)
-	}
-
-	if host == "" {
-		return fmt.Errorf("%w: host cannot be empty", ErrInvalidAddress)
-	}
-
-	if port == "" {
-		return fmt.Errorf("%w: port cannot be empty", ErrInvalidAddress)
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,7 +72,7 @@ type SSHConfig struct {
 }
 
 type SSHGatewayConfig struct {
-	Username        string               `yaml:"username"` // Default username for upstream connections
+	Username        string               `yaml:"username"` // username for upstream connections
 	Key             SSHKeyConfig         `yaml:"key"`
 	HostCertificate SSHCertificateConfig `yaml:"hostCertificate"`
 	UserCertificate SSHCertificateConfig `yaml:"userCertificate"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,10 +25,7 @@ auditLog:
 tls:
   certificateFile: "tls.crt"
   privateKeyFile: "tls.key"
-kubernetes:
-  upstreams:
-    - name: "k8s-cluster"
-      inCluster: true
+kubernetes: {}
 `
 
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
@@ -44,12 +41,9 @@ kubernetes:
 	assert.Equal(t, 8443, cfg.Port)
 	assert.Equal(t, 9090, cfg.MetricsPort)
 
-	// Verify Kubernetes upstream parsed correctly
 	require.NotNil(t, cfg.Kubernetes)
-	assert.Len(t, cfg.Kubernetes.Upstreams, 1)
+	assert.Empty(t, cfg.Kubernetes.Upstreams)
 	assert.Nil(t, cfg.SSH)
-	assert.Equal(t, "k8s-cluster", cfg.Kubernetes.Upstreams[0].Name)
-	assert.True(t, cfg.Kubernetes.Upstreams[0].InCluster)
 }
 
 func TestLoad_SSH(t *testing.T) {
@@ -76,9 +70,6 @@ ssh:
   ca:
     manual:
       privateKeyFile: "ca.key"
-  upstreams:
-    - name: "ssh-server"
-      address: "10.0.0.1:22"
 `
 
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
@@ -89,12 +80,8 @@ ssh:
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	// Verify SSH upstream parsed correctly
 	assert.Nil(t, cfg.Kubernetes)
 	require.NotNil(t, cfg.SSH)
-	assert.Len(t, cfg.SSH.Upstreams, 1)
-	assert.Equal(t, "ssh-server", cfg.SSH.Upstreams[0].Name)
-	assert.Equal(t, "10.0.0.1:22", cfg.SSH.Upstreams[0].Address)
 
 	// Verify SSH config
 	assert.Equal(t, "ed25519", cfg.SSH.Gateway.Key.Type)
@@ -132,9 +119,6 @@ ssh:
         role: "gateway"
       upstreamHostCA:
         mount: "ssh-upstream-host"
-  upstreams:
-    - name: "ssh-server"
-      address: "10.0.0.1:22"
 `
 
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
@@ -163,10 +147,7 @@ twingate:
 tls:
   certificateFile: "tls.crt"
   privateKeyFile: "tls.key"
-kubernetes:
-  upstreams:
-    - name: "k8s-cluster"
-      inCluster: true
+kubernetes: {}
 `
 
 	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
@@ -233,11 +214,7 @@ func TestConfig_Validate(t *testing.T) {
 					CertificateFile: "tls.crt",
 					PrivateKeyFile:  "tls.key",
 				},
-				Kubernetes: &KubernetesConfig{
-					Upstreams: []KubernetesUpstream{
-						{Name: "k8s", InCluster: true},
-					},
-				},
+				Kubernetes: &KubernetesConfig{},
 			},
 			wantErr: false,
 		},
@@ -250,11 +227,7 @@ func TestConfig_Validate(t *testing.T) {
 					CertificateFile: "tls.crt",
 					PrivateKeyFile:  "tls.key",
 				},
-				Kubernetes: &KubernetesConfig{
-					Upstreams: []KubernetesUpstream{
-						{Name: "k8s", InCluster: true},
-					},
-				},
+				Kubernetes: &KubernetesConfig{},
 			},
 			wantErr:     true,
 			errContains: "twingate.network",
@@ -269,11 +242,7 @@ func TestConfig_Validate(t *testing.T) {
 					CertificateFile: "tls.crt",
 					PrivateKeyFile:  "tls.key",
 				},
-				Kubernetes: &KubernetesConfig{
-					Upstreams: []KubernetesUpstream{
-						{Name: "k8s", InCluster: true},
-					},
-				},
+				Kubernetes: &KubernetesConfig{},
 			},
 			wantErr:     true,
 			errContains: "port must be between",
@@ -288,11 +257,7 @@ func TestConfig_Validate(t *testing.T) {
 					CertificateFile: "tls.crt",
 					PrivateKeyFile:  "tls.key",
 				},
-				Kubernetes: &KubernetesConfig{
-					Upstreams: []KubernetesUpstream{
-						{Name: "k8s", InCluster: true},
-					},
-				},
+				Kubernetes: &KubernetesConfig{},
 			},
 			wantErr:     true,
 			errContains: "metricsPort must be between",
@@ -373,53 +338,31 @@ func TestKubernetesConfig_Validate(t *testing.T) {
 		errContains string
 	}{
 		{
-			name: "valid",
+			name: "valid with external upstream",
 			k8s: KubernetesConfig{
 				Upstreams: []KubernetesUpstream{
-					{Name: "k8s", InCluster: true},
+					{Name: "k8s", BearerToken: "token"},
 				},
 			},
 			wantErr: false,
 		},
 		{
-			name: "no upstreams",
+			name: "no upstreams is allowed (in-cluster default)",
 			k8s: KubernetesConfig{
 				Upstreams: []KubernetesUpstream{},
 			},
-			wantErr:     true,
-			errContains: "at least one upstream is required",
+			wantErr: false,
 		},
 		{
 			name: "duplicate upstream names",
 			k8s: KubernetesConfig{
 				Upstreams: []KubernetesUpstream{
-					{Name: "prod-k8s", InCluster: true},
-					{Name: "prod-k8s", InCluster: true},
+					{Name: "prod-k8s", BearerToken: "token"},
+					{Name: "prod-k8s", BearerToken: "token"},
 				},
 			},
 			wantErr:     true,
 			errContains: "\"prod-k8s\"",
-		},
-		{
-			name: "multiple in-cluster upstreams",
-			k8s: KubernetesConfig{
-				Upstreams: []KubernetesUpstream{
-					{Name: "cluster-a", InCluster: true},
-					{Name: "cluster-b", InCluster: true},
-				},
-			},
-			wantErr:     true,
-			errContains: "only one in-cluster upstream is allowed: \"cluster-b\"",
-		},
-		{
-			name: "mixed in-cluster and external cluster",
-			k8s: KubernetesConfig{
-				Upstreams: []KubernetesUpstream{
-					{Name: "local", InCluster: true},
-					{Name: "remote", Address: "10.0.0.1:443", BearerToken: "token"},
-				},
-			},
-			wantErr: false,
 		},
 	}
 
@@ -444,43 +387,30 @@ func TestKubernetesUpstream_Validate(t *testing.T) {
 		errContains string
 	}{
 		{
-			name:     "valid in-cluster",
-			upstream: KubernetesUpstream{Name: "k8s", InCluster: true},
-			wantErr:  false,
-		},
-		{
-			name: "valid external with token",
+			name: "valid with token",
 			upstream: KubernetesUpstream{
 				Name:        "k8s",
-				Address:     "10.0.0.1:443",
 				BearerToken: "token",
 			},
 			wantErr: false,
 		},
 		{
-			name: "valid external with token file",
+			name: "valid with token file",
 			upstream: KubernetesUpstream{
 				Name:            "k8s",
-				Address:         "10.0.0.1:443",
 				BearerTokenFile: "/path/to/token",
 			},
 			wantErr: false,
 		},
 		{
 			name:        "missing name",
-			upstream:    KubernetesUpstream{InCluster: true},
+			upstream:    KubernetesUpstream{BearerToken: "token"},
 			wantErr:     true,
 			errContains: "name",
 		},
 		{
-			name:        "external missing address",
-			upstream:    KubernetesUpstream{Name: "k8s", InCluster: false, BearerToken: "token"},
-			wantErr:     true,
-			errContains: "address is required",
-		},
-		{
-			name:        "external missing auth",
-			upstream:    KubernetesUpstream{Name: "k8s", InCluster: false, Address: "10.0.0.1:443"},
+			name:        "missing auth",
+			upstream:    KubernetesUpstream{Name: "k8s"},
 			wantErr:     true,
 			errContains: "bearerToken or bearerTokenFile is required",
 		},
@@ -517,9 +447,6 @@ func TestSSHConfig_Validate(t *testing.T) {
 					},
 				},
 				CA: SSHCAConfig{},
-				Upstreams: []SSHUpstream{
-					{Name: "prod", Address: "10.0.0.1:22"},
-				},
 			},
 			wantErr: false,
 		},
@@ -537,9 +464,6 @@ func TestSSHConfig_Validate(t *testing.T) {
 						PrivateKeyFile: "ca.key",
 					},
 				},
-				Upstreams: []SSHUpstream{
-					{Name: "prod", Address: "10.0.0.1:22"},
-				},
 			},
 			wantErr: false,
 		},
@@ -555,9 +479,6 @@ func TestSSHConfig_Validate(t *testing.T) {
 						Role:    "gateway",
 					},
 				},
-				Upstreams: []SSHUpstream{
-					{Name: "prod", Address: "10.0.0.1:22"},
-				},
 			},
 			wantErr: false,
 		},
@@ -567,9 +488,6 @@ func TestSSHConfig_Validate(t *testing.T) {
 				Gateway: SSHGatewayConfig{
 					Username: "gateway",
 					Key:      SSHKeyConfig{Type: "invalid-type"},
-				},
-				Upstreams: []SSHUpstream{
-					{Name: "prod", Address: "10.0.0.1:22"},
 				},
 			},
 			wantErr:     true,
@@ -591,9 +509,6 @@ func TestSSHConfig_Validate(t *testing.T) {
 						Role:    "gateway",
 					},
 				},
-				Upstreams: []SSHUpstream{
-					{Name: "prod", Address: "10.0.0.1:22"},
-				},
 			},
 			wantErr:     true,
 			errContains: "only one of 'manual' or 'vault'",
@@ -606,9 +521,6 @@ func TestSSHConfig_Validate(t *testing.T) {
 				},
 				CA: SSHCAConfig{
 					Manual: &SSHCAManualConfig{},
-				},
-				Upstreams: []SSHUpstream{
-					{Name: "prod", Address: "10.0.0.1:22"},
 				},
 			},
 			wantErr:     true,
@@ -625,90 +537,15 @@ func TestSSHConfig_Validate(t *testing.T) {
 						Role: "gateway",
 					},
 				},
-				Upstreams: []SSHUpstream{
-					{Name: "prod", Address: "10.0.0.1:22"},
-				},
 			},
 			wantErr:     true,
 			errContains: "server",
-		},
-		{
-			name: "no upstreams",
-			ssh: SSHConfig{
-				Gateway: SSHGatewayConfig{
-					Username: "gateway",
-				},
-				CA:        SSHCAConfig{},
-				Upstreams: []SSHUpstream{},
-			},
-			wantErr:     true,
-			errContains: "at least one upstream is required",
-		},
-		{
-			name: "duplicate upstream names",
-			ssh: SSHConfig{
-				Gateway: SSHGatewayConfig{
-					Username: "gateway",
-				},
-				CA: SSHCAConfig{},
-				Upstreams: []SSHUpstream{
-					{Name: "prod-ssh", Address: "10.0.0.1:22"},
-					{Name: "prod-ssh", Address: "10.0.0.2:22"},
-				},
-			},
-			wantErr:     true,
-			errContains: "\"prod-ssh\"",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.ssh.Validate()
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errContains)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestSSHUpstream_Validate(t *testing.T) {
-	tests := []struct {
-		name        string
-		upstream    SSHUpstream
-		wantErr     bool
-		errContains string
-	}{
-		{
-			name:     "valid",
-			upstream: SSHUpstream{Name: "ssh", Address: "10.0.0.1:22"},
-			wantErr:  false,
-		},
-		{
-			name:        "missing name",
-			upstream:    SSHUpstream{Address: "10.0.0.1:22"},
-			wantErr:     true,
-			errContains: "name",
-		},
-		{
-			name:        "missing address",
-			upstream:    SSHUpstream{Name: "ssh"},
-			wantErr:     true,
-			errContains: "address",
-		},
-		{
-			name:        "invalid address format",
-			upstream:    SSHUpstream{Name: "ssh", Address: "invalid"},
-			wantErr:     true,
-			errContains: "address",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.upstream.Validate()
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errContains)
@@ -1172,79 +1009,6 @@ func TestSSHCAVaultAWSConfig_Validate(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errContains)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestValidateAddress(t *testing.T) {
-	tests := []struct {
-		name        string
-		address     string
-		wantErr     bool
-		errContains string
-	}{
-		{
-			name:    "valid IPv4 with port",
-			address: "192.168.1.1:22",
-			wantErr: false,
-		},
-		{
-			name:    "valid hostname with port",
-			address: "example.com:443",
-			wantErr: false,
-		},
-		{
-			name:    "valid IPv6 with port",
-			address: "[2001:db8::1]:8080",
-			wantErr: false,
-		},
-		{
-			name:    "valid localhost with port",
-			address: "localhost:3000",
-			wantErr: false,
-		},
-		{
-			name:        "missing port",
-			address:     "192.168.1.1",
-			wantErr:     true,
-			errContains: "missing port in address",
-		},
-		{
-			name:        "missing host",
-			address:     ":8080",
-			wantErr:     true,
-			errContains: "host cannot be empty",
-		},
-		{
-			name:        "empty port",
-			address:     "example.com:",
-			wantErr:     true,
-			errContains: "port cannot be empty",
-		},
-		{
-			name:        "empty string",
-			address:     "",
-			wantErr:     true,
-			errContains: "missing port in address",
-		},
-		{
-			name:        "only colon",
-			address:     ":",
-			wantErr:     true,
-			errContains: "host cannot be empty",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateAddress(tt.address)
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errContains)
-				assert.ErrorIs(t, err, ErrInvalidAddress)
 			} else {
 				require.NoError(t, err)
 			}

--- a/internal/httphandler/config.go
+++ b/internal/httphandler/config.go
@@ -40,13 +40,6 @@ func NewConfig(auditLogConfig *config.AuditLogConfig, k8sConfig *config.Kubernet
 	cfg.bearerTokenFile = upstream.BearerTokenFile
 	cfg.caFile = upstream.CAFile
 
-	if upstream.Address != "" {
-		logger.Warn("kubernetes.upstreams[].address is ignored; upstream routing comes from the GAT",
-			zap.String("upstream", upstream.Name),
-			zap.String("address", upstream.Address),
-		)
-	}
-
 	return cfg, nil
 }
 

--- a/internal/httphandler/config.go
+++ b/internal/httphandler/config.go
@@ -12,43 +12,53 @@ import (
 )
 
 type Config struct {
-	auditLog *config.AuditLogConfig
-	registry *prometheus.Registry
-	upstream *config.KubernetesUpstream
-	logger   *zap.Logger
+	auditLog        *config.AuditLogConfig
+	registry        *prometheus.Registry
+	bearerToken     string
+	bearerTokenFile string
+	caFile          string
+	logger          *zap.Logger
 }
 
 func NewConfig(auditLogConfig *config.AuditLogConfig, k8sConfig *config.KubernetesConfig, registry *prometheus.Registry, logger *zap.Logger) (*Config, error) {
-	// Multiple upstreams support will be added soon!
-	upstream, err := GetInClusterConfig(&k8sConfig.Upstreams[0])
-	if err != nil {
-		return nil, err
-	}
-
-	return &Config{
+	cfg := &Config{
 		auditLog: auditLogConfig,
 		registry: registry,
-		upstream: upstream,
 		logger:   logger,
-	}, nil
+	}
+
+	if len(k8sConfig.Upstreams) == 0 {
+		if err := cfg.loadInClusterCredentials(); err != nil {
+			return nil, err
+		}
+
+		return cfg, nil
+	}
+
+	upstream := k8sConfig.Upstreams[0]
+	cfg.bearerToken = upstream.BearerToken
+	cfg.bearerTokenFile = upstream.BearerTokenFile
+	cfg.caFile = upstream.CAFile
+
+	if upstream.Address != "" {
+		logger.Warn("kubernetes.upstreams[].address is ignored; upstream routing comes from the GAT",
+			zap.String("upstream", upstream.Name),
+			zap.String("address", upstream.Address),
+		)
+	}
+
+	return cfg, nil
 }
 
-const inClusterKubernetesServiceAddress = "kubernetes.default.svc.cluster.local:443"
-
-func GetInClusterConfig(upstream *config.KubernetesUpstream) (*config.KubernetesUpstream, error) {
-	if !upstream.InCluster {
-		return upstream, nil
-	}
-
-	inClusterConfig, err := rest.InClusterConfig()
+func (c *Config) loadInClusterCredentials() error {
+	inCluster, err := rest.InClusterConfig()
 	if err != nil {
-		return upstream, err
+		return err
 	}
 
-	upstream.Address = inClusterKubernetesServiceAddress
-	upstream.BearerToken = inClusterConfig.BearerToken
-	upstream.BearerTokenFile = inClusterConfig.BearerTokenFile
-	upstream.CAFile = inClusterConfig.CAFile
+	c.bearerToken = inCluster.BearerToken
+	c.bearerTokenFile = inCluster.BearerTokenFile
+	c.caFile = inCluster.CAFile
 
-	return upstream, nil
+	return nil
 }

--- a/internal/httphandler/config_test.go
+++ b/internal/httphandler/config_test.go
@@ -21,12 +21,11 @@ func TestNewConfig(t *testing.T) {
 	}
 	registry := prometheus.NewRegistry()
 
-	t.Run("Success with external upstream credentials (address ignored)", func(t *testing.T) {
+	t.Run("Success with external upstream credentials", func(t *testing.T) {
 		k8sConfig := &config.KubernetesConfig{
 			Upstreams: []config.KubernetesUpstream{
 				{
 					Name:        "test-upstream",
-					Address:     "k8s.example.com:6443",
 					BearerToken: "test-token",
 					CAFile:      "/path/to/ca.crt",
 				},

--- a/internal/httphandler/config_test.go
+++ b/internal/httphandler/config_test.go
@@ -21,16 +21,14 @@ func TestNewConfig(t *testing.T) {
 	}
 	registry := prometheus.NewRegistry()
 
-	t.Run("Success with non in-cluster upstream", func(t *testing.T) {
+	t.Run("Success with external upstream credentials (address ignored)", func(t *testing.T) {
 		k8sConfig := &config.KubernetesConfig{
 			Upstreams: []config.KubernetesUpstream{
 				{
-					Name:            "test-upstream",
-					InCluster:       false,
-					Address:         "k8s.example.com:6443",
-					BearerToken:     "test-token",
-					BearerTokenFile: "",
-					CAFile:          "/path/to/ca.crt",
+					Name:        "test-upstream",
+					Address:     "k8s.example.com:6443",
+					BearerToken: "test-token",
+					CAFile:      "/path/to/ca.crt",
 				},
 			},
 		}
@@ -42,21 +40,15 @@ func TestNewConfig(t *testing.T) {
 
 		assert.Equal(t, auditLogConfig, cfg.auditLog)
 		assert.Equal(t, registry, cfg.registry)
-		assert.Equal(t, &k8sConfig.Upstreams[0], cfg.upstream)
+		assert.Equal(t, "test-token", cfg.bearerToken)
+		assert.Empty(t, cfg.bearerTokenFile)
+		assert.Equal(t, "/path/to/ca.crt", cfg.caFile)
 	})
 
-	t.Run("Error when GetInClusterConfig fails", func(t *testing.T) {
-		// Clear environment to force in-cluster config to fail
+	t.Run("Error when in-cluster discovery fails (no upstreams)", func(t *testing.T) {
 		t.Setenv("KUBERNETES_SERVICE_HOST", "")
 
-		k8sConfig := &config.KubernetesConfig{
-			Upstreams: []config.KubernetesUpstream{
-				{
-					Name:      "in-cluster-fail",
-					InCluster: true,
-				},
-			},
-		}
+		k8sConfig := &config.KubernetesConfig{}
 
 		cfg, err := NewConfig(auditLogConfig, k8sConfig, registry, zap.NewNop())
 
@@ -64,83 +56,4 @@ func TestNewConfig(t *testing.T) {
 		assert.Contains(t, err.Error(), "unable to load in-cluster configuration")
 		assert.Nil(t, cfg)
 	})
-}
-
-func TestGetInClusterConfig(t *testing.T) {
-	tests := []struct {
-		name          string
-		upstream      *config.KubernetesUpstream
-		setupEnv      func(t *testing.T)
-		expectError   bool
-		errorContains string
-		validate      func(t *testing.T, result *config.KubernetesUpstream)
-	}{
-		{
-			name: "Non in-cluster upstream returns unchanged",
-			upstream: &config.KubernetesUpstream{
-				Name:        "external",
-				InCluster:   false,
-				Address:     "k8s.internal:6443",
-				BearerToken: "external-token",
-				CAFile:      "/path/to/ca.crt",
-			},
-			setupEnv:    func(_ *testing.T) {},
-			expectError: false,
-			validate: func(t *testing.T, result *config.KubernetesUpstream) {
-				t.Helper()
-
-				assert.Equal(t, "external", result.Name)
-				assert.False(t, result.InCluster)
-				assert.Equal(t, "k8s.internal:6443", result.Address)
-				assert.Equal(t, "external-token", result.BearerToken)
-				assert.Equal(t, "/path/to/ca.crt", result.CAFile)
-			},
-		},
-		{
-			name: "In-cluster upstream preserves original upstream on error",
-			upstream: &config.KubernetesUpstream{
-				Name:      "in-cluster-preserve",
-				InCluster: true,
-				Address:   "original-address",
-			},
-			setupEnv: func(t *testing.T) {
-				t.Helper()
-
-				t.Setenv("KUBERNETES_SERVICE_HOST", "0.0.0.0")
-			},
-			expectError:   true,
-			errorContains: "unable to load in-cluster configuration",
-			validate: func(t *testing.T, result *config.KubernetesUpstream) {
-				t.Helper()
-
-				// Even on error, the function returns the original upstream
-				assert.Equal(t, "in-cluster-preserve", result.Name)
-				assert.Equal(t, "original-address", result.Address)
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.setupEnv(t)
-
-			result, err := GetInClusterConfig(tt.upstream)
-
-			if tt.expectError {
-				require.Error(t, err)
-
-				if tt.errorContains != "" {
-					assert.Contains(t, err.Error(), tt.errorContains)
-				}
-			} else {
-				require.NoError(t, err)
-			}
-
-			require.NotNil(t, result)
-
-			if tt.validate != nil {
-				tt.validate(t, result)
-			}
-		})
-	}
 }

--- a/internal/httphandler/http_proxy.go
+++ b/internal/httphandler/http_proxy.go
@@ -44,7 +44,7 @@ func NewProxy(cfg Config) (*Proxy, error) {
 	logger := cfg.logger
 
 	// create TLS configuration for upstream
-	caCert, err := os.ReadFile(cfg.upstream.CAFile)
+	caCert, err := os.ReadFile(cfg.caFile)
 	if err != nil {
 		return nil, err
 	}
@@ -60,8 +60,8 @@ func NewProxy(cfg Config) (*Proxy, error) {
 	}
 
 	transport, err := k8stransport.NewBearerAuthWithRefreshRoundTripper(
-		cfg.upstream.BearerToken,
-		cfg.upstream.BearerTokenFile,
+		cfg.bearerToken,
+		cfg.bearerTokenFile,
 		&http.Transport{
 			TLSClientConfig: upstreamTLSConfig,
 		},
@@ -81,7 +81,7 @@ func NewProxy(cfg Config) (*Proxy, error) {
 
 			targetURL := &url.URL{
 				Scheme: "https",
-				Host:   cfg.upstream.Address,
+				Host:   conn.GetAddress(),
 			}
 			r.SetURL(targetURL)
 

--- a/internal/httphandler/http_proxy_test.go
+++ b/internal/httphandler/http_proxy_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	"gateway/internal/config"
 	"gateway/internal/connect"
 	"gateway/internal/token"
 	"gateway/test/data"
@@ -65,13 +64,10 @@ func TestProxy_ForwardRequest(t *testing.T) {
 
 	// Create HTTP proxy
 	cfg := Config{
-		registry: prometheus.NewRegistry(),
-		upstream: &config.KubernetesUpstream{
-			Address:     apiServerAddress,
-			CAFile:      "../../test/data/api_server/tls.crt",
-			BearerToken: "mock-token",
-		},
-		logger: zap.NewNop(),
+		registry:    prometheus.NewRegistry(),
+		caFile:      "../../test/data/api_server/tls.crt",
+		bearerToken: "mock-token",
+		logger:      zap.NewNop(),
 	}
 
 	httpProxy, err := NewProxy(cfg)
@@ -95,7 +91,7 @@ func TestProxy_ForwardRequest(t *testing.T) {
 			Username: "user@acme.com",
 			Groups:   []string{"Everyone", "Engineering"},
 		},
-		Resource: token.Resource{ID: "resource-1", Address: apiServerAddress},
+		Resource: token.Resource{ID: "resource-1", Type: token.ResourceTypeKubernetes, Address: apiServerAddress},
 	}
 
 	// Use NewProxyConn to properly initialize internal fields (tracker)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -51,12 +51,6 @@ var fullConfig = gatewayconfig.Config{
 			UserCertificate: gatewayconfig.SSHCertificateConfig{},
 		},
 		CA: gatewayconfig.SSHCAConfig{},
-		Upstreams: []gatewayconfig.SSHUpstream{
-			{
-				Name:    "ssh-server",
-				Address: "127.0.0.1:22",
-			},
-		},
 	},
 }
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -37,7 +37,6 @@ var fullConfig = gatewayconfig.Config{
 		Upstreams: []gatewayconfig.KubernetesUpstream{
 			{
 				Name:        "k8s-cluster",
-				Address:     "127.0.0.1:6443",
 				BearerToken: "token",
 				CAFile:      "../../test/data/api_server/tls.crt",
 			},

--- a/internal/sshhandler/config.go
+++ b/internal/sshhandler/config.go
@@ -54,12 +54,12 @@ type upstream struct {
 }
 
 type Config struct {
-	caConfig           *caConfig
-	gatewaySigner      ssh.Signer
-	gatewayPublicKey   ssh.PublicKey
-	hostCertTTL        time.Duration
-	userCertTTL        time.Duration
-	upstreamsByAddress map[string]upstream
+	caConfig         *caConfig
+	gatewaySigner    ssh.Signer
+	gatewayPublicKey ssh.PublicKey
+	hostCertTTL      time.Duration
+	userCertTTL      time.Duration
+	gatewayUsername  string
 
 	auditLog *config.AuditLogConfig
 	logger   *zap.Logger
@@ -97,27 +97,13 @@ func NewConfig(auditLogConfig *config.AuditLogConfig, sshCfg *config.SSHConfig, 
 		userCertTTL = defaultUserCertTTL
 	}
 
-	upstreams := make(map[string]upstream, len(sshCfg.Upstreams))
-	for _, u := range sshCfg.Upstreams {
-		// Use upstream-specific username if provided, otherwise use gateway default
-		username := sshCfg.Gateway.Username
-		if u.Username != "" {
-			username = u.Username
-		}
-
-		upstreams[u.Address] = upstream{
-			address:  u.Address,
-			username: username,
-		}
-	}
-
 	return &Config{
-		caConfig:           caConfig,
-		gatewaySigner:      gatewaySigner,
-		gatewayPublicKey:   gatewayPublicKey,
-		hostCertTTL:        hostCertTTL,
-		userCertTTL:        userCertTTL,
-		upstreamsByAddress: upstreams,
+		caConfig:         caConfig,
+		gatewaySigner:    gatewaySigner,
+		gatewayPublicKey: gatewayPublicKey,
+		hostCertTTL:      hostCertTTL,
+		userCertTTL:      userCertTTL,
+		gatewayUsername:  sshCfg.Gateway.Username,
 
 		auditLog: auditLogConfig,
 		logger:   logger,

--- a/internal/sshhandler/config_test.go
+++ b/internal/sshhandler/config_test.go
@@ -21,7 +21,6 @@ func TestNewConfig_Success(t *testing.T) {
 		FlushSizeThreshold: 2000,
 	}
 
-	user1 := "user1"
 	sshConfig := &gatewayconfig.SSHConfig{
 		Gateway: gatewayconfig.SSHGatewayConfig{
 			Username:        "gateway",
@@ -30,30 +29,14 @@ func TestNewConfig_Success(t *testing.T) {
 			UserCertificate: gatewayconfig.SSHCertificateConfig{TTL: 5 * time.Minute},
 		},
 		CA: gatewayconfig.SSHCAConfig{},
-		Upstreams: []gatewayconfig.SSHUpstream{
-			{Name: "server1", Address: "10.0.0.1:22", Username: user1},
-			{Name: "server2", Address: "10.0.0.2:22"},
-		},
 	}
 
 	config, err := NewConfig(auditLog, sshConfig, zap.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, config)
 
-	// Verify config
 	assert.Equal(t, auditLog, config.auditLog)
-	assert.Len(t, config.upstreamsByAddress, 2)
-
-	// Verify upstreams
-	server1, ok := config.upstreamsByAddress["10.0.0.1:22"]
-	require.True(t, ok)
-	assert.Equal(t, "10.0.0.1:22", server1.address)
-	assert.Equal(t, "user1", server1.username)
-
-	server2, ok := config.upstreamsByAddress["10.0.0.2:22"]
-	require.True(t, ok)
-	assert.Equal(t, "10.0.0.2:22", server2.address)
-	assert.Equal(t, "gateway", server2.username) // Uses gateway default username
+	assert.Equal(t, "gateway", config.gatewayUsername)
 }
 
 func TestNewConfig_WithManualCA(t *testing.T) {
@@ -71,7 +54,6 @@ func TestNewConfig_WithManualCA(t *testing.T) {
 				PrivateKeyFile: "../../test/data/ssh/ca/ca",
 			},
 		},
-		Upstreams: []gatewayconfig.SSHUpstream{{Name: "test", Address: "localhost:22"}},
 	}
 
 	config, err := NewConfig(auditLog, sshConfig, zap.NewNop())
@@ -94,7 +76,6 @@ func TestNewConfig_InvalidManualCA(t *testing.T) {
 				PrivateKeyFile: "nonexistent.key",
 			},
 		},
-		Upstreams: []gatewayconfig.SSHUpstream{{Name: "test", Address: "localhost:22"}},
 	}
 
 	config, err := NewConfig(auditLog, sshConfig, zap.NewNop())

--- a/internal/sshhandler/proxy.go
+++ b/internal/sshhandler/proxy.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"net"
 	"sync"
 	"time"
@@ -69,10 +68,7 @@ func (f *defaultConnPairFactory) NewConnPair(logger *zap.Logger, sshCtx *sshCont
 	return NewSSHConnPair(logger, sshCtx, downstreamConn, downstreamChannels, downstreamRequests, upstreamConn, upstreamChannels, upstreamRequests)
 }
 
-var (
-	errUnknownUpstream = errors.New("unknown upstream")
-	errShuttingDown    = errors.New("shutting down")
-)
+var errShuttingDown = errors.New("shutting down")
 
 // Timeout for connecting to the upstream SSH server.
 const upstreamConnTimeout = 10 * time.Second
@@ -203,13 +199,9 @@ func (p *SSHProxy) serveConn(ctx context.Context, conn connect.Conn) error {
 		zap.String("conn_id", conn.GetID()),
 	)
 
-	upstream, exists := p.config.upstreamsByAddress[conn.GetAddress()]
-	if !exists {
-		logger.Error("Unknown SSH upstream", zap.String("address", conn.GetAddress()))
-
-		_ = conn.Close()
-
-		return fmt.Errorf("%w: %s", errUnknownUpstream, conn.GetAddress())
+	upstream := upstream{
+		address:  conn.GetAddress(),
+		username: p.config.gatewayUsername,
 	}
 
 	// Give the proxyconn.ProxyConn TCP connection to the SSH server to start the SSH handshake

--- a/internal/sshhandler/proxy_test.go
+++ b/internal/sshhandler/proxy_test.go
@@ -26,9 +26,6 @@ var sshConfig = &gatewayconfig.SSHConfig{
 	Gateway: gatewayconfig.SSHGatewayConfig{
 		Username: "test-user",
 	},
-	Upstreams: []gatewayconfig.SSHUpstream{
-		{Name: "upstream", Address: upstreamAddress},
-	},
 }
 
 // Mock SSH connection factory, used for creating downstream and upstream SSH connections.
@@ -139,12 +136,12 @@ func (m *mockProtocolListener) Addr() net.Addr {
 }
 
 // Helper to create a mock ProxyConn for testing.
-func newTestProxyConn(claims *token.GATClaims, address string) *mockProxyConn {
+func newTestProxyConn(claims *token.GATClaims) *mockProxyConn {
 	mockProxyNetConn := &mockProxyNetConn{}
 	proxyConn := &connect.ProxyConn{
 		Conn:    mockProxyNetConn,
 		Claims:  claims,
-		Address: address,
+		Address: upstreamAddress,
 		ID:      "test-id",
 	}
 	mockProxyConn := &mockProxyConn{
@@ -226,7 +223,7 @@ func TestSSHProxy_Start_Success(t *testing.T) {
 
 	// Create a test proxy connection to be served
 	claims := &token.GATClaims{}
-	testConn := newTestProxyConn(claims, upstreamAddress)
+	testConn := newTestProxyConn(claims)
 	closed := make(chan struct{})
 
 	testConn.On("Close").Return(nil).Run(func(_ mock.Arguments) {
@@ -308,7 +305,7 @@ func TestSSHProxy_ServeConn_Success(t *testing.T) {
 
 	// Create a test proxy connection to be served
 	claims := &token.GATClaims{}
-	testConn := newTestProxyConn(claims, upstreamAddress)
+	testConn := newTestProxyConn(claims)
 
 	// Mock NewServerConn to return a new downstream SSH connection
 	downstreamSSHConn := &mockSSHConn{}
@@ -389,45 +386,6 @@ func TestSSHProxy_ServeConn_Success(t *testing.T) {
 	testConn.AssertExpectations(t)
 }
 
-func TestSSHProxy_ServeConn_UnknownUpstream(t *testing.T) {
-	mockProxySSHFactory := &mockProxySSHConnFactory{}
-	mockProxyDialer := &mockProxyNetDialer{}
-	mockProxyConnPairFactory := &mockProxySSHConnPairFactory{}
-
-	config, err := NewConfig(nil, sshConfig, zap.NewNop())
-	require.NoError(t, err)
-
-	downstreamConfig, err := config.GetDownstreamConfig(t.Context())
-	require.NoError(t, err)
-
-	sshProxy := NewProxy(*config)
-	sshProxy.downstreamConfig = downstreamConfig
-
-	// Set mock dependencies for testing
-	sshProxy.sshConnFactory = mockProxySSHFactory
-	sshProxy.netDialer = mockProxyDialer
-	sshProxy.connPairFactory = mockProxyConnPairFactory
-
-	// Create test proxy connection
-	claims := &token.GATClaims{}
-	testConn := newTestProxyConn(claims, "unknown-upstream:1234")
-
-	// Ensure that testConn is closed when serve returns due to error
-	testConn.On("Close").Return(nil)
-
-	// Call serve and expect it to fail
-	err = sshProxy.serveConn(t.Context(), testConn)
-
-	require.Error(t, err)
-	mockProxySSHFactory.AssertExpectations(t)
-	testConn.AssertExpectations(t)
-	assert.Empty(t, sshProxy.connsMap)
-
-	mockProxySSHFactory.AssertNotCalled(t, "NewServerConn")
-	mockProxyDialer.AssertNotCalled(t, "DialTimeout")
-	mockProxyConnPairFactory.AssertNotCalled(t, "NewConnPair")
-}
-
 func TestSSHProxy_ServeConn_DownstreamHandshakeFailure(t *testing.T) {
 	mockProxySSHFactory := &mockProxySSHConnFactory{}
 	mockProxyDialer := &mockProxyNetDialer{}
@@ -449,7 +407,7 @@ func TestSSHProxy_ServeConn_DownstreamHandshakeFailure(t *testing.T) {
 
 	// Create test proxy connection
 	claims := &token.GATClaims{}
-	testConn := newTestProxyConn(claims, upstreamAddress)
+	testConn := newTestProxyConn(claims)
 
 	// Mock NewServerConn to return an error (handshake failure)
 	mockProxySSHFactory.On("NewServerConn", testConn, downstreamConfig).Return(
@@ -496,7 +454,7 @@ func TestSSHProxy_ServeConn_UpstreamConnectionFailure(t *testing.T) {
 
 	// Create test proxy connection
 	claims := &token.GATClaims{}
-	testConn := newTestProxyConn(claims, upstreamAddress)
+	testConn := newTestProxyConn(claims)
 
 	// Mock successful downstream handshake
 	downstreamSSHConn := &mockSSHConn{}
@@ -558,7 +516,7 @@ func TestSSHProxy_ServeConn_UpstreamSSHHandshakeFailure(t *testing.T) {
 
 	// Create test proxy connection
 	claims := &token.GATClaims{}
-	testConn := newTestProxyConn(claims, upstreamAddress)
+	testConn := newTestProxyConn(claims)
 
 	// Mock successful downstream handshake
 	downstreamSSHConn := &mockSSHConn{}
@@ -633,7 +591,7 @@ func TestSSHProxy_Shutdown_WithActiveConnection(t *testing.T) {
 
 	// Create test proxy connection
 	claims := &token.GATClaims{}
-	testConn := newTestProxyConn(claims, upstreamAddress)
+	testConn := newTestProxyConn(claims)
 
 	// Mock successful downstream handshake
 	downstreamSSHConn := &mockSSHConn{}

--- a/test/data/config.yaml
+++ b/test/data/config.yaml
@@ -11,6 +11,5 @@ tls:
 kubernetes:
   upstreams:
     - name: "k8s-cluster"
-      address: "127.0.0.1:6443"
       bearerToken: "token"
       caFile: "../test/data/api_server/tls.crt"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -170,9 +170,6 @@ twingate:
 
 kubernetes:
   enabled: true
-  upstreams:
-    - name: "In-cluster k8s cluster"
-      inCluster: true
 
 image:
   repository: twingate/gateway

--- a/test/integration/concurrent_users_test.go
+++ b/test/integration/concurrent_users_test.go
@@ -62,7 +62,6 @@ func TestConcurrentUsers(t *testing.T) {
 			Upstreams: []gatewayconfig.KubernetesUpstream{
 				{
 					Name:        "kind-cluster",
-					Address:     kindURL.Host,
 					BearerToken: kindBearerToken,
 					CAFile:      "../data/api_server/tls.crt",
 				},

--- a/test/integration/kubernetes_test.go
+++ b/test/integration/kubernetes_test.go
@@ -61,7 +61,6 @@ func TestKubernetes(t *testing.T) {
 			Upstreams: []gatewayconfig.KubernetesUpstream{
 				{
 					Name:        "kind-cluster",
-					Address:     kindURL.Host,
 					BearerToken: kindBearerToken,
 					CAFile:      "../data/api_server/tls.crt",
 				},

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -64,9 +64,6 @@ func setupSSHGateway(t *testing.T, user *token.User, sshCAConfig gatewayconfig.S
 				Username: sshUsername,
 			},
 			CA: sshCAConfig,
-			Upstreams: []gatewayconfig.SSHUpstream{
-				{Name: "ssh-server", Address: sshServerAddress},
-			},
 		},
 	}
 

--- a/tools/local/main.go
+++ b/tools/local/main.go
@@ -203,7 +203,6 @@ tls:
 kubernetes:
   upstreams:
     - name: local-kind-cluster
-      address: %s:%d
       bearerToken: %s
       caFile: ./test/data/api_server/tls.crt
 ssh:
@@ -218,12 +217,9 @@ ssh:
   ca:
     manual:
       privateKeyFile: ./test/data/ssh/ca/ca
-  upstreams:
-    - name: local-ssh-server
-      address: %s:%d
 `
 
-	config := fmt.Sprintf(configTemplate, network, gatewayPort, gatewayHost, kindPort, kindBearerToken, sshUsername, gatewayHost, sshPort)
+	config := fmt.Sprintf(configTemplate, network, gatewayPort, kindBearerToken, sshUsername)
 
 	err := os.WriteFile(gatewayConfigFile, []byte(config), 0600)
 	if err != nil {


### PR DESCRIPTION
Issue: https://github.com/Twingate/gateway/issues/286

## Changes

- Use the address in the HTTP connect message as the upstream address
  - The user can limit the upstream's port by using Twingate Port Restriction <https://www.twingate.com/docs/resources#port-restrictions>
- Remove `upstreams` in Gateway config. Leave k8s upstream for testing for now
