### PR TITLE
chore: Remove unnecessary `SSHProxy.Serve()` method

### DIFF
--- a/internal/sshhandler/proxy.go
+++ b/internal/sshhandler/proxy.go
@@ -136,7 +136,7 @@ func (p *SSHProxy) Start(ctx context.Context, listener net.Listener) error {
 
 		// Serve SSH connection in a separate goroutine
 		go func() {
-			err := p.Serve(ctx, conn.(connect.Conn))
+			err := p.serveConn(ctx, conn.(connect.Conn))
 			if err != nil {
 				p.config.logger.Error("Failed to serve SSH connection", zap.Error(err))
 			}
@@ -144,25 +144,6 @@ func (p *SSHProxy) Start(ctx context.Context, listener net.Listener) error {
 	}
 
 	return nil
-}
-
-func (p *SSHProxy) Serve(ctx context.Context, conn connect.Conn) error {
-	p.mu.Lock()
-
-	if p.shuttingDown {
-		p.mu.Unlock()
-		// reject the connection and return error
-		err := conn.Close()
-		if err != nil {
-			p.config.logger.Error("Failed to close connection", zap.Error(err))
-		}
-
-		return errShuttingDown
-	}
-
-	p.mu.Unlock()
-
-	return p.serveConn(ctx, conn)
 }
 
 func (p *SSHProxy) Shutdown(_ctx context.Context) {

--- a/internal/sshhandler/proxy_test.go
+++ b/internal/sshhandler/proxy_test.go
@@ -660,7 +660,7 @@ func TestSSHProxy_Shutdown_WithActiveConnection(t *testing.T) {
 	serveDone := make(chan error, 1)
 
 	go func() {
-		serveDone <- sshProxy.Serve(t.Context(), testConn)
+		serveDone <- sshProxy.serveConn(t.Context(), testConn)
 	}()
 
 	// Wait for serve to start and connection to be added


### PR DESCRIPTION
## Changes

Remove unnecessary `SSHProxy.Serve()` method because it duplicates logic in `SSHProxy.serveConn()`.