### PR TITLE
fix: Validate `twingate.host` against trusted controller domains

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,12 +31,12 @@ var (
 // dnsLabelRegexp matches a single DNS label.
 var dnsLabelRegexp = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
 
+// hostnameRegexp allows only valid DNS-label characters, permitting a single label (e.g. "test").
+var hostnameRegexp = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
+
 // allowedHostSuffixes restricts twingate.host to controller domains we trust as the JWKS
 // (GAT signing key) source. The "test" suffix supports local/e2e testing (e.g. acme.test).
 var allowedHostSuffixes = []string{"twingate.com", "opstg.com", "test"}
-
-// hostnameRegexp allows only valid DNS-label characters, permitting a single label (e.g. "test").
-var hostnameRegexp = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
 
 const (
 	defaultTwingateHost               = "twingate.com"
@@ -700,8 +700,10 @@ func validateHost(host string) error {
 		return fmt.Errorf("%w: not a valid hostname: %q", ErrInvalidHost, host)
 	}
 
+	// DNS hostnames are case-insensitive, so match the suffix allowlist case-insensitively.
+	lowered := strings.ToLower(host)
 	for _, suffix := range allowedHostSuffixes {
-		if host == suffix || strings.HasSuffix(host, "."+suffix) {
+		if lowered == suffix || strings.HasSuffix(lowered, "."+suffix) {
 			return nil
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -20,10 +21,18 @@ import (
 var (
 	ErrRequired          = errors.New("required field is missing")
 	ErrInvalidPort       = errors.New("invalid port number")
+	ErrInvalidHost       = errors.New("invalid twingate.host")
 	ErrDuplicateUpstream = errors.New("duplicate upstream name")
 	ErrInvalidSSHKeyType = errors.New("invalid SSH key type")
 	ErrNegativeTTL       = errors.New("TTL must be non-negative")
 )
+
+// allowedHostSuffixes restricts twingate.host to controller domains we trust as the JWKS
+// (GAT signing key) source. The "test" suffix supports local/e2e testing (e.g. acme.test).
+var allowedHostSuffixes = []string{"twingate.com", "opstg.com", "test"}
+
+// hostnameRegexp allows only valid DNS-label characters, permitting a single label (e.g. "test").
+var hostnameRegexp = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
 
 const (
 	defaultTwingateHost               = "twingate.com"
@@ -247,6 +256,10 @@ func (c *Config) ResolveTwingateHost(logger *zap.Logger) {
 func (c *Config) Validate() error {
 	if c.Twingate.Network == "" {
 		return fmt.Errorf("%w: twingate.network", ErrRequired)
+	}
+
+	if err := validateHost(c.Twingate.Host); err != nil {
+		return err
 	}
 
 	if err := validatePort(c.Port, "port"); err != nil {
@@ -662,6 +675,21 @@ func (v *SSHCAVaultConfig) GetUpstreamHostCAMount() string {
 	}
 
 	return defaultVaultSSHMount
+}
+
+// validateHost checks host is a well-formed hostname ending in an approved suffix.
+func validateHost(host string) error {
+	if !hostnameRegexp.MatchString(host) {
+		return fmt.Errorf("%w: not a valid hostname: %q", ErrInvalidHost, host)
+	}
+
+	for _, suffix := range allowedHostSuffixes {
+		if host == suffix || strings.HasSuffix(host, "."+suffix) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%w: must end with one of %v: %q", ErrInvalidHost, allowedHostSuffixes, host)
 }
 
 func validatePort(port int, fieldName string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,9 +34,13 @@ var dnsLabelRegexp = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0
 // hostnameRegexp allows only valid DNS-label characters, permitting a single label (e.g. "test").
 var hostnameRegexp = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
 
-// allowedHostSuffixes restricts twingate.host to controller domains we trust as the JWKS
-// (GAT signing key) source. The "test" suffix supports local/e2e testing (e.g. acme.test).
-var allowedHostSuffixes = []string{"twingate.com", "opstg.com", "test"}
+var IssuerByDomain = map[string]string{
+	"test":          "twingate-local",
+	"dev.opstg.com": "twingate-dev",
+	"stg.opstg.com": "twingate-stg",
+	"sec.opstg.com": "twingate-sec",
+	"twingate.com":  "twingate",
+}
 
 const (
 	defaultTwingateHost               = "twingate.com"
@@ -694,21 +698,20 @@ func (v *SSHCAVaultConfig) GetUpstreamHostCAMount() string {
 	return defaultVaultSSHMount
 }
 
-// validateHost checks host is a well-formed hostname ending in an allowed suffix.
+// validateHost checks host is a well-formed hostname for a trusted Twingate controller domain.
 func validateHost(host string) error {
 	if !hostnameRegexp.MatchString(host) {
 		return fmt.Errorf("%w: not a valid hostname: %q", ErrInvalidHost, host)
 	}
 
-	// DNS hostnames are case-insensitive, so match the suffix allowlist case-insensitively.
 	lowered := strings.ToLower(host)
-	for _, suffix := range allowedHostSuffixes {
-		if lowered == suffix || strings.HasSuffix(lowered, "."+suffix) {
+	for domain := range IssuerByDomain {
+		if lowered == domain || strings.HasSuffix(lowered, "."+domain) {
 			return nil
 		}
 	}
 
-	return fmt.Errorf("%w: must end with one of %v: %q", ErrInvalidHost, allowedHostSuffixes, host)
+	return fmt.Errorf("%w: not a trusted Twingate domain: %q", ErrInvalidHost, host)
 }
 
 func validatePort(port int, fieldName string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,12 +20,16 @@ import (
 
 var (
 	ErrRequired          = errors.New("required field is missing")
-	ErrInvalidPort       = errors.New("invalid port number")
+	ErrInvalidNetwork    = errors.New("invalid twingate.network")
 	ErrInvalidHost       = errors.New("invalid twingate.host")
+	ErrInvalidPort       = errors.New("invalid port number")
 	ErrDuplicateUpstream = errors.New("duplicate upstream name")
 	ErrInvalidSSHKeyType = errors.New("invalid SSH key type")
 	ErrNegativeTTL       = errors.New("TTL must be non-negative")
 )
+
+// dnsLabelRegexp matches a single DNS label.
+var dnsLabelRegexp = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
 
 // allowedHostSuffixes restricts twingate.host to controller domains we trust as the JWKS
 // (GAT signing key) source. The "test" suffix supports local/e2e testing (e.g. acme.test).
@@ -241,6 +245,13 @@ func resolveTwingateHostname(targetURL, defaultHost string, retryMax int, logger
 	}
 
 	resolved := location.Hostname()
+	if err := validateHost(resolved); err != nil {
+		logger.Warn("Resolved Twingate host failed validation, keeping configured host",
+			zap.String("resolvedHost", resolved), zap.Error(err))
+
+		return defaultHost
+	}
+
 	logger.Info("Resolved Twingate hostname", zap.String("hostname", resolved))
 
 	return resolved
@@ -256,6 +267,12 @@ func (c *Config) ResolveTwingateHost(logger *zap.Logger) {
 func (c *Config) Validate() error {
 	if c.Twingate.Network == "" {
 		return fmt.Errorf("%w: twingate.network", ErrRequired)
+	}
+
+	// twingate.network is interpolated into the JWKS URL authority (https://<network>.<host>/...),
+	// so it must be a single DNS label to keep the URL host from being altered.
+	if !dnsLabelRegexp.MatchString(c.Twingate.Network) {
+		return fmt.Errorf("%w: must be a valid DNS label: %q", ErrInvalidNetwork, c.Twingate.Network)
 	}
 
 	if err := validateHost(c.Twingate.Host); err != nil {
@@ -677,7 +694,7 @@ func (v *SSHCAVaultConfig) GetUpstreamHostCAMount() string {
 	return defaultVaultSSHMount
 }
 
-// validateHost checks host is a well-formed hostname ending in an approved suffix.
+// validateHost checks host is a well-formed hostname ending in an allowed suffix.
 func validateHost(host string) error {
 	if !hostnameRegexp.MatchString(host) {
 		return fmt.Errorf("%w: not a valid hostname: %q", ErrInvalidHost, host)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -48,6 +48,17 @@ func TestResolveTwingateHostname(t *testing.T) {
 		assert.Equal(t, "acme.us1.twingate.com", result)
 	})
 
+	t.Run("returns default host when resolved host is untrusted", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Location", "https://evil.com/api/v1/jwk/ec")
+			w.WriteHeader(http.StatusPermanentRedirect)
+		}))
+		t.Cleanup(server.Close)
+
+		result := resolveTwingateHostname(server.URL+"/api/v1/jwk/ec", "twingate.com", 0, zap.NewNop())
+		assert.Equal(t, "twingate.com", result)
+	})
+
 	t.Run("returns default host on empty location", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Location", "")
@@ -325,48 +336,16 @@ func TestConfig_Validate(t *testing.T) {
 			errContains: "twingate.network",
 		},
 		{
-			name: "invalid port",
+			name: "network with invalid characters",
 			config: &Config{
-				Twingate:    TwingateConfig{Network: "test", Host: "twingate.com"},
-				Port:        -1,
-				MetricsPort: 9090,
-				TLS: TLSConfig{
-					CertificateFile: "tls.crt",
-					PrivateKeyFile:  "tls.key",
-				},
-				Kubernetes: &KubernetesConfig{},
-			},
-			wantErr:     true,
-			errContains: "port must be between",
-		},
-		{
-			name: "invalid metrics port",
-			config: &Config{
-				Twingate:    TwingateConfig{Network: "test", Host: "twingate.com"},
-				Port:        8443,
-				MetricsPort: 70000,
-				TLS: TLSConfig{
-					CertificateFile: "tls.crt",
-					PrivateKeyFile:  "tls.key",
-				},
-				Kubernetes: &KubernetesConfig{},
-			},
-			wantErr:     true,
-			errContains: "metricsPort must be between",
-		},
-		{
-			name: "no protocols configured",
-			config: &Config{
-				Twingate:    TwingateConfig{Network: "test", Host: "twingate.com"},
+				Twingate:    TwingateConfig{Network: "evil.com/x", Host: "twingate.com"},
 				Port:        8443,
 				MetricsPort: 9090,
-				TLS: TLSConfig{
-					CertificateFile: "tls.crt",
-					PrivateKeyFile:  "tls.key",
-				},
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
 			},
 			wantErr:     true,
-			errContains: "at least one protocol",
+			errContains: "twingate.network",
 		},
 		{
 			name: "host with opstg suffix",
@@ -449,6 +428,50 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "must end with one of",
+		},
+		{
+			name: "invalid port",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "twingate.com"},
+				Port:        -1,
+				MetricsPort: 9090,
+				TLS: TLSConfig{
+					CertificateFile: "tls.crt",
+					PrivateKeyFile:  "tls.key",
+				},
+				Kubernetes: &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "port must be between",
+		},
+		{
+			name: "invalid metrics port",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "twingate.com"},
+				Port:        8443,
+				MetricsPort: 70000,
+				TLS: TLSConfig{
+					CertificateFile: "tls.crt",
+					PrivateKeyFile:  "tls.key",
+				},
+				Kubernetes: &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "metricsPort must be between",
+		},
+		{
+			name: "no protocols configured",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "twingate.com"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS: TLSConfig{
+					CertificateFile: "tls.crt",
+					PrivateKeyFile:  "tls.key",
+				},
+			},
+			wantErr:     true,
+			errContains: "at least one protocol",
 		},
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -350,7 +350,7 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "host with opstg suffix",
 			config: &Config{
-				Twingate:    TwingateConfig{Network: "test", Host: "foo.opstg.com"},
+				Twingate:    TwingateConfig{Network: "test", Host: "foo.stg.opstg.com"},
 				Port:        8443,
 				MetricsPort: 9090,
 				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
@@ -402,7 +402,7 @@ func TestConfig_Validate(t *testing.T) {
 				Kubernetes:  &KubernetesConfig{},
 			},
 			wantErr:     true,
-			errContains: "must end with one of",
+			errContains: "not a trusted Twingate domain",
 		},
 		{
 			name: "host with scheme and path",
@@ -438,7 +438,7 @@ func TestConfig_Validate(t *testing.T) {
 				Kubernetes:  &KubernetesConfig{},
 			},
 			wantErr:     true,
-			errContains: "must end with one of",
+			errContains: "not a trusted Twingate domain",
 		},
 		{
 			name: "invalid port",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -345,7 +345,7 @@ func TestConfig_Validate(t *testing.T) {
 				Kubernetes:  &KubernetesConfig{},
 			},
 			wantErr:     true,
-			errContains: "twingate.network",
+			errContains: "must be a valid DNS label",
 		},
 		{
 			name: "host with opstg suffix",
@@ -362,6 +362,17 @@ func TestConfig_Validate(t *testing.T) {
 			name: "host with test suffix",
 			config: &Config{
 				Twingate:    TwingateConfig{Network: "test", Host: "acme.test"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "host suffix match is case-insensitive",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "Foo.Twingate.COM"},
 				Port:        8443,
 				MetricsPort: 9090,
 				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -296,7 +296,7 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "valid config",
 			config: &Config{
-				Twingate:    TwingateConfig{Network: "test"},
+				Twingate:    TwingateConfig{Network: "test", Host: "twingate.com"},
 				Port:        8443,
 				MetricsPort: 9090,
 				TLS: TLSConfig{
@@ -327,7 +327,7 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "invalid port",
 			config: &Config{
-				Twingate:    TwingateConfig{Network: "test"},
+				Twingate:    TwingateConfig{Network: "test", Host: "twingate.com"},
 				Port:        -1,
 				MetricsPort: 9090,
 				TLS: TLSConfig{
@@ -342,7 +342,7 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "invalid metrics port",
 			config: &Config{
-				Twingate:    TwingateConfig{Network: "test"},
+				Twingate:    TwingateConfig{Network: "test", Host: "twingate.com"},
 				Port:        8443,
 				MetricsPort: 70000,
 				TLS: TLSConfig{
@@ -357,7 +357,7 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "no protocols configured",
 			config: &Config{
-				Twingate:    TwingateConfig{Network: "test"},
+				Twingate:    TwingateConfig{Network: "test", Host: "twingate.com"},
 				Port:        8443,
 				MetricsPort: 9090,
 				TLS: TLSConfig{
@@ -367,6 +367,88 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "at least one protocol",
+		},
+		{
+			name: "host with opstg suffix",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "foo.opstg.com"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "host with test suffix",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "acme.test"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty host",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: ""},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "invalid twingate.host",
+		},
+		{
+			name: "host with disallowed suffix",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "evil.example.com"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "must end with one of",
+		},
+		{
+			name: "host with scheme and path",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "https://evil.com/x"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "not a valid hostname",
+		},
+		{
+			name: "host embeds allowed suffix in path",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "evil.com/x.twingate.com"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "not a valid hostname",
+		},
+		{
+			name: "host is an IP address",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "10.0.0.5"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "must end with one of",
 		},
 	}
 

--- a/internal/token/parser.go
+++ b/internal/token/parser.go
@@ -10,22 +10,18 @@ import (
 
 	"github.com/MicahParks/keyfunc/v3"
 	"github.com/golang-jwt/jwt/v5"
+
+	"gateway/internal/config"
 )
 
 var errInvalidTokenType = errors.New("token type is invalid")
 
 var allowedSigningMethods = []string{jwt.SigningMethodES256.Alg()}
 
-var allowedIssuerByDomain = map[string]string{
-	"test":          "twingate-local",
-	"dev.opstg.com": "twingate-dev",
-	"stg.opstg.com": "twingate-stg",
-	"twingate.com":  "twingate",
-}
-
 func getIssuer(host string) string {
-	for baseDomain, issuer := range allowedIssuerByDomain {
-		if baseDomain == host || strings.HasSuffix(host, "."+baseDomain) {
+	lowered := strings.ToLower(host)
+	for domain, issuer := range config.IssuerByDomain {
+		if lowered == domain || strings.HasSuffix(lowered, "."+domain) {
 			return issuer
 		}
 	}
@@ -51,27 +47,27 @@ type Parser struct {
 	config ParserConfig
 }
 
-func NewParser(config ParserConfig) (*Parser, error) {
-	if config.Keyfunc == nil {
-		jwkURL := fmt.Sprintf("https://%s.%s/api/v1/jwk/ec", config.Network, config.Host)
+func NewParser(cfg ParserConfig) (*Parser, error) {
+	if cfg.Keyfunc == nil {
+		jwkURL := fmt.Sprintf("https://%s.%s/api/v1/jwk/ec", cfg.Network, cfg.Host)
 
 		jwks, err := keyfunc.NewDefault([]string{jwkURL})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create JWKS store: %w", err)
 		}
 
-		config.Keyfunc = jwks.Keyfunc
+		cfg.Keyfunc = jwks.Keyfunc
 	}
 
 	return &Parser{
 		parser: jwt.NewParser(
 			jwt.WithValidMethods(allowedSigningMethods),
-			jwt.WithIssuer(getIssuer(config.Host)),
-			jwt.WithAudience(config.Network),
+			jwt.WithIssuer(getIssuer(cfg.Host)),
+			jwt.WithAudience(cfg.Network),
 			jwt.WithIssuedAt(),
 			jwt.WithExpirationRequired(),
 		),
-		config: config,
+		config: cfg,
 	}, nil
 }
 


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #352

## Changes

- Validate `twingate.network` is a single DNS label, since it is interpolated into the JWKS URL authority.
- Validate `twingate.host` against the trusted Twingate controller domains, matched case-insensitively, using the same allowlist as token issuer validation (single source of truth in `config`) so an accepted host always has a known JWT issuer.
- Re-validate the controller-resolved host, keeping the configured host if the redirect target is not trusted.
