### PR TITLE
feat: rewrite CONNECT destination port to GAT upstream port

### DIFF
--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -182,6 +182,13 @@ func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (connectI
 			}
 	}
 
+	// The upstream port is validated for presence and range when the token is parsed
+	// (see GATClaims.Validate), so it is guaranteed to be within the valid range here.
+	upstreamPort := gatClaims.Resource.GatewayMetadata.Upstream.Port
+
+	// rewrite the destination port to the upstream port for backend forwarding
+	address = net.JoinHostPort(host, strconv.Itoa(upstreamPort))
+
 	return Info{
 		Address: address,
 		Claims:  gatClaims,

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -155,9 +155,10 @@ func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (connectI
 			}
 	}
 
-	// The downstream port is validated for presence and range when the token is parsed
+	// Both ports are validated for presence and range when the token is parsed
 	// so it is guaranteed to be within the valid range here.
 	downstreamPort := gatClaims.Resource.GatewayMetadata.Downstream.Port
+	upstreamPort := gatClaims.Resource.GatewayMetadata.Upstream.Port
 
 	requestedPort, portErr := strconv.Atoi(port)
 	if portErr != nil {
@@ -181,10 +182,6 @@ func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (connectI
 				Err:     nil,
 			}
 	}
-
-	// The upstream port is validated for presence and range when the token is parsed
-	// (see GATClaims.Validate), so it is guaranteed to be within the valid range here.
-	upstreamPort := gatClaims.Resource.GatewayMetadata.Upstream.Port
 
 	// rewrite the destination port to the upstream port for backend forwarding
 	address = net.JoinHostPort(host, strconv.Itoa(upstreamPort))

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -66,6 +66,7 @@ func newGATTokenClaims(clientPublicKey token.PublicKey) token.GATClaims {
 			Address: "example.com",
 			GatewayMetadata: token.GatewayMetadata{
 				Downstream: token.Downstream{Port: 443},
+				Upstream:   token.Upstream{Port: 443},
 			},
 		},
 	}
