### PR TITLE
fix: Validate `twingate.host` and `twingate.network` against trusted domains

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,7 +28,7 @@ var (
 	ErrNegativeTTL       = errors.New("TTL must be non-negative")
 )
 
-// networkRegexp matches a twingate.network slug: 1-63 lowercase letters and digits.
+// networkRegexp matches a twingate.network slug: 1-63 lowercase alphanumeric characters.
 var networkRegexp = regexp.MustCompile(`^[a-z0-9]{1,63}$`)
 
 // hostnameRegexp allows only valid DNS-label characters, permitting a single label (e.g. "test").
@@ -297,7 +297,7 @@ func (c *Config) Validate() error {
 	}
 
 	if !networkRegexp.MatchString(c.Twingate.Network) {
-		return fmt.Errorf("%w: must be 1-63 lowercase letters or digits: %q", ErrInvalidNetwork, c.Twingate.Network)
+		return fmt.Errorf("%w: must be 1-63 lowercase alphanumeric characters: %q", ErrInvalidNetwork, c.Twingate.Network)
 	}
 
 	if err := validateHost(c.Twingate.Host); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -19,11 +20,19 @@ import (
 
 var (
 	ErrRequired          = errors.New("required field is missing")
+	ErrInvalidNetwork    = errors.New("invalid twingate.network")
+	ErrInvalidHost       = errors.New("invalid twingate.host")
 	ErrInvalidPort       = errors.New("invalid port number")
 	ErrDuplicateUpstream = errors.New("duplicate upstream name")
 	ErrInvalidSSHKeyType = errors.New("invalid SSH key type")
 	ErrNegativeTTL       = errors.New("TTL must be non-negative")
 )
+
+// networkRegexp matches a twingate.network slug: 1-63 lowercase letters and digits.
+var networkRegexp = regexp.MustCompile(`^[a-z0-9]{1,63}$`)
+
+// hostnameRegexp allows only valid DNS-label characters, permitting a single label (e.g. "test").
+var hostnameRegexp = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
 
 var issuerByDomain = map[string]string{
 	"test":          "twingate-local",
@@ -264,6 +273,13 @@ func resolveTwingateHostname(targetURL, defaultHost string, retryMax int, logger
 	}
 
 	resolved := location.Hostname()
+	if err := validateHost(resolved); err != nil {
+		logger.Warn("Resolved Twingate host failed validation, keeping configured host",
+			zap.String("resolvedHost", resolved), zap.Error(err))
+
+		return defaultHost
+	}
+
 	logger.Info("Resolved Twingate hostname", zap.String("hostname", resolved))
 
 	return resolved
@@ -278,6 +294,14 @@ func (c *Config) ResolveTwingateHost(logger *zap.Logger) {
 func (c *Config) Validate() error {
 	if c.Twingate.Network == "" {
 		return fmt.Errorf("%w: twingate.network", ErrRequired)
+	}
+
+	if !networkRegexp.MatchString(c.Twingate.Network) {
+		return fmt.Errorf("%w: must be 1-63 lowercase letters or digits: %q", ErrInvalidNetwork, c.Twingate.Network)
+	}
+
+	if err := validateHost(c.Twingate.Host); err != nil {
+		return err
 	}
 
 	if err := validatePort(c.Port, "port"); err != nil {
@@ -708,12 +732,26 @@ func (v *SSHCAVaultConfig) GetUpstreamHostCAMount() string {
 	return defaultVaultSSHMount
 }
 
+// validateHost checks host is a well-formed hostname for a trusted Twingate controller domain.
+func validateHost(host string) error {
+	if !hostnameRegexp.MatchString(host) {
+		return fmt.Errorf("%w: not a valid hostname: %q", ErrInvalidHost, host)
+	}
+
+	if trustedDomainFor(host) == "" {
+		return fmt.Errorf("%w: not a trusted Twingate domain: %q", ErrInvalidHost, host)
+	}
+
+	return nil
+}
+
 // trustedDomainFor returns the trusted Twingate domain that host belongs to, or "" if none.
 // A host matches a domain exactly or as a subdomain, so sharded hosts like us1.twingate.com are
-// trusted.
+// trusted. Matching is case-insensitive.
 func trustedDomainFor(host string) string {
+	lowered := strings.ToLower(host)
 	for domain := range issuerByDomain {
-		if host == domain || strings.HasSuffix(host, "."+domain) {
+		if lowered == domain || strings.HasSuffix(lowered, "."+domain) {
 			return domain
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,8 +226,9 @@ func Load(path string) (*Config, error) {
 	return cfg, nil
 }
 
+// stripNetworkPrefix lowercases hostname and removes a leading "<network>." label if present.
 func stripNetworkPrefix(hostname, network string) string {
-	return strings.TrimPrefix(hostname, network+".")
+	return strings.TrimPrefix(strings.ToLower(hostname), strings.ToLower(network)+".")
 }
 
 func resolveTwingateHostname(targetURL, defaultHost string, retryMax int, logger *zap.Logger) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,6 +27,8 @@ func TestStripNetworkPrefix(t *testing.T) {
 		{name: "non-sharded host", hostname: "acme.test.com", network: "acme", expected: "test.com"},
 		{name: "no network prefix", hostname: "test.com", network: "acme", expected: "test.com"},
 		{name: "empty network", hostname: "us1.twingate.com", network: "", expected: "us1.twingate.com"},
+		{name: "uppercase host prefix", hostname: "ACME.us1.twingate.com", network: "acme", expected: "us1.twingate.com"},
+		{name: "uppercase network", hostname: "acme.us1.twingate.com", network: "ACME", expected: "us1.twingate.com"},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -71,6 +72,17 @@ func TestResolveTwingateHostname(t *testing.T) {
 
 		result := resolveTwingateHostname(server.URL+"/api/v1/jwk/ec", "twingate.com", 0, zap.NewNop())
 		assert.Equal(t, "acme.us1.twingate.com", result)
+	})
+
+	t.Run("returns default host when resolved host is untrusted", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Location", "https://evil.com/api/v1/jwk/ec")
+			w.WriteHeader(http.StatusPermanentRedirect)
+		}))
+		t.Cleanup(server.Close)
+
+		result := resolveTwingateHostname(server.URL+"/api/v1/jwk/ec", "twingate.com", 0, zap.NewNop())
+		assert.Equal(t, "twingate.com", result)
 	})
 
 	t.Run("returns default host on empty location", func(t *testing.T) {
@@ -321,7 +333,7 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "valid config",
 			config: &Config{
-				Twingate:    TwingateConfig{Network: "test"},
+				Twingate:    TwingateConfig{Network: "test", Host: "twingate.com"},
 				Port:        8443,
 				MetricsPort: 9090,
 				TLS: TLSConfig{
@@ -350,9 +362,172 @@ func TestConfig_Validate(t *testing.T) {
 			errContains: "twingate.network",
 		},
 		{
+			name: "network with digits",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "us1", Host: "twingate.com"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "network with invalid characters",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "evil.com/x", Host: "twingate.com"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "must be 1-63 lowercase letters or digits",
+		},
+		{
+			name: "network with uppercase letters",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "ACME", Host: "twingate.com"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "must be 1-63 lowercase letters or digits",
+		},
+		{
+			name: "network with hyphen",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "us1-acme", Host: "twingate.com"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "must be 1-63 lowercase letters or digits",
+		},
+		{
+			name: "network at max length",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: strings.Repeat("a", 63), Host: "twingate.com"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "network over max length",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: strings.Repeat("a", 64), Host: "twingate.com"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "must be 1-63 lowercase letters or digits",
+		},
+		{
+			name: "host with opstg suffix",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "foo.stg.opstg.com"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "host with test suffix",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "acme", Host: "test"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "host suffix match is case-insensitive",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "Foo.Twingate.COM"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty host",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: ""},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "invalid twingate.host",
+		},
+		{
+			name: "host with disallowed suffix",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "evil.example.com"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "not a trusted Twingate domain",
+		},
+		{
+			name: "host with scheme and path",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "https://evil.com/x"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "not a valid hostname",
+		},
+		{
+			name: "host embeds allowed suffix in path",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "evil.com/x.twingate.com"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "not a valid hostname",
+		},
+		{
+			name: "host is an IP address",
+			config: &Config{
+				Twingate:    TwingateConfig{Network: "test", Host: "10.0.0.5"},
+				Port:        8443,
+				MetricsPort: 9090,
+				TLS:         TLSConfig{CertificateFile: "tls.crt", PrivateKeyFile: "tls.key"},
+				Kubernetes:  &KubernetesConfig{},
+			},
+			wantErr:     true,
+			errContains: "not a trusted Twingate domain",
+		},
+		{
 			name: "invalid port",
 			config: &Config{
-				Twingate:    TwingateConfig{Network: "test"},
+				Twingate:    TwingateConfig{Network: "test", Host: "twingate.com"},
 				Port:        -1,
 				MetricsPort: 9090,
 				TLS: TLSConfig{
@@ -367,7 +542,7 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "invalid metrics port",
 			config: &Config{
-				Twingate:    TwingateConfig{Network: "test"},
+				Twingate:    TwingateConfig{Network: "test", Host: "twingate.com"},
 				Port:        8443,
 				MetricsPort: 70000,
 				TLS: TLSConfig{
@@ -382,7 +557,7 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "no protocols configured",
 			config: &Config{
-				Twingate:    TwingateConfig{Network: "test"},
+				Twingate:    TwingateConfig{Network: "test", Host: "twingate.com"},
 				Port:        8443,
 				MetricsPort: 9090,
 				TLS: TLSConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -382,7 +382,7 @@ func TestConfig_Validate(t *testing.T) {
 				Kubernetes:  &KubernetesConfig{},
 			},
 			wantErr:     true,
-			errContains: "must be 1-63 lowercase letters or digits",
+			errContains: "must be 1-63 lowercase alphanumeric characters",
 		},
 		{
 			name: "network with uppercase letters",
@@ -394,7 +394,7 @@ func TestConfig_Validate(t *testing.T) {
 				Kubernetes:  &KubernetesConfig{},
 			},
 			wantErr:     true,
-			errContains: "must be 1-63 lowercase letters or digits",
+			errContains: "must be 1-63 lowercase alphanumeric characters",
 		},
 		{
 			name: "network with hyphen",
@@ -406,7 +406,7 @@ func TestConfig_Validate(t *testing.T) {
 				Kubernetes:  &KubernetesConfig{},
 			},
 			wantErr:     true,
-			errContains: "must be 1-63 lowercase letters or digits",
+			errContains: "must be 1-63 lowercase alphanumeric characters",
 		},
 		{
 			name: "network at max length",
@@ -429,7 +429,7 @@ func TestConfig_Validate(t *testing.T) {
 				Kubernetes:  &KubernetesConfig{},
 			},
 			wantErr:     true,
-			errContains: "must be 1-63 lowercase letters or digits",
+			errContains: "must be 1-63 lowercase alphanumeric characters",
 		},
 		{
 			name: "host with opstg suffix",


### PR DESCRIPTION
## Related Tickets & Documents

- Closes #352

## Changes

- Validate `twingate.network` as a lowercase alphanumeric slug (1-63 lowercase letters + digits)
- Validate `twingate.host` against the trusted Twingate domains (case-insensitive), reusing the token-issuer allowlist so an accepted host always has a known JWT issuer
- Re-validate the resolved host after redirect; keep the configured host if the redirect target is untrusted
- Strip the network prefix from the resolved host case-insensitively (the redirect target's case is not under our control)

