### PR TITLE
feat: Support GAT `request_header_rewrites` for Web App traffic

### DIFF
--- a/internal/token/gat_claims.go
+++ b/internal/token/gat_claims.go
@@ -111,9 +111,15 @@ const (
 )
 
 type Resource struct {
-	ID      string       `json:"id"`
-	Type    ResourceType `json:"type"`
-	Address string       `json:"address"`
+	ID              string          `json:"id"`
+	Type            ResourceType    `json:"type"`
+	Address         string          `json:"address"`
+	GatewayMetadata GatewayMetadata `json:"gateway_metadata"` //nolint:tagliatelle // GAT wire format from the controller uses snake_case
+}
+
+// GatewayMetadata carries per-resource routing details from the GAT.
+type GatewayMetadata struct {
+	RequestHeaderRewrites map[string]string `json:"request_header_rewrites,omitempty"` //nolint:tagliatelle // GAT wire format from the controller uses snake_case
 }
 
 // PublicKey is a wrapper for ecdsa.PublicKey that adds support for JSON

--- a/internal/token/gat_claims.go
+++ b/internal/token/gat_claims.go
@@ -117,7 +117,6 @@ type Resource struct {
 	GatewayMetadata GatewayMetadata `json:"gateway_metadata"` //nolint:tagliatelle // GAT wire format from the controller uses snake_case
 }
 
-// GatewayMetadata carries per-resource routing details from the GAT.
 type GatewayMetadata struct {
 	RequestHeaderRewrites map[string]string `json:"request_header_rewrites,omitempty"` //nolint:tagliatelle // GAT wire format from the controller uses snake_case
 }

