### PR TITLE
chore: fix goreleaser arm build target broken by v2.17 GOARM validation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,7 @@ builds:
       - CGO_ENABLED=0
     targets:
       - linux_amd64
-      - linux_arm_v7
+      - linux_arm_7
       - linux_arm64
       - darwin_amd64
       - darwin_arm64
@@ -39,7 +39,7 @@ builds:
       - CGO_ENABLED=0
     targets:
       - linux_amd64
-      - linux_arm_v7
+      - linux_arm_7
       - linux_arm64
       - darwin_amd64
       - darwin_arm64


### PR DESCRIPTION
## Related Tickets

N/A — CI breakage.

## Changes

Rename the arm build target in `.goreleaser.yaml` from `linux_arm_v7` to `linux_arm_7` for both the `gateway` and `gateway-debug` builds.

## Notes

The goreleaser upgrade from `v2.16.0` to `v2.17.0` broke the `build` job on every branch with `invalid goarm: v7` ([example](https://github.com/Twingate/gateway/actions/runs/28772064930/job/85309273402)). The cause is `v2.17.0`'s new GOARM softfloat/hardfloat support (goreleaser/goreleaser#6198), which added strict validation of the GOARM component of explicit build targets — valid values are `5`/`6`/`7`, so the `v7` spelling was never valid.

Until now the invalid value slipped through: goreleaser passed `GOARM=v7` to the Go toolchain, which silently ignores unrecognized values and falls back to the default (`7`), so the published binaries were correct by coincidence. The typo was visible in release asset names as a double `v`. After this fix the next release archive is named `gateway_Linux_armv7.tar.gz` instead of `gateway_Linux_armvv7.tar.gz` — anything referencing the old asset name will need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)