### PR TITLE
chore: Remove redundant TestHandler_ServeHTTP test

### DIFF
--- a/internal/kuberneteshandler/kubernetes_test.go
+++ b/internal/kuberneteshandler/kubernetes_test.go
@@ -4,13 +4,9 @@
 package kuberneteshandler
 
 import (
-	"context"
-	"crypto/tls"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
-	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,85 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	"gateway/internal/config"
 	"gateway/internal/connect"
-	"gateway/internal/httpproxy"
-	"gateway/internal/metrics"
 	"gateway/internal/token"
-	"gateway/test/data"
 )
-
-func TestHandler_ServeHTTP(t *testing.T) {
-	// Create mock upstream API server with TLS
-	apiServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "user@acme.com", r.Header.Get("Impersonate-User"))
-		assert.Equal(t, []string{"Everyone", "Engineering"}, r.Header.Values("Impersonate-Group"))
-		assert.Equal(t, "Bearer mock-token", r.Header.Get("Authorization"))
-		assert.Empty(t, r.Header.Get("Impersonate-Uid"))
-		assert.Empty(t, r.Header.Get("Impersonate-Extra-Scopes"))
-
-		_, err := io.WriteString(w, "Upstream API Server Response!")
-		assert.NoError(t, err)
-	}))
-
-	serverCert, err := tls.X509KeyPair(data.ServerCert, data.ServerKey)
-	require.NoError(t, err)
-
-	apiServer.TLS = &tls.Config{
-		Certificates: []tls.Certificate{serverCert},
-		MinVersion:   tls.VersionTLS13,
-	}
-
-	apiServer.StartTLS()
-	defer apiServer.Close()
-
-	apiServerAddress := strings.TrimPrefix(apiServer.URL, "https://")
-
-	handler, err := NewHandler(Config{
-		bearerToken:         "mock-token",
-		caFile:              "../../test/data/api_server/tls.crt",
-		auditLog:            &config.AuditLogConfig{},
-		roundTripperMetrics: metrics.RegisterRoundTripperMetrics(prometheus.NewRegistry()),
-		logger:              zap.NewNop(),
-	})
-	require.NoError(t, err)
-
-	claims := &token.GATClaims{
-		User: token.User{
-			ID:       "user-1",
-			Username: "user@acme.com",
-			Groups:   []string{"Everyone", "Engineering"},
-		},
-		Resource: token.Resource{Address: apiServerAddress},
-	}
-
-	connMetrics := connect.CreateProxyConnMetrics(prometheus.NewRegistry())
-	proxyConn := connect.NewProxyConn(nil, nil, nil, zap.NewNop(), connMetrics)
-	proxyConn.Claims = claims
-	proxyConn.ID = "test-conn-id"
-	proxyConn.Address = apiServerAddress
-
-	request := httptest.NewRequest(http.MethodGet, "/api/v1/pods", nil)
-	request.Header.Set("Authorization", "Bearer should-be-stripped")
-	request.Header.Set("Impersonate-Uid", "should-be-stripped")
-	request.Header.Set("Impersonate-Extra-Scopes", "should-be-stripped")
-
-	ctx := context.WithValue(request.Context(), httpproxy.AuditLoggerKey{}, zap.NewNop())
-	ctx = context.WithValue(ctx, httpproxy.ConnContextKey{}, proxyConn)
-	request = request.WithContext(ctx)
-
-	recorder := httptest.NewRecorder()
-	handler.ServeHTTP(recorder, request)
-
-	resp := recorder.Result()
-	defer resp.Body.Close()
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Equal(t, "Upstream API Server Response!", string(body))
-}
 
 func TestRewrite(t *testing.T) {
 	connMetrics := connect.CreateProxyConnMetrics(prometheus.NewRegistry())


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #311
- Follow-up from missed review comment: https://github.com/Twingate/gateway/pull/296#discussion_r3308734442

## Changes

- Remove `TestHandler_ServeHTTP` unit test from `internal/kuberneteshandler/kubernetes_test.go` that is now redundant with integration test coverage
- Clean up unused imports (`context`, `crypto/tls`, `io`, `strings`, `config`, `httpproxy`, `metrics`, `data`)

## Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)