### PR TITLE
fix(ssh): present only the CA-signed host certificate

### DIFF
--- a/internal/sshhandler/config.go
+++ b/internal/sshhandler/config.go
@@ -145,8 +145,6 @@ func (c *Config) GetDownstreamConfig(ctx context.Context) (*ssh.ServerConfig, er
 	}()
 
 	downstreamSSHConfig.AddHostKey(hostCertSigner)
-	// Add the public key as a fallback for clients that don't support certificate-based host key algorithms.
-	downstreamSSHConfig.AddHostKey(hostCertSigner.keySigner)
 
 	return downstreamSSHConfig, nil
 }

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -169,6 +169,11 @@ func TestSSH(t *testing.T) {
 		"target": "upstream",
 	}
 	testutil.AssertLogsForSSH(t, env.logs, expectedUser, expectedRequest)
+	// The gateway presents only its CA-signed host certificate, so a client that accepts
+	// only the plain ed25519 host key algorithm cannot negotiate a host key.
+	_, err = env.user.SSH.Command("-o", "HostKeyAlgorithms=ssh-ed25519", "whoami")
+	require.Error(t, err, "connection should fail when only the plain host key algorithm is offered")
+	assert.Contains(t, err.Error(), "no matching host key type found. Their offer: ssh-ed25519-cert-v01@openssh.com")
 }
 
 // TestSSHVault tests SSH proxying through the gateway using Vault as the CA backend.


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #369

## Changes

- Remove the raw host-key fallback; the gateway presents only its CA-signed host certificate.

## Notes

Clients that accept only plain host-key algorithms (not `*-cert-v01@openssh.com`) can no longer negotiate a host key. This is intended: presenting the raw ephemeral key is what let host identity drift across restarts.