### PR TITLE
fix: Enforce TLS 1.3 for the Vault client

### DIFF
--- a/internal/sshhandler/vault.go
+++ b/internal/sshhandler/vault.go
@@ -5,8 +5,10 @@ package sshhandler
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -120,6 +122,12 @@ type Vault struct {
 func newVault(vaultConfig *gatewayconfig.SSHCAVaultConfig, logger *zap.Logger) (*Vault, error) {
 	config := vault.DefaultConfig()
 	config.Address = vaultConfig.Address
+
+	//nolint:revive // unchecked-type-assertion: transport type guaranteed by DefaultConfig
+	transport := config.HttpClient.Transport.(*http.Transport)
+	// Enforce TLS 1.3 for the Vault client, which carries all CA signing requests.
+	// Vault's DefaultConfig sets only a TLS 1.2 minimum.
+	transport.TLSClientConfig.MinVersion = tls.VersionTLS13
 
 	if vaultConfig.CABundleFile != "" {
 		if err := config.ConfigureTLS(&vault.TLSConfig{

--- a/internal/sshhandler/vault_test.go
+++ b/internal/sshhandler/vault_test.go
@@ -5,7 +5,9 @@ package sshhandler
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
+	"net/http"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -14,6 +16,7 @@ import (
 	"github.com/hashicorp/vault/api/auth/approle"
 	"github.com/hashicorp/vault/api/auth/aws"
 	"github.com/hashicorp/vault/api/auth/gcp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -21,6 +24,19 @@ import (
 
 	gatewayconfig "gateway/internal/config"
 )
+
+func TestNewVault_EnforcesTLS13(t *testing.T) {
+	v, err := newVault(&gatewayconfig.SSHCAVaultConfig{
+		Address: "https://vault.example.com",
+		Auth:    gatewayconfig.SSHCAVaultAuthConfig{Token: "test-token"},
+	}, zap.NewNop())
+	require.NoError(t, err)
+
+	transport, ok := v.client.CloneConfig().HttpClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, transport.TLSClientConfig)
+	assert.Equal(t, uint16(tls.VersionTLS13), transport.TLSClientConfig.MinVersion)
+}
 
 func TestNewVaultAuthMethod_AppRole(t *testing.T) {
 	t.Run("with secretID", func(t *testing.T) {


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #348

## Changes

- Enforce a TLS 1.3 minimum on the Vault client used for SSH CA signing (Vault's default permits TLS 1.2).