### PR TITLE
fix: remove stray `expectAlgo` field from TestNewKeyConfig case

### DIFF
--- a/internal/sshhandler/keys_test.go
+++ b/internal/sshhandler/keys_test.go
@@ -25,7 +25,6 @@ func TestNewKeyConfig(t *testing.T) {
 			keyType:    "",
 			keyBits:    0,
 			expectType: keyTypeED25519,
-			expectAlgo: ssh.KeyAlgoED25519,
 		},
 		{
 			name:       "ed25519",


### PR DESCRIPTION
## Related Tickets

N/A

## Changes

- Remove stray `expectAlgo` field from the "empty defaults to ed25519" case in `TestNewKeyConfig`; the field is not part of that test's struct and broke the build. Regression from #351.