### PR TITLE
chore: Migrate goreleaser from dockers+docker_manifests to dockers_v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,7 +150,8 @@ jobs:
     needs: [lint-docker, lint-go, lint-markdown, test, test-helm]
     env:
       REGISTRY: ghcr.io/twingate
-      DOCKER_BUILDX_CACHE: --cache-to type=gha,mode=max --cache-from type=gha
+      DOCKER_BUILDX_CACHE_FROM: type=gha
+      DOCKER_BUILDX_CACHE_TO: type=gha,mode=max
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,7 +66,6 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGE_REGISTRY: ghcr.io/twingate
           DOCKER_BUILDX_BUILDER: twingate-gateway-builder
 
       - name: Helm Publish (Github)

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -69,8 +69,8 @@ dockers_v2:
     flags:
       - "--pull"
       - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
-      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_FROM" }}--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}{{ end }}'
-      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_TO" }}--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}{{ end }}'
+      - '--cache-from={{ envOrDefault "DOCKER_BUILDX_CACHE_FROM" "" }}'
+      - '--cache-to={{ envOrDefault "DOCKER_BUILDX_CACHE_TO" "" }}'
     extra_files:
       - LICENSE
   # Release: latest/dev, major, minor tags
@@ -97,8 +97,8 @@ dockers_v2:
     flags:
       - "--pull"
       - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
-      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_FROM" }}--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}{{ end }}'
-      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_TO" }}--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}{{ end }}'
+      - '--cache-from={{ envOrDefault "DOCKER_BUILDX_CACHE_FROM" "" }}'
+      - '--cache-to={{ envOrDefault "DOCKER_BUILDX_CACHE_TO" "" }}'
     extra_files:
       - LICENSE
   # Debug snapshot + release: version tag only
@@ -119,8 +119,8 @@ dockers_v2:
     flags:
       - "--pull"
       - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
-      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_FROM" }}--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}{{ end }}'
-      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_TO" }}--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}{{ end }}'
+      - '--cache-from={{ envOrDefault "DOCKER_BUILDX_CACHE_FROM" "" }}'
+      - '--cache-to={{ envOrDefault "DOCKER_BUILDX_CACHE_TO" "" }}'
     build_args:
       GOLANG_VERSION: "{{ .Env.GOLANG_VERSION }}"
     extra_files:
@@ -149,8 +149,8 @@ dockers_v2:
     flags:
       - "--pull"
       - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
-      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_FROM" }}--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}{{ end }}'
-      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_TO" }}--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}{{ end }}'
+      - '--cache-from={{ envOrDefault "DOCKER_BUILDX_CACHE_FROM" "" }}'
+      - '--cache-to={{ envOrDefault "DOCKER_BUILDX_CACHE_TO" "" }}'
     build_args:
       GOLANG_VERSION: "{{ .Env.GOLANG_VERSION }}"
     extra_files:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -69,8 +69,8 @@ dockers_v2:
     flags:
       - "--pull"
       - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
-      - "--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}"
-      - "--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}"
+      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_FROM" }}--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}{{ end }}'
+      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_TO" }}--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}{{ end }}'
     extra_files:
       - LICENSE
   # Release: latest/dev, major, minor tags
@@ -97,8 +97,8 @@ dockers_v2:
     flags:
       - "--pull"
       - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
-      - "--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}"
-      - "--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}"
+      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_FROM" }}--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}{{ end }}'
+      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_TO" }}--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}{{ end }}'
     extra_files:
       - LICENSE
   # Debug snapshot + release: version tag only
@@ -119,8 +119,10 @@ dockers_v2:
     flags:
       - "--pull"
       - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
-      - "--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}"
-      - "--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}"
+      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_FROM" }}--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}{{ end }}'
+      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_TO" }}--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}{{ end }}'
+    build_args:
+      GOLANG_VERSION: "{{ .Env.GOLANG_VERSION }}"
     extra_files:
       - LICENSE
   # Debug release: latest/dev, major, minor tags
@@ -147,8 +149,10 @@ dockers_v2:
     flags:
       - "--pull"
       - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
-      - "--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}"
-      - "--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}"
+      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_FROM" }}--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}{{ end }}'
+      - '{{ if isEnvSet "DOCKER_BUILDX_CACHE_TO" }}--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}{{ end }}'
+    build_args:
+      GOLANG_VERSION: "{{ .Env.GOLANG_VERSION }}"
     extra_files:
       - LICENSE
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ before:
     - go mod tidy
 
 snapshot:
