### PR TITLE
fix(ssh): harden channel session request handling

### DIFF
--- a/internal/sshhandler/channel_pair_test.go
+++ b/internal/sshhandler/channel_pair_test.go
@@ -118,6 +118,38 @@ func TestChannelPair_ForwardsRequests(t *testing.T) {
 	}
 }
 
+func TestChannelPair_ForwardsTargetPtyAndWindowChange(t *testing.T) {
+	// The target-side request handler has no pty/window-change callbacks: requests of those
+	// types arriving from the target must hit the nil-callback guards and forward cleanly
+	// instead of panicking.
+	tests := []struct {
+		name    string
+		payload []byte
+	}{
+		{name: requestTypePty, payload: ssh.Marshal(ptyReq{Term: "xterm", WidthColumns: 80, HeightRows: 24})},
+		{name: requestTypeWindowChange, payload: ssh.Marshal(windowChangeReq{WidthColumns: 120, HeightRows: 40})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			channels := newProxyChannels(t, "direct-tcpip")
+			done := channels.serve(t)
+
+			awaitReply := sendRequest(channels.target.ch, tt.name, true, tt.payload)
+
+			forwarded := assertSentRequest(t, channels.source.requests, tt.name)
+			assert.Equal(t, tt.payload, forwarded.Payload)
+			require.NoError(t, forwarded.Reply(true, nil))
+
+			ok, err := awaitReply(t)
+			require.NoError(t, err)
+			assert.True(t, ok)
+
+			channels.close(t, done)
+		})
+	}
+}
+
 func TestChannelPair_RequestForwardFailure(t *testing.T) {
 	// On a session channel the gate keeps the copiers un-started, so closing the target
 	// cannot race the failure reply against a concurrent source teardown.
@@ -296,6 +328,46 @@ func TestChannelPair_SessionWaitsForStart(t *testing.T) {
 			case <-time.After(testTimeout):
 				t.Fatal("timed out waiting for data after session start")
 			}
+
+			channels.close(t, done)
+		})
+	}
+}
+
+func TestChannelPair_RejectsDuplicateSessionStart(t *testing.T) {
+	// A channel runs at most one shell, exec, or subsystem request (RFC 4254, Section 6.5). The
+	// started signal is closed on first use, so forwarding a second session start would signal on
+	// a closed channel and panic, killing every session on the proxy. The duplicate must be
+	// rejected at the proxy without being forwarded.
+	tests := []struct {
+		name    string
+		reqType string
+		payload []byte
+	}{
+		{name: "shell", reqType: requestTypeShell},
+		{name: "exec", reqType: requestTypeExec, payload: ssh.Marshal(execReq{Command: "whoami"})},
+		{name: "subsystem", reqType: requestTypeSubsystem, payload: ssh.Marshal(subsystemReq{Name: "sftp"})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			channels := newProxyChannels(t, "session")
+			done := channels.serve(t)
+
+			channels.sendRequestAwaitReply(t, requestTypeExec, ssh.Marshal(execReq{Command: "whoami"}))
+
+			// WantReply is false so SendRequest returns without waiting for a reply. The duplicate
+			// is deliberately never answered at the target (assertNoRequest only observes it), so a
+			// blocking request would stall the test; a non-blocking send lets a mis-forwarded
+			// duplicate reach the session-start signal instead.
+			_, err := channels.source.ch.SendRequest(tt.reqType, false, tt.payload)
+			require.NoError(t, err)
+			assertNoRequest(t, channels.target.requests)
+
+			// The original session is intact: data still flows.
+			_, err = channels.source.ch.Write([]byte("still-alive"))
+			require.NoError(t, err)
+			assert.Equal(t, "still-alive", string(readInFull(t, channels.target.ch, len("still-alive"))))
 
 			channels.close(t, done)
 		})
@@ -599,6 +671,19 @@ func startRead(reader io.Reader, n int) <-chan []byte {
 	}()
 
 	return out
+}
+
+// assertNoRequest asserts that no request arrives on the requests channel within shortTimeout.
+func assertNoRequest(t *testing.T, reqs <-chan *ssh.Request) {
+	t.Helper()
+
+	select {
+	case req, ok := <-reqs:
+		if ok {
+			t.Fatalf("unexpected %q request", req.Type)
+		}
+	case <-time.After(shortTimeout):
+	}
 }
 
 // waitReqChanClosed asserts the requests channel closes within testTimeout without delivering

