### PR TITLE
refactor: move Twingate backend config from `token` into `config` package

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,14 @@ var (
 	ErrNegativeTTL       = errors.New("TTL must be non-negative")
 )
 
+var issuerByDomain = map[string]string{
+	"test":          "twingate-local",
+	"dev.opstg.com": "twingate-dev",
+	"stg.opstg.com": "twingate-stg",
+	"sec.opstg.com": "twingate-sec",
+	"twingate.com":  "twingate",
+}
+
 const (
 	defaultTwingateHost               = "twingate.com"
 	defaultPort                       = 8443
@@ -51,6 +59,16 @@ type WebAppConfig struct {
 type TwingateConfig struct {
 	Network string `yaml:"network"`
 	Host    string `yaml:"host"`
+}
+
+// JWKSURL returns the controller endpoint for fetching GAT signing keys.
+func (t TwingateConfig) JWKSURL() string {
+	return fmt.Sprintf("https://%s.%s/api/v1/jwk/ec", t.Network, t.Host)
+}
+
+// Issuer returns the expected JWT issuer for the configured controller host.
+func (t TwingateConfig) Issuer() string {
+	return issuerByDomain[trustedDomainFor(t.Host)]
 }
 
 type AuditLogConfig struct {
@@ -238,8 +256,7 @@ func resolveTwingateHostname(targetURL, defaultHost string, retryMax int, logger
 }
 
 func (c *Config) ResolveTwingateHost(logger *zap.Logger) {
-	targetURL := fmt.Sprintf("https://%s.%s/api/v1/jwk/ec", c.Twingate.Network, c.Twingate.Host)
-	resolvedHostname := resolveTwingateHostname(targetURL, c.Twingate.Host, 2, logger)
+	resolvedHostname := resolveTwingateHostname(c.Twingate.JWKSURL(), c.Twingate.Host, 2, logger)
 
 	c.Twingate.Host = stripNetworkPrefix(resolvedHostname, c.Twingate.Network)
 }
@@ -662,6 +679,19 @@ func (v *SSHCAVaultConfig) GetUpstreamHostCAMount() string {
 	}
 
 	return defaultVaultSSHMount
+}
+
+// trustedDomainFor returns the trusted Twingate domain that host belongs to, or "" if none.
+// A host matches a domain exactly or as a subdomain, so sharded hosts like us1.twingate.com are
+// trusted.
+func trustedDomainFor(host string) string {
+	for domain := range issuerByDomain {
+		if host == domain || strings.HasSuffix(host, "."+domain) {
+			return domain
+		}
+	}
+
+	return ""
 }
 
 func validatePort(port int, fieldName string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -36,6 +36,29 @@ func TestStripNetworkPrefix(t *testing.T) {
 	}
 }
 
+func TestTwingateConfig_JWKSURL(t *testing.T) {
+	cfg := TwingateConfig{Network: "acme", Host: "twingate.com"}
+	assert.Equal(t, "https://acme.twingate.com/api/v1/jwk/ec", cfg.JWKSURL())
+}
+
+func TestTwingateConfig_Issuer(t *testing.T) {
+	tests := []struct {
+		name   string
+		host   string
+		issuer string
+	}{
+		{name: "exact match", host: "twingate.com", issuer: "twingate"},
+		{name: "sharded host", host: "us1.twingate.com", issuer: "twingate"},
+		{name: "unknown host", host: "unknown-dev.opstg.com", issuer: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.issuer, TwingateConfig{Host: tt.host}.Issuer())
+		})
+	}
+}
+
 func TestResolveTwingateHostname(t *testing.T) {
 	t.Run("returns location hostname on 308 status code", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -72,8 +72,8 @@ func createParserAndGATToken(t *testing.T, claims token.GATClaims) (*token.Parse
 	require.NoError(t, err)
 
 	parser, err := token.NewParser(token.ParserConfig{
-		Network: "acme",
-		Host:    "twingate.com",
+		Issuer:   "twingate",
+		Audience: "acme",
 		Keyfunc: func(_token *jwt.Token) (any, error) {
 			return &privateKey.PublicKey, nil
 		},

--- a/internal/connect/listener.go
+++ b/internal/connect/listener.go
@@ -93,8 +93,9 @@ func NewListener(
 	logger *zap.Logger,
 ) (*Listener, error) {
 	tokenParser, err := token.NewParser(token.ParserConfig{
-		Network: twingateConfig.Network,
-		Host:    twingateConfig.Host,
+		Issuer:   twingateConfig.Issuer(),
+		Audience: twingateConfig.Network,
+		JWKSURL:  twingateConfig.JWKSURL(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create token parser: %w", err)

--- a/internal/token/parser.go
+++ b/internal/token/parser.go
@@ -6,7 +6,6 @@ package token
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/MicahParks/keyfunc/v3"
 	"github.com/golang-jwt/jwt/v5"
@@ -16,32 +15,17 @@ var errInvalidTokenType = errors.New("token type is invalid")
 
 var allowedSigningMethods = []string{jwt.SigningMethodES256.Alg()}
 
-var allowedIssuerByDomain = map[string]string{
-	"test":          "twingate-local",
-	"dev.opstg.com": "twingate-dev",
-	"stg.opstg.com": "twingate-stg",
-	"twingate.com":  "twingate",
-}
-
-func getIssuer(host string) string {
-	for baseDomain, issuer := range allowedIssuerByDomain {
-		if baseDomain == host || strings.HasSuffix(host, "."+baseDomain) {
-			return issuer
-		}
-	}
-
-	return ""
-}
-
 type ClaimsWithHeaderType interface {
 	getHeaderType() string
 }
 
 type ParserConfig struct {
-	// Twingate network ID
-	Network string
-	// Twingate service domain
-	Host string
+	// Issuer is the expected JWT issuer (iss claim).
+	Issuer string
+	// Audience is the expected JWT audience (aud claim).
+	Audience string
+	// JWKSURL is the endpoint to fetch signing keys from when Keyfunc is not provided.
+	JWKSURL string
 	// Keyfunc to verify token. Default to using remote JWKs
 	Keyfunc jwt.Keyfunc
 }
@@ -53,9 +37,7 @@ type Parser struct {
 
 func NewParser(config ParserConfig) (*Parser, error) {
 	if config.Keyfunc == nil {
-		jwkURL := fmt.Sprintf("https://%s.%s/api/v1/jwk/ec", config.Network, config.Host)
-
-		jwks, err := keyfunc.NewDefault([]string{jwkURL})
+		jwks, err := keyfunc.NewDefault([]string{config.JWKSURL})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create JWKS store: %w", err)
 		}
@@ -66,8 +48,8 @@ func NewParser(config ParserConfig) (*Parser, error) {
 	return &Parser{
 		parser: jwt.NewParser(
 			jwt.WithValidMethods(allowedSigningMethods),
-			jwt.WithIssuer(getIssuer(config.Host)),
-			jwt.WithAudience(config.Network),
+			jwt.WithIssuer(config.Issuer),
+			jwt.WithAudience(config.Audience),
 			jwt.WithIssuedAt(),
 			jwt.WithExpirationRequired(),
 		),

--- a/internal/token/parser_test.go
+++ b/internal/token/parser_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -73,9 +72,9 @@ func (c *CustomClaims) getHeaderType() string {
 func TestParser_ParseWithClaims(t *testing.T) {
 	tokenService := newTokenService()
 	parser, _ := NewParser(ParserConfig{
-		Network: "acme",
-		Host:    "twingate.com",
-		Keyfunc: tokenService.keyfunc,
+		Issuer:   "twingate",
+		Audience: "acme",
+		Keyfunc:  tokenService.keyfunc,
 	})
 
 	t.Run("Valid token type", func(t *testing.T) {
@@ -128,9 +127,9 @@ func TestNewParser(t *testing.T) {
 	tokenService := newTokenService()
 
 	parser, err := NewParser(ParserConfig{
-		Network: "acme",
-		Host:    "twingate.com",
-		Keyfunc: tokenService.keyfunc,
+		Issuer:   "twingate",
+		Audience: "acme",
+		Keyfunc:  tokenService.keyfunc,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, parser)
@@ -203,24 +202,6 @@ func TestNewParser(t *testing.T) {
 
 			require.ErrorIs(t, err, tt.expectedError)
 			require.Nil(t, token)
-		})
-	}
-}
-
-func TestGetIssuer(t *testing.T) {
-	tests := []struct {
-		name   string
-		host   string
-		issuer string
-	}{
-		{name: "exact match", host: "twingate.com", issuer: "twingate"},
-		{name: "sharded host", host: "us1.twingate.com", issuer: "twingate"},
-		{name: "unknown host", host: "unknown-dev.opstg.com", issuer: ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.issuer, getIssuer(tt.host))
 		})
 	}
 }


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #352
- Prerequisite for the trust-anchor validation in #359 (stacked on this).

## Changes

- Move the trusted domain → issuer map and JWKS URL construction into `config` as `TwingateConfig.Issuer()` and `TwingateConfig.JWKSURL()`.
- `token.ParserConfig` now takes `Issuer`, `Audience`, `JWKSURL` instead of `Network`/`Host`.
- `ResolveTwingateHost` reuses `JWKSURL()` so the JWKS URL is built in one place.
- Add `sec.opstg.com` to the trusted domains.

## Notes

- Separates concerns: `config` owns Twingate-backend specifics, `token` is generic JWT validation. The host/network trust-anchor validation lands in the follow-up PR stacked on this one.