-  version_template: '{{ .Version }}-{{envOrDefault "VERSION_PRERELEASE" "local"}}+{{ .ShortCommit }}'
+  version_template: '{{ .Version }}-{{envOrDefault "VERSION_PRERELEASE" "local"}}-{{ .ShortCommit }}'
 
 checksum:
   name_template: 'checksums.txt'
@@ -49,172 +49,108 @@ builds:
       - -X gateway/internal/version.Version={{.Version}}
     mod_timestamp: '{{ .CommitTimestamp }}'
 
-dockers:
-  - use: buildx
-    goos: linux
-    goarch: amd64
+dockers_v2:
+  # Snapshot + release: version tag only
+  - id: gateway
     dockerfile: Dockerfile.goreleaser
     ids:
       - gateway
-    image_templates:
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64"
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64"
-    build_flag_templates:
+    images:
+      - "twingate/{{ .ProjectName }}"
+      - "ghcr.io/twingate/{{ .ProjectName }}"
+    tags:
+      # Example: twingate/gateway:0.2.2
+      - "{{ .Version }}"
+    labels:
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.title": "{{.ProjectName}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "{{.Tag}}"
+    flags:
       - "--pull"
       - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Tag}}"
+      - "--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}"
+      - "--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}"
     extra_files:
       - LICENSE
-  - use: buildx
-    goos: linux
-    goarch: arm64
+  # Release: latest/dev, major, minor tags
+  - id: gateway-release
+    disable: "{{ .IsSnapshot }}"
     dockerfile: Dockerfile.goreleaser
     ids:
       - gateway
-    image_templates:
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64"
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64"
-    build_flag_templates:
+    images:
+      - "twingate/{{ .ProjectName }}"
+      - "ghcr.io/twingate/{{ .ProjectName }}"
+    tags:
+      # Example: twingate/gateway:latest (or dev)
+      - "{{ if not .Prerelease }}latest{{ else }}dev{{ end }}"
+      # Example: twingate/gateway:0
+      - "{{ if not .Prerelease }}{{.Major}}{{ end }}"
+      # Example: twingate/gateway:0.2
+      - "{{ if not .Prerelease }}{{.Major}}.{{.Minor}}{{ end }}"
+    labels:
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.title": "{{.ProjectName}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "{{.Tag}}"
+    flags:
       - "--pull"
       - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Tag}}"
+      - "--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}"
+      - "--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}"
     extra_files:
       - LICENSE
-  # Debug containers
-  - use: buildx
-    goos: linux
-    goarch: amd64
+  # Debug snapshot + release: version tag only
+  - id: gateway-debug
     dockerfile: Dockerfile.goreleaser-debug
     ids:
       - gateway-debug
-    image_templates:
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64-debug"
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64-debug"
-    build_flag_templates:
+    images:
+      - "twingate/{{ .ProjectName }}"
+      - "ghcr.io/twingate/{{ .ProjectName }}"
+    tags:
+      - "{{ .Version }}-debug"
+    labels:
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.title": "{{.ProjectName}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "{{.Tag}}"
+    flags:
       - "--pull"
       - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Tag}}"
+      - "--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}"
+      - "--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}"
     extra_files:
       - LICENSE
-  - use: buildx
-    goos: linux
-    goarch: arm64
+  # Debug release: latest/dev, major, minor tags
+  - id: gateway-debug-release
+    disable: "{{ .IsSnapshot }}"
     dockerfile: Dockerfile.goreleaser-debug
     ids:
       - gateway-debug
-    image_templates:
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64-debug"
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64-debug"
-    build_flag_templates:
+    images:
+      - "twingate/{{ .ProjectName }}"
+      - "ghcr.io/twingate/{{ .ProjectName }}"
+    tags:
+      # Example: twingate/gateway:latest-debug (or dev-debug)
+      - "{{ if not .Prerelease }}latest{{ else }}dev{{ end }}-debug"
+      # Example: twingate/gateway:0-debug
+      - "{{ if not .Prerelease }}{{.Major}}-debug{{ end }}"
+      # Example: twingate/gateway:0.2-debug
+      - "{{ if not .Prerelease }}{{.Major}}.{{.Minor}}-debug{{ end }}"
+    labels:
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.title": "{{.ProjectName}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "{{.Tag}}"
+    flags:
       - "--pull"
       - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Tag}}"