--- a/internal/sshhandler/channel_pair_test.go
+++ b/internal/sshhandler/channel_pair_test.go
@@ -292,13 +292,15 @@ func TestChannelPair_PeerAbortMidTransfer(t *testing.T) {
 
 func TestChannelPair_SessionWaitsForStart(t *testing.T) {
 	tests := []struct {
-		name    string
-		reqType string
-		payload []byte
+		name      string
+		reqType   string
+		payload   []byte
+		wantReply bool
 	}{
-		{name: "shell", reqType: requestTypeShell},
-		{name: "exec", reqType: requestTypeExec, payload: ssh.Marshal(execReq{Command: "whoami"})},
-		{name: "subsystem", reqType: requestTypeSubsystem, payload: ssh.Marshal(subsystemReq{Name: "sftp"})},
+		{name: "shell", reqType: requestTypeShell, wantReply: true},
+		{name: "exec", reqType: requestTypeExec, payload: ssh.Marshal(execReq{Command: "whoami"}), wantReply: true},
+		{name: "subsystem", reqType: requestTypeSubsystem, payload: ssh.Marshal(subsystemReq{Name: "sftp"}), wantReply: true},
+		{name: "shell without reply", reqType: requestTypeShell},
 	}
 
 	for _, tt := range tests {
@@ -320,7 +322,13 @@ func TestChannelPair_SessionWaitsForStart(t *testing.T) {
 
 			// Forwarding the session-start request opens the gate and the held-back
 			// bytes flow through.
-			channels.sendRequestAwaitReply(t, tt.reqType, tt.payload)
+			if tt.wantReply {
+				channels.sendRequestAwaitReply(t, tt.reqType, tt.payload)
+			} else {
+				_, err := channels.source.ch.SendRequest(tt.reqType, false, tt.payload)
+				require.NoError(t, err)
+				assertSentRequest(t, channels.target.requests, tt.reqType)
+			}
 
 			select {
 			case got := <-read:
@@ -332,6 +340,36 @@ func TestChannelPair_SessionWaitsForStart(t *testing.T) {
 			channels.close(t, done)
 		})
 	}
+}
+
+func TestChannelPair_SessionStartRejected(t *testing.T) {
+	channels := newProxyChannels(t, "session")
+	done := channels.serve(t)
+
+	channels.sendRequestRejected(t, requestTypeExec, ssh.Marshal(execReq{Command: "whoami"}))
+
+	_, err := channels.source.ch.Write([]byte("gated-bytes"))
+	require.NoError(t, err)
+
+	read := startRead(channels.target.ch, len("gated-bytes"))
+
+	select {
+	case <-read:
+		t.Fatal("data crossed the session gate after a rejected session start")
+	case <-time.After(shortTimeout):
+	}
+
+	// The rejection leaves the channel free to start a session with a later request.
+	channels.sendRequestAwaitReply(t, requestTypeShell, nil)
+
+	select {
+	case got := <-read:
+		assert.Equal(t, "gated-bytes", string(got))
+	case <-time.After(testTimeout):
+		t.Fatal("timed out waiting for data after the retried session start")
+	}
+
+	channels.close(t, done)
 }
 
 func TestChannelPair_RejectsDuplicateSessionStart(t *testing.T) {
@@ -615,6 +653,21 @@ func (p *proxyChannels) sendRequestAwaitReply(t *testing.T, reqType string, payl
 	ok, err := awaitReply(t)
 	require.NoError(t, err)
 	require.True(t, ok, "%q request must succeed", reqType)
+}
+
+// sendRequestRejected sends a WantReply request from the source, rejects it at the target, and
+// requires the rejection to round-trip back to the source.
+func (p *proxyChannels) sendRequestRejected(t *testing.T, reqType string, payload []byte) {
+	t.Helper()
+
+	awaitReply := sendRequest(p.source.ch, reqType, true, payload)
+
+	forwarded := assertSentRequest(t, p.target.requests, reqType)
+	require.NoError(t, forwarded.Reply(false, nil))
+
+	ok, err := awaitReply(t)
+	require.NoError(t, err)
+	require.False(t, ok, "%q request must be rejected", reqType)
 }
 
 // sendWindowChange sends a window-change and waits for the proxy to finish handling it; the

--- a/internal/sshhandler/channel_pair_test.go
+++ b/internal/sshhandler/channel_pair_test.go
@@ -394,13 +394,14 @@ func TestChannelPair_RejectsDuplicateSessionStart(t *testing.T) {
 
 			channels.sendRequestAwaitReply(t, requestTypeExec, ssh.Marshal(execReq{Command: "whoami"}))
 
-			// WantReply is false so SendRequest returns without waiting for a reply. The duplicate
-			// is deliberately never answered at the target (assertNoRequest only observes it), so a
-			// blocking request would stall the test; a non-blocking send lets a mis-forwarded
-			// duplicate reach the session-start signal instead.
-			_, err := channels.source.ch.SendRequest(tt.reqType, false, tt.payload)
-			require.NoError(t, err)
+			// The duplicate is never answered at the target, so the failure reply can only
+			// come from the proxy's own rejection.
+			awaitReply := sendRequest(channels.source.ch, tt.reqType, true, tt.payload)
 			assertNoRequest(t, channels.target.requests)
+
+			ok, err := awaitReply(t)
+			require.NoError(t, err)
+			assert.False(t, ok, "duplicate session start must be rejected")
 
 			// The original session is intact: data still flows.
 			_, err = channels.source.ch.Write([]byte("still-alive"))

--- a/internal/sshhandler/request_handler.go
+++ b/internal/sshhandler/request_handler.go
@@ -180,7 +180,7 @@ type SSHRequestHandler struct {
 	// Target SSH channel to forward SSH channel requests to
 	targetChannel ssh.Channel
 
-	// Whether a session-start request (shell, exec, or subsystem) has already been forwarded;
+	// Whether a session-start request (shell, exec, or subsystem) has already started a session;
 	// only the handleRequests goroutine touches it
 	sessionStarted bool
 

--- a/internal/sshhandler/request_handler.go
+++ b/internal/sshhandler/request_handler.go
@@ -83,7 +83,9 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 		var ptyReq ptyReq
 		h.parseRequestPayload(req, &ptyReq)
 
-		h.onPtyRequest(ptyReq)
+		if h.onPtyRequest != nil {
+			h.onPtyRequest(ptyReq)
+		}
 
 		shouldLog = true
 	case requestTypeShell:
@@ -115,9 +117,27 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 		var windowChangeReq windowChangeReq
 		h.parseRequestPayload(req, &windowChangeReq)
 
-		h.onWindowChange(windowChangeReq)
+		if h.onWindowChange != nil {
+			h.onWindowChange(windowChangeReq)
+		}
 	default:
 		// No special handling
+	}
+
+	// A channel runs at most one shell, exec, or subsystem request (RFC 4254, Section 6.5).
+	// Reject duplicates without forwarding: signaling a second session start would send on
+	// the already-closed started channel.
+	if sessionStarted && h.sessionStarted {
+		h.logger.Warn("Rejecting duplicate session start request",
+			zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, extra)))
+
+		if err := req.Reply(false, nil); err != nil {
+			h.logger.Error("Failed to reply to request",
+				zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, nil)),
+				zap.Error(err))
+		}
+
+		return
 	}
 
 	if shouldLog {
@@ -135,6 +155,8 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 
 	// Close the session started channel to signal that the session has started
 	if sessionStarted {
+		h.sessionStarted = true
+
 		sessionSignals.started <- command
 
 		close(sessionSignals.started)
@@ -156,10 +178,14 @@ type SSHRequestHandler struct {
 	// Target SSH channel to forward SSH channel requests to
 	targetChannel ssh.Channel
 
-	// Callback for when a pty request is received providing the width and height of the terminal
+	// Whether a session-start request (shell, exec, or subsystem) has already been forwarded;
+	// only the handleRequests goroutine touches it
+	sessionStarted bool
+
+	// Optional callback for when a pty request is received providing the width and height of the terminal
 	onPtyRequest func(req ptyReq)
 
-	// Callback for when a window-change request is received
+	// Optional callback for when a window-change request is received
 	onWindowChange func(req windowChangeReq)
 }
 

--- a/internal/sshhandler/request_handler.go
+++ b/internal/sshhandler/request_handler.go
@@ -145,7 +145,8 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 			zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, extra)))
 	}
 
