### PR TITLE
chore(deps): bump codecov/codecov-action from v6.0.1 to v7.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
 
       # Upload coverage to CodeCov
       - name: Upload unit test coverage to CodeCov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./covprofile-unit
           flags: unit
@@ -118,7 +118,7 @@ jobs:
           verbose: true
 
       - name: Upload integration test coverage to CodeCov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./covprofile-integration
           flags: integration
@@ -128,7 +128,7 @@ jobs:
           verbose: true
 
       - name: Upload unit test results to CodeCov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./junit-unit.xml
           report_type: test_results
@@ -137,7 +137,7 @@ jobs:
           verbose: true
 
       - name: Upload integration test results to CodeCov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./junit-integration.xml
           report_type: test_results


### PR DESCRIPTION
## Related Tickets

Issue: https://github.com/codecov/codecov-action/issues/1956

## Changes

- Bump `codecov/codecov-action` from `v6.0.1` to `v7.0.0` 


🤖 Generated with [Claude Code](https://claude.com/claude-code)