+      - "--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}"
+      - "--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}"
     extra_files:
       - LICENSE
-
-docker_manifests:
-  #******************* Dockerhub *******************#
-  # Example: twingate/gateway:latest (or dev)
-  - name_template: "twingate/{{ .ProjectName }}:{{ if not .Prerelease }}latest{{ else }}dev{{ end }}"
-    image_templates:
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64"
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64"
-  # Example: twingate/gateway:v0.2.2
-  - name_template: "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}"
-    image_templates:
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64"
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64"
-  # Example: twingate/gateway:v0
-  - name_template: "twingate/{{ .ProjectName }}:{{.Major}}"
-    skip_push: auto
-    image_templates:
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64"
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64"
-  # Example: twingate/gateway:v0.2
-  - name_template: "twingate/{{ .ProjectName }}:{{.Major}}.{{.Minor}}"
-    skip_push: auto
-    image_templates:
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64"
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64"
-  #### Debug manifests
-  - name_template: "twingate/{{ .ProjectName }}:{{ if not .Prerelease }}latest{{ else }}dev{{ end }}-debug"
-    image_templates:
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64-debug"
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64-debug"
-  - name_template: "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-debug"
-    image_templates:
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64-debug"
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64-debug"
-  - name_template: "twingate/{{ .ProjectName }}:{{.Major}}-debug"
-    skip_push: auto
-    image_templates:
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64-debug"
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64-debug"
-  - name_template: "twingate/{{ .ProjectName }}:{{.Major}}.{{.Minor}}-debug"
-    skip_push: auto
-    image_templates:
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64-debug"
-      - "twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64-debug"
-
-  #******************* Github *******************#
-  # Example: twingate/gateway:latest (or dev)
-  - name_template: "ghcr.io/twingate/{{ .ProjectName }}:{{ if not .Prerelease }}latest{{ else }}dev{{ end }}"
-    image_templates:
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64"
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64"
-  # Example: twingate/gateway:v0.2.2
-  - name_template: "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}"
-    image_templates:
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64"
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64"
-  # Example: twingate/gateway:v0
-  - name_template: "ghcr.io/twingate/{{ .ProjectName }}:{{.Major}}"
-    skip_push: auto
-    image_templates:
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64"
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64"
-  # Example: twingate/gateway:v0.2
-  - name_template: "ghcr.io/twingate/{{ .ProjectName }}:{{.Major}}.{{.Minor}}"
-    skip_push: auto
-    image_templates:
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64"
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64"
-  #### Debug manifests
-  - name_template: "ghcr.io/twingate/{{ .ProjectName }}:{{ if not .Prerelease }}latest{{ else }}dev{{ end }}-debug"
-    image_templates:
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64-debug"
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64-debug"
-  - name_template: "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-debug"
-    image_templates:
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64-debug"
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64-debug"
-  - name_template: "ghcr.io/twingate/{{ .ProjectName }}:{{.Major}}-debug"
-    skip_push: auto
-    image_templates:
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64-debug"
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64-debug"
-  - name_template: "ghcr.io/twingate/{{ .ProjectName }}:{{.Major}}.{{.Minor}}-debug"
-    skip_push: auto
-    image_templates:
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-amd64-debug"
-      - "ghcr.io/twingate/{{ .ProjectName }}:{{ replace .Version \"+\" \"-\" }}-linux-arm64-debug"
-
 
 archives:
   - formats: [tar.gz]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,5 @@
 FROM gcr.io/distroless/static-debian12:nonroot
+ARG TARGETPLATFORM
 ENTRYPOINT ["/gateway", "start"]
-COPY gateway /
+COPY $TARGETPLATFORM/gateway /
 COPY LICENSE /

--- a/Dockerfile.goreleaser-debug
+++ b/Dockerfile.goreleaser-debug
@@ -3,10 +3,11 @@ ARG TARGETOS
 ARG TARGETARCH
 
 FROM --platform=$BUILDPLATFORM  golang:${GOLANG_VERSION} AS builder
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install github.com/go-delve/delve/cmd/dlv@v1.25.2
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install github.com/go-delve/delve/cmd/dlv@v1.26.3
 
 FROM gcr.io/distroless/static-debian12:debug
