### PR TITLE
chore: update webApp headers template examples in values schema

### DIFF
--- a/deploy/gateway/values.schema.json
+++ b/deploy/gateway/values.schema.json
@@ -315,7 +315,7 @@
         },
         "headers": {
           "type": "object",
-          "description": "Custom HTTP headers to inject into proxied requests. Values may use template expressions with the twingate namespace (e.g. {{twingate.username}}, {{twingate.groups}}, {{twingate.jwt}}, {{twingate.clientGeoLoc}}).",
+          "description": "Custom HTTP headers to inject into proxied requests. Values may use template expressions with the twingate namespace (e.g. {{username}}, {{groups}}, {{jwt}}, {{clientGeoLoc}}).",
           "additionalProperties": {
             "type": "string"
           }


### PR DESCRIPTION
## Related Tickets

Closes #354

## Changes

- Update `webApp.headers` template examples in `values.schema.json` to the namespace-less syntax (`{{username}}`, `{{groups}}`, `{{jwt}}`, `{{clientGeoLoc}}`)

## Notes

Fast follow-up from #355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)