### PR TITLE
fix: Split SSH gateway key into separate host and user keys

### DIFF
--- a/internal/sshhandler/config.go
+++ b/internal/sshhandler/config.go
@@ -28,7 +28,6 @@ var (
 
 // Default values for SSH configuration.
 const (
-	defaultKeyType     = keyTypeED25519
 	defaultHostCertTTL = 24 * time.Hour
 	defaultUserCertTTL = 5 * time.Minute
 )
@@ -77,15 +76,9 @@ func NewConfig(auditLogConfig *config.AuditLogConfig, sshCfg *config.SSHConfig, 
 		return nil, fmt.Errorf("failed to create ca: %w", err)
 	}
 
-	// Apply defaults for Gateway's key config
-	keyType := keyType(sshCfg.Gateway.Key.Type)
-	if keyType == "" {
-		keyType = defaultKeyType
-	}
-
-	keyCfg := keyConfig{
-		typ:  keyType,
-		bits: sshCfg.Gateway.Key.Bits,
+	keyCfg, err := newKeyConfig(sshCfg.Gateway.Key.Type, sshCfg.Gateway.Key.Bits)
+	if err != nil {
+		return nil, fmt.Errorf("invalid gateway key config: %w", err)
 	}
 
 	hostSigner, hostPublicKey, err := keyCfg.Generate(rand.Reader)
@@ -149,7 +142,7 @@ func (c *Config) GetDownstreamConfig(ctx context.Context) (*ssh.ServerConfig, er
 
 	hostCertSigner, err := newAutoRenewingCertSigner(ctx, c.caConfig.GatewayHostCA, hostCertRequest, c.hostSigner, c.logger)
 	if err != nil {
-		return nil, fmt.Errorf("failed to Gateway's host cert signer: %w", err)
+		return nil, fmt.Errorf("failed to create Gateway's host cert signer: %w", err)
 	}
 
 	go func() {

--- a/internal/sshhandler/config.go
+++ b/internal/sshhandler/config.go
@@ -54,12 +54,17 @@ type upstream struct {
 }
 
 type Config struct {
-	caConfig         *caConfig
-	gatewaySigner    ssh.Signer
-	gatewayPublicKey ssh.PublicKey
-	hostCertTTL      time.Duration
-	userCertTTL      time.Duration
-	gatewayUsername  string
+	caConfig *caConfig
+
+	hostSigner    ssh.Signer
+	hostPublicKey ssh.PublicKey
+	hostCertTTL   time.Duration
+
+	userSigner    ssh.Signer
+	userPublicKey ssh.PublicKey
+	userCertTTL   time.Duration
+
+	gatewayUsername string
 
 	auditLog *config.AuditLogConfig
 	logger   *zap.Logger
@@ -78,12 +83,19 @@ func NewConfig(auditLogConfig *config.AuditLogConfig, sshCfg *config.SSHConfig, 
 		keyType = defaultKeyType
 	}
 
-	gatewaySigner, gatewayPublicKey, err := keyConfig{
+	keyConfig := keyConfig{
 		typ:  keyType,
 		bits: sshCfg.Gateway.Key.Bits,
-	}.Generate(rand.Reader)
+	}
+
+	hostSigner, hostPublicKey, err := keyConfig.Generate(rand.Reader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate gateway key: %w", err)
+		return nil, fmt.Errorf("failed to generate gateway host key: %w", err)
+	}
+
+	userSigner, userPublicKey, err := keyConfig.Generate(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate gateway user key: %w", err)
 	}
 
 	// Apply defaults for certificate TTLs
@@ -98,12 +110,14 @@ func NewConfig(auditLogConfig *config.AuditLogConfig, sshCfg *config.SSHConfig, 
 	}
 
 	return &Config{
-		caConfig:         caConfig,
-		gatewaySigner:    gatewaySigner,
-		gatewayPublicKey: gatewayPublicKey,
-		hostCertTTL:      hostCertTTL,
-		userCertTTL:      userCertTTL,
-		gatewayUsername:  sshCfg.Gateway.Username,
+		caConfig:        caConfig,
+		hostSigner:      hostSigner,
+		hostPublicKey:   hostPublicKey,
+		hostCertTTL:     hostCertTTL,
+		userSigner:      userSigner,
+		userPublicKey:   userPublicKey,
+		userCertTTL:     userCertTTL,
+		gatewayUsername: sshCfg.Gateway.Username,
 
 		auditLog: auditLogConfig,
 		logger:   logger,
@@ -129,11 +143,11 @@ func (c *Config) GetDownstreamConfig(ctx context.Context) (*ssh.ServerConfig, er
 
 	hostCertRequest := &certificateRequest{
 		certType:  ssh.HostCert,
-		publicKey: c.gatewayPublicKey,
+		publicKey: c.hostPublicKey,
 		ttl:       c.hostCertTTL,
 	}
 
-	hostCertSigner, err := newAutoRenewingCertSigner(ctx, c.caConfig.GatewayHostCA, hostCertRequest, c.gatewaySigner, c.logger)
+	hostCertSigner, err := newAutoRenewingCertSigner(ctx, c.caConfig.GatewayHostCA, hostCertRequest, c.hostSigner, c.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to Gateway's host cert signer: %w", err)
 	}
@@ -154,7 +168,7 @@ func (c *Config) GetDownstreamConfig(ctx context.Context) (*ssh.ServerConfig, er
 func (c *Config) GetUpstreamConfig(ctx context.Context, upstream upstream) (*ssh.ClientConfig, error) {
 	userCertRequest := &certificateRequest{
 		certType:  ssh.UserCert,
-		publicKey: c.gatewayPublicKey,
+		publicKey: c.userPublicKey,
 		principals: []string{
 			upstream.username,
 		},
@@ -175,7 +189,7 @@ func (c *Config) GetUpstreamConfig(ctx context.Context, upstream upstream) (*ssh
 		return nil, fmt.Errorf("failed to sign user certificate: %w", err)
 	}
 
-	userCertSigner, err := ssh.NewCertSigner(userCert, c.gatewaySigner)
+	userCertSigner, err := ssh.NewCertSigner(userCert, c.userSigner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Gateway's user certificate: %w", err)
 	}

--- a/internal/sshhandler/config.go
+++ b/internal/sshhandler/config.go
@@ -83,17 +83,17 @@ func NewConfig(auditLogConfig *config.AuditLogConfig, sshCfg *config.SSHConfig, 
 		keyType = defaultKeyType
 	}
 
-	keyConfig := keyConfig{
+	keyCfg := keyConfig{
 		typ:  keyType,
 		bits: sshCfg.Gateway.Key.Bits,
 	}
 
-	hostSigner, hostPublicKey, err := keyConfig.Generate(rand.Reader)
+	hostSigner, hostPublicKey, err := keyCfg.Generate(rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate gateway host key: %w", err)
 	}
 
-	userSigner, userPublicKey, err := keyConfig.Generate(rand.Reader)
+	userSigner, userPublicKey, err := keyCfg.Generate(rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate gateway user key: %w", err)
 	}

--- a/internal/sshhandler/config_test.go
+++ b/internal/sshhandler/config_test.go
@@ -37,6 +37,13 @@ func TestNewConfig_Success(t *testing.T) {
 
 	assert.Equal(t, auditLog, config.auditLog)
 	assert.Equal(t, "gateway", config.gatewayUsername)
+
+	require.NotNil(t, config.hostSigner)
+	require.NotNil(t, config.userSigner)
+	assert.False(t, keysEqual(config.hostPublicKey, config.userPublicKey),
+		"host and user public keys must be distinct")
+	assert.False(t, keysEqual(config.hostSigner.PublicKey(), config.userSigner.PublicKey()),
+		"host and user signers must be distinct")
 }
 
 func TestNewConfig_WithManualCA(t *testing.T) {

--- a/internal/sshhandler/config_test.go
+++ b/internal/sshhandler/config_test.go
@@ -15,35 +15,69 @@ import (
 	"gateway/test/data"
 )
 
-func TestNewConfig_Success(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	auditLog := &gatewayconfig.AuditLogConfig{
 		FlushInterval:      time.Minute * 5,
 		FlushSizeThreshold: 2000,
 	}
 
-	sshConfig := &gatewayconfig.SSHConfig{
-		Gateway: gatewayconfig.SSHGatewayConfig{
-			Username:        "gateway",
-			Key:             gatewayconfig.SSHKeyConfig{Type: "ed25519"},
-			HostCertificate: gatewayconfig.SSHCertificateConfig{TTL: 24 * time.Hour},
-			UserCertificate: gatewayconfig.SSHCertificateConfig{TTL: 5 * time.Minute},
+	tests := []struct {
+		name        string
+		keyType     string
+		wantErr     error
+		wantErrText string
+	}{
+		{
+			name:    "supported key type",
+			keyType: "ed25519",
 		},
-		CA: gatewayconfig.SSHCAConfig{},
+		{
+			name:    "alternate identifier is normalized",
+			keyType: "ssh-ed25519",
+		},
+		{
+			name:        "unsupported type is rejected",
+			keyType:     "invalid-type",
+			wantErr:     errUnsupportedKeyType,
+			wantErrText: "invalid gateway key config",
+		},
 	}
 
-	config, err := NewConfig(auditLog, sshConfig, zap.NewNop())
-	require.NoError(t, err)
-	require.NotNil(t, config)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sshConfig := &gatewayconfig.SSHConfig{
+				Gateway: gatewayconfig.SSHGatewayConfig{
+					Username:        "gateway",
+					Key:             gatewayconfig.SSHKeyConfig{Type: tt.keyType},
+					HostCertificate: gatewayconfig.SSHCertificateConfig{TTL: 24 * time.Hour},
+					UserCertificate: gatewayconfig.SSHCertificateConfig{TTL: 5 * time.Minute},
+				},
+				CA: gatewayconfig.SSHCAConfig{},
+			}
 
-	assert.Equal(t, auditLog, config.auditLog)
-	assert.Equal(t, "gateway", config.gatewayUsername)
+			config, err := NewConfig(auditLog, sshConfig, zap.NewNop())
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.ErrorContains(t, err, tt.wantErrText)
+				assert.Nil(t, config)
 
-	require.NotNil(t, config.hostSigner)
-	require.NotNil(t, config.userSigner)
-	assert.False(t, keysEqual(config.hostPublicKey, config.userPublicKey),
-		"host and user public keys must be distinct")
-	assert.False(t, keysEqual(config.hostSigner.PublicKey(), config.userSigner.PublicKey()),
-		"host and user signers must be distinct")
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, config)
+
+			assert.Equal(t, auditLog, config.auditLog)
+			assert.Equal(t, "gateway", config.gatewayUsername)
+
+			require.NotNil(t, config.hostSigner)
+			require.NotNil(t, config.userSigner)
+			assert.False(t, keysEqual(config.hostPublicKey, config.userPublicKey),
+				"host and user public keys must be distinct")
+			assert.False(t, keysEqual(config.hostSigner.PublicKey(), config.userSigner.PublicKey()),
+				"host and user signers must be distinct")
+		})
+	}
 }
 
 func TestNewConfig_WithManualCA(t *testing.T) {

--- a/internal/sshhandler/config_test.go
+++ b/internal/sshhandler/config_test.go
@@ -58,7 +58,7 @@ func TestNewConfig(t *testing.T) {
 			config, err := NewConfig(auditLog, sshConfig, zap.NewNop())
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
-				assert.ErrorContains(t, err, tt.wantErrText)
+				require.ErrorContains(t, err, tt.wantErrText)
 				assert.Nil(t, config)
 
 				return

--- a/internal/sshhandler/keys.go
+++ b/internal/sshhandler/keys.go
@@ -36,8 +36,8 @@ type keyConfig struct {
 
 func newKeyConfig(keyType string, keyBits int) (keyConfig, error) {
 	switch keyType {
-	// Ed25519
-	case "ed25519", ssh.KeyAlgoED25519:
+	// Ed25519 (also the default when no type is set)
+	case "", "ed25519", ssh.KeyAlgoED25519:
 		return keyConfig{typ: keyTypeED25519, bits: keyBits}, nil
 
 	// ECDSA variants

--- a/internal/sshhandler/keys_test.go
+++ b/internal/sshhandler/keys_test.go
@@ -21,6 +21,13 @@ func TestNewKeyConfigAndGenerate_ByKeyType(t *testing.T) {
 		expectAlgo string
 	}{
 		{
+			name:       "empty defaults to ed25519",
+			keyType:    "",
+			keyBits:    0,
+			expectType: keyTypeED25519,
+			expectAlgo: ssh.KeyAlgoED25519,
+		},
+		{
 			name:       "ed25519",
 			keyType:    "ed25519",
 			keyBits:    0,


### PR DESCRIPTION
## Related Tickets & Documents

- Closes #350

## Changes

- Generate separate host and user keypairs instead of one shared gateway key