+ARG TARGETPLATFORM
 ENTRYPOINT ["./dlv", "exec", "./gateway-debug", "--headless", "--listen=:2345", "--api-version=2", "--accept-multiclient", "--continue", "--", "start"]
-COPY gateway-debug /
+COPY $TARGETPLATFORM/gateway-debug /
 COPY LICENSE /
 COPY --from=builder /go/bin/dlv /

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,8 @@ upload-coverage: ##@test Upload code coverage to CodeCov (requires CI environmen
 .PHONY: prepare-buildx
 prepare-buildx: ##@build Prepare buildx
 	@echo "Preparing buildx..."
-	docker buildx create --use --name $(DOCKER_BUILDX_BUILDER) --node=$(DOCKER_BUILDX_BUILDER)
+	docker buildx inspect $(DOCKER_BUILDX_BUILDER) >/dev/null 2>&1 && docker buildx use $(DOCKER_BUILDX_BUILDER) || \
+		docker buildx create --use --name $(DOCKER_BUILDX_BUILDER) --node=$(DOCKER_BUILDX_BUILDER)
 
 .PHONY: build
 build: prepare-buildx ##@build Build the Go binaries and container images

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ GOLANG_VERSION 		?= $(shell cat .tool-versions | grep golang | cut -d' ' -f2)
 GOLANGCI_LINT_VERSION	?= v2.11.1
 VERSION 			?= $(shell go tool svu current)
 REGISTRY 			?= twingate
-IMAGE				:= kubernetes-gateway
+IMAGE				:= gateway
 IMAGE_NAME			:= $(REGISTRY)/$(IMAGE)
-DOCKER_BUILDX_BUILDER ?= twingate-kubernetes-gateway-builder
-DOCKER_BUILDX_CACHE ?=
+DOCKER_BUILDX_BUILDER ?= twingate-gateway-builder
+DOCKER_BUILDX_CACHE_FROM ?=
+DOCKER_BUILDX_CACHE_TO ?=
 
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
@@ -127,7 +128,7 @@ prepare-buildx: ##@build Prepare buildx
 
 .PHONY: build
 build: prepare-buildx ##@build Build the Go binaries and container images
-	DOCKER_BUILDX_BUILDER=$(DOCKER_BUILDX_BUILDER) GOLANG_VERSION=$(GOLANG_VERSION) IMAGE_REGISTRY=$(REGISTRY) goreleaser release --snapshot --clean
+	DOCKER_BUILDX_BUILDER=$(DOCKER_BUILDX_BUILDER) DOCKER_BUILDX_CACHE_FROM=$(DOCKER_BUILDX_CACHE_FROM) DOCKER_BUILDX_CACHE_TO=$(DOCKER_BUILDX_CACHE_TO) goreleaser release --snapshot --clean
 
 .PHONY: cut-release-prod
 cut-release-prod: ##@release Cut a production release (create a version tag and push it)

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ prepare-buildx: ##@build Prepare buildx
 
 .PHONY: build
 build: prepare-buildx ##@build Build the Go binaries and container images