@@ -369,6 +370,52 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 	t.Run("Missing downstream port in token is rejected at parse", func(t *testing.T) {
 		claimsNoPort := newGATTokenClaims(c.getPublicKey())
 		claimsNoPort.Resource.GatewayMetadata = token.GatewayMetadata{}
+		parserNoPort, tokenNoPort := createParserAndGATToken(t, claimsNoPort)
+		validator := &MessageValidator{TokenParser: parserNoPort}
+
+		req := httptest.NewRequest(http.MethodConnect, "example.com:443", nil)
+		req.Header.Set(AuthHeaderKey, "Bearer "+tokenNoPort)
+
+		signature := c.sign(sigData)
+		req.Header.Set(AuthSignatureHeaderKey, signature)
+		req.Header.Set(ConnIDHeaderKey, "conn-id")
+
+		connectInfo, err := validator.ParseConnect(req, []byte(sigData))
+
+		var httpErr *HTTPError
+
+		require.ErrorAs(t, err, &httpErr)
+		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
+		assert.Contains(t, httpErr.Error(), "failed to parse token")
+		assert.Contains(t, httpErr.Error(), "invalid port")
+		assert.Nil(t, connectInfo.Claims)
+		assert.Equal(t, "conn-id", connectInfo.ConnID)
+	})
+
+	t.Run("Rewrites destination port to upstream port", func(t *testing.T) {
+		claims := newGATTokenClaims(c.getPublicKey())
+		claims.Resource.GatewayMetadata.Upstream = token.Upstream{Port: 8443}
+		parserRewrite, tokenRewrite := createParserAndGATToken(t, claims)
+		validator := &MessageValidator{TokenParser: parserRewrite}
+
+		// client targets the downstream port 443; backend must be dialed on upstream 8443
+		req := httptest.NewRequest(http.MethodConnect, "example.com:443", nil)
+		req.Header.Set(AuthHeaderKey, "Bearer "+tokenRewrite)
+
+		signature := c.sign(sigData)
+		req.Header.Set(AuthSignatureHeaderKey, signature)
+		req.Header.Set(ConnIDHeaderKey, "conn-id")
+
+		connectInfo, err := validator.ParseConnect(req, []byte(sigData))
+
+		require.NoError(t, err)
+		assert.Equal(t, "example.com:8443", connectInfo.Address)
+		assert.Equal(t, "conn-id", connectInfo.ConnID)
+	})
+
+	t.Run("Missing upstream port in token is rejected at parse", func(t *testing.T) {
+		claimsNoPort := newGATTokenClaims(c.getPublicKey())
+		claimsNoPort.Resource.GatewayMetadata.Upstream = token.Upstream{}
 		parserNoPort, tokenNoPort := createParserAndGATToken(t, claimsNoPort)
 		validator := &MessageValidator{TokenParser: parserNoPort}
 

--- a/internal/token/gat_claims.go
+++ b/internal/token/gat_claims.go
@@ -64,7 +64,11 @@ func (p GATClaims) Validate() error {
 		return fmt.Errorf("%w: %w %q", jwt.ErrTokenInvalidClaims, errUnsupportedVersion, p.Version)
 	}
 
-	return validatePort(p.Resource.GatewayMetadata.Downstream.Port, "resource.gateway_metadata.downstream.port")
+	if err := validatePort(p.Resource.GatewayMetadata.Downstream.Port, "resource.gateway_metadata.downstream.port"); err != nil {
+		return err
+	}
+
+	return validatePort(p.Resource.GatewayMetadata.Upstream.Port, "resource.gateway_metadata.upstream.port")
 }
 
 // validatePort ensures a GAT-provided port is within the valid TCP range. A missing port (zero)
@@ -136,10 +140,16 @@ type Resource struct {
 // GatewayMetadata carries per-resource routing details from the GAT.
 type GatewayMetadata struct {
 	Downstream Downstream `json:"downstream"`
+	Upstream   Upstream   `json:"upstream"`
 }
 
 // Downstream is the client-facing endpoint the CONNECT destination must target.
 type Downstream struct {
+	Port int `json:"port"`
+}
+
+// Upstream is the backend endpoint the CONNECT destination is forwarded to.
+type Upstream struct {
 	Port int `json:"port"`
 }
 

--- a/internal/token/gat_claims_test.go
+++ b/internal/token/gat_claims_test.go
@@ -77,6 +77,7 @@ func TestGATTokenClaims_Validate(t *testing.T) {
 			Address: "resource.internal",
 			GatewayMetadata: GatewayMetadata{
 				Downstream: Downstream{Port: 443},
+				Upstream:   Upstream{Port: 8443},
 			},
 		},
 	}
@@ -179,6 +180,30 @@ func TestGATTokenClaims_Validate(t *testing.T) {
 			},
 			expectedError:        jwt.ErrTokenInvalidClaims,
 			expectedErrorMessage: "invalid port \"resource.gateway_metadata.downstream.port\"=65536",
+		},
+		{
+			name: "Missing upstream port",
+			setupFn: func(claims *GATClaims) {
+				claims.Resource.GatewayMetadata.Upstream.Port = 0
+			},
+			expectedError:        jwt.ErrTokenInvalidClaims,
+			expectedErrorMessage: "invalid port \"resource.gateway_metadata.upstream.port\"=0",
+		},
+		{
+			name: "Negative upstream port",
+			setupFn: func(claims *GATClaims) {
+				claims.Resource.GatewayMetadata.Upstream.Port = -1
+			},
+			expectedError:        jwt.ErrTokenInvalidClaims,
+			expectedErrorMessage: "invalid port \"resource.gateway_metadata.upstream.port\"=-1",
+		},
+		{
+			name: "Upstream port out of range",
+			setupFn: func(claims *GATClaims) {
+				claims.Resource.GatewayMetadata.Upstream.Port = 65536
+			},
+			expectedError:        jwt.ErrTokenInvalidClaims,
+			expectedErrorMessage: "invalid port \"resource.gateway_metadata.upstream.port\"=65536",
 		},
 	}
 

