### PR TITLE
test: split SSH key config parsing and key generation tests

### DIFF
--- a/internal/sshhandler/keys_test.go
+++ b/internal/sshhandler/keys_test.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func TestNewKeyConfig_ByKeyType(t *testing.T) {
+func TestNewKeyConfig(t *testing.T) {
 	tests := []struct {
 		name       string
 		keyType    string
@@ -137,9 +137,6 @@ func TestNewKeyConfig_InvalidInputs(t *testing.T) {
 }
 
 func TestKeyConfigGenerate(t *testing.T) {
-	// One case per code path in Generate: each ECDSA curve is a separate
-	// branch, while the RSA branch does not vary by bits, so 2048 (the
-	// cheapest allowed size) covers it.
 	tests := []struct {
 		name       string
 		keyConfig  keyConfig
@@ -182,6 +179,28 @@ func TestKeyConfigGenerate(t *testing.T) {
 			assert.Equal(t, tt.expectAlgo, signer.PublicKey().Type())
 			assert.Equal(t, tt.expectAlgo, pub.Type())
 			assert.Equal(t, signer.PublicKey().Marshal(), pub.Marshal())
+		})
+	}
+}
+
+func TestKeyConfigGenerate_InvalidInputs(t *testing.T) {
+	tests := []struct {
+		name       string
+		keyConfig  keyConfig
+		wantErr    error
+		wantErrMsg string
+	}{
+		{name: "unsupported key type", keyConfig: keyConfig{typ: "foo"}, wantErr: errUnsupportedKeyType, wantErrMsg: "unsupported key type: foo"},
+		{name: "ECDSA invalid bits", keyConfig: keyConfig{typ: keyTypeECDSA, bits: 123}, wantErr: errUnsupportedKeySize, wantErrMsg: "unsupported key size: ecdsa 123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signer, pub, err := tt.keyConfig.Generate(rand.Reader)
+			require.ErrorIs(t, err, tt.wantErr)
+			require.EqualError(t, err, tt.wantErrMsg)
+			assert.Nil(t, signer)
+			assert.Nil(t, pub)
 		})
 	}
 }

--- a/internal/sshhandler/keys_test.go
+++ b/internal/sshhandler/keys_test.go
@@ -7,32 +7,30 @@ import (
 	"crypto/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 )
 
-func TestNewKeyConfigAndGenerate_ByKeyType(t *testing.T) {
+func TestNewKeyConfig_ByKeyType(t *testing.T) {
 	tests := []struct {
 		name       string
 		keyType    string
 		keyBits    int
 		expectType keyType
 		expectBits int
-		expectAlgo string
 	}{
 		{
 			name:       "ed25519",
 			keyType:    "ed25519",
 			keyBits:    0,
 			expectType: keyTypeED25519,
-			expectAlgo: ssh.KeyAlgoED25519,
 		},
 		{
 			name:       "ssh-ed25519 (SSH key type)",
 			keyType:    ssh.KeyAlgoED25519,
 			keyBits:    0,
 			expectType: keyTypeED25519,
-			expectAlgo: ssh.KeyAlgoED25519,
 		},
 		{
 			name:       "ecdsa default bits",
@@ -40,7 +38,6 @@ func TestNewKeyConfigAndGenerate_ByKeyType(t *testing.T) {
 			keyBits:    0,
 			expectType: keyTypeECDSA,
 			expectBits: 256,
-			expectAlgo: "ecdsa-sha2-nistp256",
 		},
 		{
 			name:       "ecdsa 384 bits",
@@ -48,7 +45,6 @@ func TestNewKeyConfigAndGenerate_ByKeyType(t *testing.T) {
 			keyBits:    384,
 			expectType: keyTypeECDSA,
 			expectBits: 384,
-			expectAlgo: "ecdsa-sha2-nistp384",
 		},
 		{
 			name:       "ecdsa 521 bits",
@@ -56,7 +52,6 @@ func TestNewKeyConfigAndGenerate_ByKeyType(t *testing.T) {
 			keyBits:    521,
 			expectType: keyTypeECDSA,
 			expectBits: 521,
-			expectAlgo: "ecdsa-sha2-nistp521",
 		},
 		{
 			name:       "ecdsa-sha2-nistp256 (SSH key type)",
@@ -64,7 +59,6 @@ func TestNewKeyConfigAndGenerate_ByKeyType(t *testing.T) {
 			keyBits:    0,
 			expectType: keyTypeECDSA,
 			expectBits: 256,
-			expectAlgo: "ecdsa-sha2-nistp256",
 		},
 		{
 			name:       "ecdsa-sha2-nistp384 (SSH key type)",
@@ -72,7 +66,6 @@ func TestNewKeyConfigAndGenerate_ByKeyType(t *testing.T) {
 			keyBits:    0,
 			expectType: keyTypeECDSA,
 			expectBits: 384,
-			expectAlgo: "ecdsa-sha2-nistp384",
 		},
 		{
 			name:       "ecdsa-sha2-nistp521 (SSH key type)",
@@ -80,7 +73,6 @@ func TestNewKeyConfigAndGenerate_ByKeyType(t *testing.T) {
 			keyBits:    0,
 			expectType: keyTypeECDSA,
 			expectBits: 521,
-			expectAlgo: "ecdsa-sha2-nistp521",
 		},
 		{
 			name:       "rsa default bits",
@@ -88,7 +80,6 @@ func TestNewKeyConfigAndGenerate_ByKeyType(t *testing.T) {
 			keyBits:    0,
 			expectType: keyTypeRSA,
 			expectBits: 4096,
-			expectAlgo: "ssh-rsa",
 		},
 		{
 			name:       "ssh-rsa (SSH key type)",
@@ -96,7 +87,6 @@ func TestNewKeyConfigAndGenerate_ByKeyType(t *testing.T) {
 			keyBits:    0,
 			expectType: keyTypeRSA,
 			expectBits: 4096,
-			expectAlgo: "ssh-rsa",
 		},
 		{
 			name:       "rsa 2048",
@@ -104,7 +94,6 @@ func TestNewKeyConfigAndGenerate_ByKeyType(t *testing.T) {
 			keyBits:    2048,
 			expectType: keyTypeRSA,
 			expectBits: 2048,
-			expectAlgo: "ssh-rsa",
 		},
 		{
 			name:       "rsa 3072",
@@ -112,7 +101,6 @@ func TestNewKeyConfigAndGenerate_ByKeyType(t *testing.T) {
 			keyBits:    3072,
 			expectType: keyTypeRSA,
 			expectBits: 3072,
-			expectAlgo: "ssh-rsa",
 		},
 	}
 
@@ -120,17 +108,8 @@ func TestNewKeyConfigAndGenerate_ByKeyType(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			kc, err := newKeyConfig(tt.keyType, tt.keyBits)
 			require.NoError(t, err)
-			require.Equal(t, tt.expectType, kc.typ)
-			require.Equal(t, tt.expectBits, kc.bits)
-
-			signer, pub, err := kc.Generate(rand.Reader)
-			require.NoError(t, err)
-			require.NotNil(t, signer)
-			require.NotNil(t, pub)
-
-			require.Equal(t, tt.expectAlgo, signer.PublicKey().Type())
-			require.Equal(t, tt.expectAlgo, pub.Type())
-			require.Equal(t, signer.PublicKey().Marshal(), pub.Marshal())
+			assert.Equal(t, tt.expectType, kc.typ)
+			assert.Equal(t, tt.expectBits, kc.bits)
 		})
 	}
 }
@@ -153,6 +132,56 @@ func TestNewKeyConfig_InvalidInputs(t *testing.T) {
 			_, err := newKeyConfig(tt.keyType, tt.keyBits)
 			require.ErrorIs(t, err, tt.wantErr)
 			require.EqualError(t, err, tt.wantErrMsg)
+		})
+	}
+}
+
+func TestKeyConfigGenerate(t *testing.T) {
+	// One case per code path in Generate: each ECDSA curve is a separate
+	// branch, while the RSA branch does not vary by bits, so 2048 (the
+	// cheapest allowed size) covers it.
+	tests := []struct {
+		name       string
+		keyConfig  keyConfig
+		expectAlgo string
+	}{
+		{
+			name:       "ed25519",
+			keyConfig:  keyConfig{typ: keyTypeED25519},
+			expectAlgo: ssh.KeyAlgoED25519,
+		},
+		{
+			name:       "ecdsa 256 bits",
+			keyConfig:  keyConfig{typ: keyTypeECDSA, bits: 256},
+			expectAlgo: ssh.KeyAlgoECDSA256,
+		},
+		{
+			name:       "ecdsa 384 bits",
+			keyConfig:  keyConfig{typ: keyTypeECDSA, bits: 384},
+			expectAlgo: ssh.KeyAlgoECDSA384,
+		},
+		{
+			name:       "ecdsa 521 bits",
+			keyConfig:  keyConfig{typ: keyTypeECDSA, bits: 521},
+			expectAlgo: ssh.KeyAlgoECDSA521,
+		},
+		{
+			name:       "rsa 2048 bits",
+			keyConfig:  keyConfig{typ: keyTypeRSA, bits: 2048},
+			expectAlgo: ssh.KeyAlgoRSA,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signer, pub, err := tt.keyConfig.Generate(rand.Reader)
+			require.NoError(t, err)
+			require.NotNil(t, signer)
+			require.NotNil(t, pub)
+
+			assert.Equal(t, tt.expectAlgo, signer.PublicKey().Type())
+			assert.Equal(t, tt.expectAlgo, pub.Type())
+			assert.Equal(t, signer.PublicKey().Marshal(), pub.Marshal())
 		})
 	}
 }


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: N/A

## Changes

- Split `TestNewKeyConfigAndGenerate_ByKeyType` into two tests:
  - `TestNewKeyConfig`: all 12 parsing cases, no key generation
  - `TestKeyConfigGenerate`: one case per `Generate` code path (ed25519, ECDSA 256/384/521, RSA 2048)

## Notes

- Every parsing case previously ran `Generate`, so the RSA cases dominated the test runtime (1.5-4s out of ~12s total, [sample build](https://github.com/Twingate/gateway/actions/runs/28804917304/job/85417827252))
- RSA-4096 was generated twice: once via the `rsa` key type with default bits, once via `ssh-rsa`
- The RSA branch in `Generate` does not vary by key size, so a single 2048-bit case covers it
- Test runtime drops to ~0.2s ([sample build](https://github.com/Twingate/gateway/actions/runs/28810211844/job/85435919214?pr=380)) with no loss of branch coverage