-	if err := forwardRequest(h.targetChannel, req); err != nil {
+	accepted, err := forwardRequest(h.targetChannel, req)
+	if err != nil {
 		h.logger.Error("Failed to forward request",
 			zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, nil)),
 			zap.Error(err))
@@ -153,8 +154,9 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 		return
 	}
 
-	// Close the session started channel to signal that the session has started
-	if sessionStarted {
+	// A session starts only when the target accepted the request; without WantReply there is
+	// no confirmation and the session starts unconditionally (RFC 4254, Section 6.5).
+	if sessionStarted && (accepted || !req.WantReply) {
 		h.sessionStarted = true
 
 		sessionSignals.started <- command
@@ -244,13 +246,15 @@ func (h *SSHRequestHandler) handleRequests() SSHSessionSignals {
 	return sessionSignals
 }
 
-func forwardRequest(channel ssh.Channel, request *ssh.Request) error {
+// forwardRequest relays a request to the channel and the reply back; the returned accepted
+// result is meaningless when the request does not want a reply.
+func forwardRequest(channel ssh.Channel, request *ssh.Request) (bool, error) {
 	reply, requestErr := channel.SendRequest(request.Type, request.WantReply, request.Payload)
 	if requestErr != nil {
 		_ = request.Reply(false, nil)
 
-		return requestErr
+		return false, requestErr
 	}
 
-	return request.Reply(reply, nil)
+	return reply, request.Reply(reply, nil)
 }

--- a/internal/sshhandler/request_handler.go
+++ b/internal/sshhandler/request_handler.go
@@ -70,9 +70,9 @@ func (h *SSHRequestHandler) parseRequestPayload(req *ssh.Request, target any) {
 func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSessionSignals) {
 	h.logger.Debug("Channel request", zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, nil)))
 
-	// Sessions are started when a shell, exec, or subsystem request is received
+	// A shell, exec, or subsystem request starts the session
 	// see: https://datatracker.ietf.org/doc/html/rfc4254#section-6.5
-	sessionStarted := false
+	isSessionStartReq := false
 	command := ""
 
 	shouldLog := false
@@ -89,12 +89,12 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 
 		shouldLog = true
 	case requestTypeShell:
-		sessionStarted = true
+		isSessionStartReq = true
 		command = req.Type
 
 		shouldLog = true
 	case requestTypeExec:
-		sessionStarted = true
+		isSessionStartReq = true
 
 		var execReq execReq
 		h.parseRequestPayload(req, &execReq)
@@ -104,7 +104,7 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 		shouldLog = true
 		extra["command"] = execReq.Command
 	case requestTypeSubsystem:
-		sessionStarted = true
+		isSessionStartReq = true
 
 		var subsystemReq subsystemReq
 		h.parseRequestPayload(req, &subsystemReq)
@@ -127,7 +127,7 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 	// A channel runs at most one shell, exec, or subsystem request (RFC 4254, Section 6.5).
 	// Reject duplicates without forwarding: signaling a second session start would send on
 	// the already-closed started channel.
-	if sessionStarted && h.sessionStarted {
+	if isSessionStartReq && h.sessionStarted {
 		h.logger.Warn("Rejecting duplicate session start request",
 			zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, extra)))
 
@@ -156,7 +156,7 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 
 	// A session starts only when the target accepted the request; without WantReply there is
 	// no confirmation and the session starts unconditionally (RFC 4254, Section 6.5).
-	if sessionStarted && (accepted || !req.WantReply) {
+	if isSessionStartReq && (accepted || !req.WantReply) {
 		h.sessionStarted = true
 
 		sessionSignals.started <- command


### PR DESCRIPTION
## Related Tickets & Documents

Issue: https://github.com/Twingate/gateway/issues/396

## Changes

- Reject a duplicate session-start request (`shell`/`exec`/`subsystem`) at the proxy instead of forwarding it; a second one would signal on the already-closed `started` channel and panic, tearing down every session on the connection.
- Gate session start on the target's reply: a session-start request the target rejects no longer opens the session data gate or marks the session as started, leaving the channel free to start one with a later request. Without `WantReply` there is no confirmation and the session starts as before ([RFC 4254 §6.5](https://datatracker.ietf.org/doc/html/rfc4254#section-6.5)).
- Guard the pty and window-change callbacks against nil so target-originated requests of those types forward cleanly instead of panicking (the target-side handler has no callbacks).