--- a/test/fake/client.go
+++ b/test/fake/client.go
@@ -45,7 +45,8 @@ type Client struct {
 	controllerURL string
 
 	resourceHostname string
-	resourcePort     string
+	downstreamPort   int
+	upstreamPort     int
 	resourceType     token.ResourceType
 
 	cancel context.CancelFunc
@@ -54,8 +55,10 @@ type Client struct {
 	logger *zap.Logger
 }
 
-// NewClient creates a new Client. upstreamAddress must include both the host and the port.
-func NewClient(user *token.User, geoIPLocation token.GeoIPLocation, proxyAddress, controllerURL, upstreamAddress string, resourceType token.ResourceType) *Client {
+// NewClient creates a new Client. upstreamAddress must include both the host and the port that
+// the backend actually listens on. downstreamPort is the client-facing port used in the CONNECT
+// request; the Gateway rewrites it to the upstream port before forwarding to the backend.
+func NewClient(user *token.User, geoIPLocation token.GeoIPLocation, proxyAddress, controllerURL, upstreamAddress string, downstreamPort int, resourceType token.ResourceType) *Client {
 	logger := zap.Must(zap.NewDevelopment()).Named(fmt.Sprintf("client-%s-%s", user.ID, user.Username))
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -72,6 +75,13 @@ func NewClient(user *token.User, geoIPLocation token.GeoIPLocation, proxyAddress
 		return nil
 	}
 
+	upstreamPort, err := strconv.Atoi(resourcePort)
+	if err != nil {
+		logger.Fatal("Failed to parse upstream port", zap.Error(err))
+
+		return nil
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	c := &Client{
@@ -82,7 +92,8 @@ func NewClient(user *token.User, geoIPLocation token.GeoIPLocation, proxyAddress
 		user:             user,
 		geoIPLocation:    geoIPLocation,
 		resourceHostname: resourceHostname,
-		resourcePort:     resourcePort,
+		downstreamPort:   downstreamPort,
+		upstreamPort:     upstreamPort,
 		resourceType:     resourceType,
 		cancel:           cancel,
 		wg:               &sync.WaitGroup{},
@@ -167,7 +178,7 @@ func (c *Client) handleConnection(ctx context.Context, clientConn net.Conn, gat 
 	defer proxyTLSConn.Close()
 
 	// Create CONNECT request
-	connectReq, err := http.NewRequest(http.MethodConnect, "https://"+net.JoinHostPort(c.resourceHostname, c.resourcePort), nil)
+	connectReq, err := http.NewRequest(http.MethodConnect, "https://"+net.JoinHostPort(c.resourceHostname, strconv.Itoa(c.downstreamPort)), nil)
 	if err != nil {
 		c.logger.Error("Failed to create request", zap.Error(err))
 
@@ -223,13 +234,6 @@ func (c *Client) handleConnection(ctx context.Context, clientConn net.Conn, gat 
 func (c *Client) fetchGAT() (string, error) {
 	clientPublicKey, _ := ReadECKey(data.ClientKey)
 
-	downstreamPort, err := strconv.Atoi(c.resourcePort)
-	if err != nil {
-		c.logger.Error("Failed to parse resource port", zap.Error(err))
-
-		return "", err
-	}
-
 	requestBody := requestBody{
 		ClientPublicKey: &token.PublicKey{
 			PublicKey: clientPublicKey.PublicKey,
@@ -244,7 +248,8 @@ func (c *Client) fetchGAT() (string, error) {
 			Type:    c.resourceType,
 			Address: c.resourceHostname,
 			GatewayMetadata: token.GatewayMetadata{
-				Downstream: token.Downstream{Port: downstreamPort},
+				Downstream: token.Downstream{Port: c.downstreamPort},
+				Upstream:   token.Upstream{Port: c.upstreamPort},
 			},
 		},
 	}

--- a/test/fake/client.go
+++ b/test/fake/client.go
@@ -56,8 +56,8 @@ type Client struct {
 }
 
 // NewClient creates a new Client. upstreamAddress must include both the host and the port that
-// the backend actually listens on. downstreamPort is the client-facing port used in the CONNECT
-// request; the Gateway rewrites it to the upstream port before forwarding to the backend.
+// the backend actually listens on. downstreamPort is the client-facing port used in the CONNECT request.
+// The Gateway rewrites it to the upstream port before forwarding to the backend.
 func NewClient(user *token.User, geoIPLocation token.GeoIPLocation, proxyAddress, controllerURL, upstreamAddress string, downstreamPort int, resourceType token.ResourceType) *Client {
 	logger := zap.Must(zap.NewDevelopment()).Named(fmt.Sprintf("client-%s-%s", user.ID, user.Username))
 

--- a/test/integration/testutil/user.go
+++ b/test/integration/testutil/user.go
@@ -19,6 +19,15 @@ type User struct {
 	client  *fake.Client
 }
 
+// downstreamPort values are the client-facing ports used in the CONNECT request. They differ
+// from the upstream ports the backends actually listen on, so the Gateway's port rewrite is
+// exercised end-to-end: the client targets the downstream port and reaches the upstream port.
+const (
+	kubernetesDownstreamPort = 443
+	sshDownstreamPort        = 22
+	webAppDownstreamPort     = 80
+)
+
 func NewUser(user *token.User, gatewayPort int, kindAddress, controllerURL string) (*User, error) {
 	client := fake.NewClient(
 		user,
@@ -26,6 +35,7 @@ func NewUser(user *token.User, gatewayPort int, kindAddress, controllerURL strin
 		fmt.Sprintf("127.0.0.1:%d", gatewayPort),
 		controllerURL,
 		kindAddress,
+		kubernetesDownstreamPort,
 		token.ResourceTypeKubernetes,
 	)
 
@@ -62,6 +72,7 @@ func NewSSHUser(user *token.User, gatewayPort int, sshServerAddress, controllerU
 		fmt.Sprintf("127.0.0.1:%d", gatewayPort),
 		controllerURL,
 		sshServerAddress,
+		sshDownstreamPort,
 		token.ResourceTypeSSH,
 	)
 
@@ -96,6 +107,7 @@ func NewWebAppUser(user *token.User, geoIPLocation token.GeoIPLocation, gatewayP
 		fmt.Sprintf("127.0.0.1:%d", gatewayPort),
 		controllerURL,
 		upstreamAddress,
+		webAppDownstreamPort,
 		token.ResourceTypeWebApp,
 	)
 

--- a/test/integration/testutil/user.go
+++ b/test/integration/testutil/user.go
@@ -19,9 +19,7 @@ type User struct {
 	client  *fake.Client
 }
 
-// downstreamPort values are the client-facing ports used in the CONNECT request. They differ
-// from the upstream ports the backends actually listen on, so the Gateway's port rewrite is
-// exercised end-to-end: the client targets the downstream port and reaches the upstream port.
+// downstreamPort values are the client-facing ports used in the CONNECT request.
 const (
 	kubernetesDownstreamPort = 443
 	sshDownstreamPort        = 22

--- a/tools/local/main.go
+++ b/tools/local/main.go
@@ -27,8 +27,6 @@ const (
 	defaultUsername   = "alex@acme.com"
 	gatewayConfigFile = "gateway-config.local.yaml"
 
-	// Client-facing downstream ports used in the CONNECT request. The Gateway rewrites them to
-	// the upstream ports the backends actually listen on before forwarding.
 	kubernetesDownstreamPort = 443
 	sshDownstreamPort        = 22
 	webAppDownstreamPort     = 80

--- a/tools/local/main.go
+++ b/tools/local/main.go
@@ -26,6 +26,12 @@ const (
 	controllerPort    = 8080
 	defaultUsername   = "alex@acme.com"
 	gatewayConfigFile = "gateway-config.local.yaml"
+
+	// Client-facing downstream ports used in the CONNECT request. The Gateway rewrites them to
+	// the upstream ports the backends actually listen on before forwarding.
+	kubernetesDownstreamPort = 443
+	sshDownstreamPort        = 22
+	webAppDownstreamPort     = 80
 )
 
 // Before running this local dev client, Caddy must be already running. Run `caddy run` to start Caddy.
@@ -86,6 +92,7 @@ func main() {
 		fmt.Sprintf("%s:%d", gatewayHost, gatewayPort),
 		controller.URL,
 		fmt.Sprintf("%s:%d", gatewayHost, kindPort),
+		kubernetesDownstreamPort,
 		token.ResourceTypeKubernetes,
 	)
 
@@ -116,6 +123,7 @@ func main() {
 		fmt.Sprintf("%s:%d", gatewayHost, gatewayPort),
 		controller.URL,
 		fmt.Sprintf("%s:%d", gatewayHost, sshPort),
+		sshDownstreamPort,
 		token.ResourceTypeSSH,
 	)
 
@@ -154,6 +162,7 @@ func main() {
 		fmt.Sprintf("%s:%d", gatewayHost, gatewayPort),
 		controller.URL,
 		echoServer.address,
+		webAppDownstreamPort,
 		token.ResourceTypeWebApp,
 	)
 	defer webAppClient.Close()


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: https://github.com/Twingate/gateway/issues/342
- Stacked on: #363 (verify CONNECT destination port matches GAT downstream port)

## Changes

The controller issues a backend-facing **upstream** port in the GAT under `resource.gateway_metadata.upstream.port`. This PR makes the Gateway honor it: after verifying the CONNECT destination matches the token's downstream port, the destination port is rewritten to the upstream port before forwarding to the backend.