### PR TITLE
fix(ssh): drop permit-X11-forwarding and permit-agent-forwarding from upstream user certs

### DIFF
--- a/internal/sshhandler/config.go
+++ b/internal/sshhandler/config.go
@@ -161,11 +161,9 @@ func (c *Config) GetUpstreamConfig(ctx context.Context, upstream upstream) (*ssh
 		ttl: c.userCertTTL,
 		permissions: ssh.Permissions{
 			Extensions: map[string]string{
-				"permit-X11-forwarding":   "",
-				"permit-agent-forwarding": "",
-				"permit-port-forwarding":  "",
-				"permit-pty":              "",
-				"permit-user-rc":          "",
+				"permit-port-forwarding": "",
+				"permit-pty":             "",
+				"permit-user-rc":         "",
 			},
 		},
 	}

--- a/test/integration/testutil/vault.go
+++ b/test/integration/testutil/vault.go
@@ -86,7 +86,7 @@ func SetupVaultServer(t *testing.T) (string, int) {
 		"key_type=ca",
 		"allow_user_certificates=true",
 		"allow_host_certificates=true",
-		"allowed_extensions=permit-X11-forwarding,permit-agent-forwarding,permit-port-forwarding,permit-pty,permit-user-rc",
+		"allowed_extensions=permit-port-forwarding,permit-pty,permit-user-rc",
 		"allow_empty_principals=true",
 		"allowed_users=admin",
 	))


### PR DESCRIPTION
## Related Tickets & Documents

- Closes #386

## Changes

- Drop `permit-X11-forwarding` and `permit-agent-forwarding` from signed upstream user certs