-	DOCKER_BUILDX_BUILDER=$(DOCKER_BUILDX_BUILDER) DOCKER_BUILDX_CACHE_FROM=$(DOCKER_BUILDX_CACHE_FROM) DOCKER_BUILDX_CACHE_TO=$(DOCKER_BUILDX_CACHE_TO) goreleaser release --snapshot --clean
+	DOCKER_BUILDX_BUILDER=$(DOCKER_BUILDX_BUILDER) DOCKER_BUILDX_CACHE_FROM=$(DOCKER_BUILDX_CACHE_FROM) DOCKER_BUILDX_CACHE_TO=$(DOCKER_BUILDX_CACHE_TO) GOLANG_VERSION=$(GOLANG_VERSION) goreleaser release --snapshot --clean
 
 .PHONY: cut-release-prod
 cut-release-prod: ##@release Cut a production release (create a version tag and push it)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -136,7 +136,7 @@ func downloadCaddyCACert(t *testing.T) string {
 func getDockerImageTag(t *testing.T) string {
 	t.Helper()
 
-	var imageReference = "twingate/gateway:*-linux-"
+	var imageReference = "twingate/gateway:*-"
 	if runtime.GOARCH == archARM64 {
 		imageReference += "arm64"
 	} else {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -147,8 +147,17 @@ func getDockerImageTag(t *testing.T) string {
 	output, err := testutil.RunCommand(cmd)
 	require.NoError(t, err, "failed to get docker image tag")
 
-	// Parse output to handle multiple tags
-	tags := strings.Fields(strings.TrimSpace(string(output)))
+	// Parse output and filter out debug tags
+	allTags := strings.Fields(strings.TrimSpace(string(output)))
+
+	var tags []string
+
+	for _, tag := range allTags {
+		if !strings.Contains(tag, "debug") {
+			tags = append(tags, tag)
+		}
+	}
+
 	require.NotEmpty(t, tags, "no docker image tags found for reference: %s", imageReference)
 
 	// Return the first tag (most recently built) as `docker images` returns tags in reverse chronological order


### PR DESCRIPTION
## Related Tickets

Issue : #146

## Changes

Migrate `.goreleaser.yaml` from the deprecated `dockers` + `docker_manifests` configuration to `dockers_v2` (available since goreleaser v2.12). This leverages Docker buildx native multi-arch manifest support, eliminating ~170 lines of repetitive YAML.

See [deprecation notice](https://goreleaser.com/resources/deprecations/#dockers) 

### What changed

- **`.goreleaser.yaml`**: Replaced `dockers` (4 entries) + `docker_manifests` (16 entries) with `dockers_v2` (4 entries)
- **`Dockerfile.goreleaser`**: Added `ARG TARGETPLATFORM` and updated `COPY` to use platform-prefixed binary path (`$TARGETPLATFORM/gateway`)
- **`Dockerfile.goreleaser-debug`**: Added `ARG TARGETPLATFORM` in final stage, updated `COPY` path, bumped delve to `v1.26.3`
- **`Makefile`**: Renamed builder, split `DOCKER_BUILDX_CACHE` into `DOCKER_BUILDX_CACHE_FROM`/`DOCKER_BUILDX_CACHE_TO`, removed unused `GOLANG_VERSION` and `IMAGE_REGISTRY` env vars from build target
- **`.github/workflows/ci.yaml`**: Split `DOCKER_BUILDX_CACHE` env var into `DOCKER_BUILDX_CACHE_FROM` and `DOCKER_BUILDX_CACHE_TO`

### Registry tag changes

#### Snapshot builds (local / CI)

| Type | Old (`dockers`) | New (`dockers_v2`) |
|------|----------------|-------------------|
| Per-platform tag | `gateway:0.17.0-dev-abc1234-linux-amd64` | `gateway:0.17.0-dev-abc1234-amd64` |
| Per-platform debug tag | `gateway:0.17.0-dev-abc1234-linux-amd64-debug` | `gateway:0.17.0-dev-abc1234-debug-amd64` |
| `linux` prefix | Yes (`-linux-arm64`) | No (`-arm64`) |
| `-debug` suffix position | After platform (`-arm64-debug`) | Before platform (`-debug-arm64`) |

#### Production release (pushed to registry)

| Type | Old (`dockers` + `docker_manifests`) | New (`dockers_v2`) |
|------|-------------------------------------|-------------------|
| Version tag | `gateway:0.17.0` (manifest) + `gateway:0.17.0-linux-amd64` + `gateway:0.17.0-linux-arm64` (per-platform) | `gateway:0.17.0` (multi-arch manifest only) |
| Latest tag | `gateway:latest` (manifest) | `gateway:latest` (multi-arch manifest) |
| Major tag | `gateway:0` (manifest) | `gateway:0` (multi-arch manifest) |
| Minor tag | `gateway:0.17` (manifest) | `gateway:0.17` (multi-arch manifest) |
| Debug version tag | `gateway:0.17.0-debug` (manifest) + per-platform tags | `gateway:0.17.0-debug` (multi-arch manifest only) |
| Per-platform tags in registry | Yes (e.g. `gateway:0.17.0-linux-amd64`) | No — embedded in manifest |

**Key difference**: In the old config, per-platform tags (e.g. `gateway:0.17.0-linux-amd64`) were pushed to the registry alongside manifests. With `dockers_v2`, only multi-arch manifest tags are pushed — per-platform images are embedded in the manifest, not separately tagged.

## Notes

- Requires goreleaser v2.12+ (CI uses `~> v2` which resolves to latest v2.x)
- `docker_manifests` section is fully eliminated — `dockers_v2` handles manifest creation automatically
- Cache flags (`--cache-from`, `--cache-to`) are wired up via env vars, defaulting to empty (no-op) for local builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)