### PR TITLE
fix(ci): Work around `nolintlint` false positives from golangci-lint cache bug

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,6 +49,10 @@ linters:
         # golang.org/x/crypto/ssh
         - Signer
         - PublicKey
+    nolintlint:
+      # Workaround for golangci-lint cache bug that causes false "unused nolint" reports.
+      # See: https://github.com/golangci/golangci-lint/issues/3228
+      allow-unused: true
     goheader:
       template: |-
         Copyright (c) Twingate Inc.


### PR DESCRIPTION
Issue: https://github.com/Twingate/gateway/issues/300

## Changes

- Set `allow-unused: true` for `nolintlint` in `.golangci.yml` to prevent flaky CI failures

## Notes

### Problem

The `lint-go` CI job intermittently fails with errors like:

```
directive `//nolint:ireturn` is unused for linter "ireturn" (nolintlint)
```

**Evidence**: [Failed CI run](https://github.com/Twingate/gateway/actions/runs/26206509968/job/77107441411?pr=296)

### Root Cause

This is a [known golangci-lint bug](https://github.com/golangci/golangci-lint/issues/3228) where the internal linter cache loses analysis facts (in our case, `ireturn` violations) across runs. When this happens:

1. `ireturn` violations become invisible due to stale/partial cache
2. `nolintlint` checks whether each `//nolint` directive suppresses a real violation
3. With the cached facts missing, `nolintlint` concludes the directive is "unused" and flags it
4. With `--fix` enabled (as in `make lint`), these "unused" directives get silently deleted
5. The next clean run sees the real violations again and fails

The bug is flaky — it depends on which cache entries are evicted, so it affects a different subset of directives each time. It is more likely in CI where the GitHub Actions cache is restored from previous runs against different code states.

### Fix

Following the same [workaround adopted by cloudnative-pg](https://github.com/cloudnative-pg/cloudnative-pg/pull/10136), we set `allow-unused: true` for `nolintlint` to tolerate potentially "unused" nolint directives rather than falsely flagging them.