--- a/internal/webapphandler/handler.go
+++ b/internal/webapphandler/handler.go
@@ -81,16 +81,21 @@ func rewrite(r *httputil.ProxyRequest, conn *connect.ProxyConn, headers map[stri
 	}
 
 	// Per-resource request header rewrites from the GAT are applied last, so they override
-	// any config headers with the same name.
+	// any config headers with the same name. Malformed or unsupported headers are skipped
+	// rather than failing the request.
 	for headerName, value := range conn.GATClaims().Resource.GatewayMetadata.RequestHeaderRewrites {
 		tmpl, err := template.New(value)
 		if err != nil {
-			return fmt.Errorf("header %q: %w", headerName, err)
+			conn.Logger.Debug("skipping GAT request header rewrite", zap.String("header", headerName), zap.String("value", value), zap.Error(err))
+
+			continue
 		}
 
 		headerValue, err := tmpl.Evaluate(variables)
 		if err != nil {
-			return fmt.Errorf("header %q: %w", headerName, err)
+			conn.Logger.Debug("skipping GAT request header rewrite", zap.String("header", headerName), zap.String("value", value), zap.Error(err))
+
+			continue
 		}
 
 		r.Out.Header.Set(headerName, headerValue)

--- a/internal/webapphandler/handler.go
+++ b/internal/webapphandler/handler.go
@@ -80,5 +80,21 @@ func rewrite(r *httputil.ProxyRequest, conn *connect.ProxyConn, headers map[stri
 		r.Out.Header.Set(headerName, headerValue)
 	}
 
+	// Per-resource request header rewrites from the GAT are applied last, so they override
+	// any config headers with the same name.
+	for headerName, value := range conn.GATClaims().Resource.GatewayMetadata.RequestHeaderRewrites {
+		tmpl, err := template.New(value)
+		if err != nil {
+			return fmt.Errorf("header %q: %w", headerName, err)
+		}
+
+		headerValue, err := tmpl.Evaluate(variables)
+		if err != nil {
+			return fmt.Errorf("header %q: %w", headerName, err)
+		}
+
+		r.Out.Header.Set(headerName, headerValue)
+	}
+
 	return nil
 }

--- a/internal/webapphandler/handler.go
+++ b/internal/webapphandler/handler.go
@@ -86,14 +86,14 @@ func rewrite(r *httputil.ProxyRequest, conn *connect.ProxyConn, headers map[stri
 	for headerName, value := range conn.GATClaims().Resource.GatewayMetadata.RequestHeaderRewrites {
 		tmpl, err := template.New(value)
 		if err != nil {
-			conn.Logger.Debug("skipping GAT request header rewrite", zap.String("header", headerName), zap.String("value", value), zap.Error(err))
+			conn.Logger.Warn("skipping GAT request header rewrite", zap.String("header", headerName), zap.Error(err))
 
 			continue
 		}
 
 		headerValue, err := tmpl.Evaluate(variables)
 		if err != nil {
-			conn.Logger.Debug("skipping GAT request header rewrite", zap.String("header", headerName), zap.String("value", value), zap.Error(err))
+			conn.Logger.Warn("skipping GAT request header rewrite", zap.String("header", headerName), zap.Error(err))
 
 			continue
 		}

--- a/internal/webapphandler/handler_test.go
+++ b/internal/webapphandler/handler_test.go
@@ -64,6 +64,13 @@ func TestNewHandler_PanicsOnRewriteError(t *testing.T) {
 	})
 }
 
+func withRequestHeaderRewrites(base *token.GATClaims, rewrites map[string]string) *token.GATClaims {
+	claims := *base
+	claims.Resource.GatewayMetadata.RequestHeaderRewrites = rewrites
+
+	return &claims
+}
+
 func TestRewrite(t *testing.T) {
 	baseClaims := &token.GATClaims{
 		User: token.User{
@@ -108,6 +115,39 @@ func TestRewrite(t *testing.T) {
 				"X-Region":      "CA",
 				"X-Country":     "US",
 				"Existing":      "new-value",
+			},
+		},
+		{
+			name:     "applies GAT request header rewrites with template values",
+			jwtToken: "test-token",
+			claims: withRequestHeaderRewrites(baseClaims, map[string]string{
+				"X-GAT-Static":   "static-value",
+				"X-GAT-Username": "{{username}}",
+				"X-GAT-Auth":     "Bearer {{jwt}}",
+			}),
+			headers: map[string]string{
+				"X-Config": "{{groups}}",
+			},
+			wantHeaders: map[string]string{
+				"X-Config":       "Everyone,Engineering",
+				"X-GAT-Static":   "static-value",
+				"X-GAT-Username": "alice@acme.com",
+				"X-GAT-Auth":     "Bearer test-token",
+			},
+		},
+		{
+			name:     "GAT request header rewrites override config headers on conflict",
+			jwtToken: "test-token",
+			claims: withRequestHeaderRewrites(baseClaims, map[string]string{
+				"X-Username": "{{username}}",
+			}),
+			headers: map[string]string{
+				"X-Config":   "Dont override",
+				"X-Username": "Not preserved",
+			},
+			wantHeaders: map[string]string{
+				"X-Config":   "Dont override",
+				"X-Username": "alice@acme.com",
 			},
 		},
 		{

--- a/internal/webapphandler/handler_test.go
+++ b/internal/webapphandler/handler_test.go
@@ -122,32 +122,34 @@ func TestRewrite(t *testing.T) {
 			jwtToken: "test-token",
 			claims: withRequestHeaderRewrites(baseClaims, map[string]string{
 				"X-GAT-Static":   "static-value",
+				"X-Username":     "{{username}}",
 				"X-GAT-Username": "{{username}}",
 				"X-GAT-Auth":     "Bearer {{jwt}}",
-			}),
-			headers: map[string]string{
-				"X-Config": "{{groups}}",
-			},
-			wantHeaders: map[string]string{
-				"X-Config":       "Everyone,Engineering",
-				"X-GAT-Static":   "static-value",
-				"X-GAT-Username": "alice@acme.com",
-				"X-GAT-Auth":     "Bearer test-token",
-			},
-		},
-		{
-			name:     "GAT request header rewrites override config headers on conflict",
-			jwtToken: "test-token",
-			claims: withRequestHeaderRewrites(baseClaims, map[string]string{
-				"X-Username": "{{username}}",
 			}),
 			headers: map[string]string{
 				"X-Config":   "Dont override",
 				"X-Username": "Overridden by GAT Token",
 			},
 			wantHeaders: map[string]string{
-				"X-Config":   "Dont override",
-				"X-Username": "alice@acme.com",
+				"X-Config":       "Dont override",
+				"X-Username":     "alice@acme.com",
+				"X-GAT-Username": "alice@acme.com",
+				"X-GAT-Auth":     "Bearer test-token",
+			},
+		},
+		{
+			name:     "skips malformed and unsupported GAT request header rewrites",
+			jwtToken: "test-token",
+			claims: withRequestHeaderRewrites(baseClaims, map[string]string{
+				"X-GAT-Good":      "{{username}}",
+				"X-GAT-Malformed": "{{unclosed",
+				"X-GAT-Unknown":   "{{nonexistent}}",
+			}),
+			headers: map[string]string{},
+			wantHeaders: map[string]string{
+				"X-GAT-Good":      "alice@acme.com",
+				"X-GAT-Malformed": "",
+				"X-GAT-Unknown":   "",
 			},
 		},
 		{

--- a/internal/webapphandler/handler_test.go
+++ b/internal/webapphandler/handler_test.go
@@ -122,34 +122,45 @@ func TestRewrite(t *testing.T) {
 			jwtToken: "test-token",
 			claims: withRequestHeaderRewrites(baseClaims, map[string]string{
 				"X-GAT-Static":   "static-value",
-				"X-Username":     "{{username}}",
 				"X-GAT-Username": "{{username}}",
 				"X-GAT-Auth":     "Bearer {{jwt}}",
+			}),
+			headers: map[string]string{},
+			wantHeaders: map[string]string{
+				"X-GAT-Static":   "static-value",
+				"X-GAT-Username": "alice@acme.com",
+				"X-GAT-Auth":     "Bearer test-token",
+			},
+		},
+		{
+			name:     "GAT request header rewrites override config headers on conflict",
+			jwtToken: "test-token",
+			claims: withRequestHeaderRewrites(baseClaims, map[string]string{
+				"X-Username": "{{username}}",
 			}),
 			headers: map[string]string{
 				"X-Config":   "Dont override",
 				"X-Username": "Overridden by GAT Token",
 			},
 			wantHeaders: map[string]string{
-				"X-Config":       "Dont override",
-				"X-Username":     "alice@acme.com",
-				"X-GAT-Username": "alice@acme.com",
-				"X-GAT-Auth":     "Bearer test-token",
+				"X-Config":   "Dont override",
+				"X-Username": "alice@acme.com",
 			},
 		},
 		{
-			name:     "skips malformed and unsupported GAT request header rewrites",
+			name:     "preserve config header when conflict with unsupported GAT request header rewrites",
 			jwtToken: "test-token",
 			claims: withRequestHeaderRewrites(baseClaims, map[string]string{
-				"X-GAT-Good":      "{{username}}",
-				"X-GAT-Malformed": "{{unclosed",
-				"X-GAT-Unknown":   "{{nonexistent}}",
+				"X-Malformed": "{{unclosed",
+				"X-Unknown":   "{{nonexistent}}",
 			}),
-			headers: map[string]string{},
+			headers: map[string]string{
+				"X-Malformed": "Config value",
+				"X-Unknown":   "Config value",
+			},
 			wantHeaders: map[string]string{
-				"X-GAT-Good":      "alice@acme.com",
-				"X-GAT-Malformed": "",
-				"X-GAT-Unknown":   "",
+				"X-Malformed": "Config value",
+				"X-Unknown":   "Config value",
 			},
 		},
 		{
@@ -209,6 +220,31 @@ func TestRewrite(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRewrite_SkipsInvalidGATHeaders(t *testing.T) {
+	baseClaims := &token.GATClaims{
+		User: token.User{ID: "user-1", Username: "alice@acme.com"},
+	}
+
+	connMetrics := connect.CreateProxyConnMetrics(prometheus.NewRegistry())
+	conn := connect.NewProxyConn(nil, nil, nil, zap.NewNop(), connMetrics)
+	conn.Token = "test-token"
+	conn.Claims = withRequestHeaderRewrites(baseClaims, map[string]string{
+		"X-Malformed": "{{unclosed",
+		"X-Unknown":   "{{nonexistent}}",
+	})
+
+	proxyReq := &httputil.ProxyRequest{
+		In:  httptest.NewRequest(http.MethodGet, "http://test/api/resource", nil),
+		Out: httptest.NewRequest(http.MethodGet, "http://test/api/resource", nil),
+	}
+
+	err := rewrite(proxyReq, conn, nil)
+	require.NoError(t, err)
+
+	assert.Empty(t, proxyReq.Out.Header.Values("X-Malformed"), "malformed header should not be set")
+	assert.Empty(t, proxyReq.Out.Header.Values("X-Unknown"), "unknown header should not be set")
 }
 
 func TestBuildVariables_CoversAllowedKeys(t *testing.T) {

--- a/internal/webapphandler/handler_test.go
+++ b/internal/webapphandler/handler_test.go
@@ -143,7 +143,7 @@ func TestRewrite(t *testing.T) {
 			}),
 			headers: map[string]string{
 				"X-Config":   "Dont override",
-				"X-Username": "Not preserved",
+				"X-Username": "Overridden by GAT Token",
 			},
 			wantHeaders: map[string]string{
 				"X-Config":   "Dont override",

--- a/test/fake/client.go
+++ b/test/fake/client.go
@@ -43,9 +43,10 @@ type Client struct {
 	proxyAddress  string
 	controllerURL string
 
-	resourceHostname string
-	resourcePort     string
-	resourceType     token.ResourceType
+	resourceHostname      string
+	resourcePort          string
+	resourceType          token.ResourceType
+	requestHeaderRewrites map[string]string
 
 	cancel context.CancelFunc
 	wg     *sync.WaitGroup
@@ -53,8 +54,18 @@ type Client struct {
 	logger *zap.Logger
 }
 
+// Option configures a Client at construction time.
+type Option func(*Client)
+
+// WithRequestHeaderRewrites sets the Web App request header rewrites carried in the GAT.
+func WithRequestHeaderRewrites(rewrites map[string]string) Option {
+	return func(c *Client) {
+		c.requestHeaderRewrites = rewrites
+	}
+}
+
 // NewClient creates a new Client. upstreamAddress must include both the host and the port.
-func NewClient(user *token.User, geoIPLocation token.GeoIPLocation, proxyAddress, controllerURL, upstreamAddress string, resourceType token.ResourceType) *Client {
+func NewClient(user *token.User, geoIPLocation token.GeoIPLocation, proxyAddress, controllerURL, upstreamAddress string, resourceType token.ResourceType, opts ...Option) *Client {
 	logger := zap.Must(zap.NewDevelopment()).Named(fmt.Sprintf("client-%s-%s", user.ID, user.Username))
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -87,6 +98,11 @@ func NewClient(user *token.User, geoIPLocation token.GeoIPLocation, proxyAddress
 		wg:               &sync.WaitGroup{},
 		logger:           logger,
 	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
 	go c.serve(ctx)
 
 	return c
@@ -234,6 +250,9 @@ func (c *Client) fetchGAT() (string, error) {
 			ID:      "resource-1",
 			Type:    c.resourceType,
 			Address: c.resourceHostname,
+			GatewayMetadata: token.GatewayMetadata{
+				RequestHeaderRewrites: c.requestHeaderRewrites,
+			},
 		},
 	}
 

--- a/test/integration/testutil/user.go
+++ b/test/integration/testutil/user.go
@@ -89,7 +89,7 @@ type WebAppUser struct {
 	client *fake.Client
 }
 
-func NewWebAppUser(user *token.User, geoIPLocation token.GeoIPLocation, gatewayPort int, upstreamAddress, controllerURL string) *WebAppUser {
+func NewWebAppUser(user *token.User, geoIPLocation token.GeoIPLocation, gatewayPort int, upstreamAddress, controllerURL string, requestHeaderRewrites map[string]string) *WebAppUser {
 	client := fake.NewClient(
 		user,
 		geoIPLocation,
@@ -97,6 +97,7 @@ func NewWebAppUser(user *token.User, geoIPLocation token.GeoIPLocation, gatewayP
 		controllerURL,
 		upstreamAddress,
 		token.ResourceTypeWebApp,
+		fake.WithRequestHeaderRewrites(requestHeaderRewrites),
 	)
 
 	return &WebAppUser{

--- a/test/integration/web_app_test.go
+++ b/test/integration/web_app_test.go
@@ -48,7 +48,6 @@ func TestWebApp(t *testing.T) {
 		WebApp: &gatewayconfig.WebAppConfig{
 			Headers: map[string]string{
 				"Authorization":                 "Bearer {{jwt}}",
-				"X-Twingate-Username":           "Overridden by GAT Token",
 				"X-Twingate-Groups":             "{{groups}}",
 				"X-Twingate-Client-Geo-LatLong": "{{clientGeoLatLong}}",
 				"X-Twingate-Client-Geo-City":    "{{clientGeoCity}}",
@@ -88,7 +87,6 @@ func TestWebApp(t *testing.T) {
 		upstreamAddress,
 		controller.URL,
 		map[string]string{
-			"X-GAT-Token-Header":  "value preserved",
 			"X-Twingate-Username": "{{username}}",
 		},
 	)
@@ -120,7 +118,6 @@ func TestWebApp(t *testing.T) {
 		"X-Twingate-Client-Geo-Country": "US",
 		// From GAT Token
 		"X-Twingate-Username": "alex@acme.com",
-		"X-GAT-Token-Header":  "value preserved",
 	}
 
 	for header, expected := range expectedHeaders {

--- a/test/integration/web_app_test.go
+++ b/test/integration/web_app_test.go
@@ -48,7 +48,7 @@ func TestWebApp(t *testing.T) {
 		WebApp: &gatewayconfig.WebAppConfig{
 			Headers: map[string]string{
 				"Authorization":                 "Bearer {{jwt}}",
-				"X-Twingate-Username":           "override",
+				"X-Twingate-Username":           "Overridden by GAT Token",
 				"X-Twingate-Groups":             "{{groups}}",
 				"X-Twingate-Client-Geo-LatLong": "{{clientGeoLatLong}}",
 				"X-Twingate-Client-Geo-City":    "{{clientGeoCity}}",

--- a/test/integration/web_app_test.go
+++ b/test/integration/web_app_test.go
@@ -48,7 +48,7 @@ func TestWebApp(t *testing.T) {
 		WebApp: &gatewayconfig.WebAppConfig{
 			Headers: map[string]string{
 				"Authorization":                 "Bearer {{jwt}}",
-				"X-Twingate-Username":           "{{username}}",
+				"X-Twingate-Username":           "override",
 				"X-Twingate-Groups":             "{{groups}}",
 				"X-Twingate-Client-Geo-LatLong": "{{clientGeoLatLong}}",
 				"X-Twingate-Client-Geo-City":    "{{clientGeoCity}}",
@@ -87,6 +87,10 @@ func TestWebApp(t *testing.T) {
 		gatewayPort,
 		upstreamAddress,
 		controller.URL,
+		map[string]string{
+			"X-GAT-Token-Header":  "value preserved",
+			"X-Twingate-Username": "{{username}}",
+		},
 	)
 	defer user.Close()
 
@@ -108,12 +112,15 @@ func TestWebApp(t *testing.T) {
 	require.NoError(t, err, "failed to parse echo response")
 
 	expectedHeaders := map[string]string{
-		"X-Twingate-Username":           "alex@acme.com",
+		// From Gateway config
 		"X-Twingate-Groups":             "OnCall,Engineering",
 		"X-Twingate-Client-Geo-LatLong": "37.5,-122.4",
 		"X-Twingate-Client-Geo-City":    "San Mateo",
 		"X-Twingate-Client-Geo-Region":  "CA",
 		"X-Twingate-Client-Geo-Country": "US",
+		// From GAT Token
+		"X-Twingate-Username": "alex@acme.com",
+		"X-GAT-Token-Header":  "value preserved",
 	}
 
 	for header, expected := range expectedHeaders {


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: https://github.com/Twingate/gateway/issues/342

## Changes

For Web App resources, the controller can specify per-resource `request_header_rewrites` in the GAT under `resource.gateway_metadata`. This PR makes the Gateway apply those header rewrites to Web App requests before forwarding them upstream.
