### PR TITLE
chore(config): Rename webApp `headers` to `requestHeaders`

### DIFF
--- a/deploy/gateway/templates/gateway-configmap.yaml
+++ b/deploy/gateway/templates/gateway-configmap.yaml
@@ -105,9 +105,9 @@ data:
 
     {{ with .Values.webApp -}}
     {{ if .enabled -}}
-    {{ with .headers -}}
+    {{ with .requestHeaders -}}
     webApp:
-      headers:
+      requestHeaders:
         {{- . | toYaml | nindent 8 }}
     {{ else -}}
     webApp: {}

--- a/deploy/gateway/tests/gateway-configmap_test.yaml
+++ b/deploy/gateway/tests/gateway-configmap_test.yaml
@@ -429,7 +429,7 @@ tests:
   - it: should render webApp with custom headers
     set:
       webApp:
-        headers:
+        requestHeaders:
           X-Groups: "{{groups}}"
           X-User: "{{username}}"
     asserts:
@@ -452,7 +452,7 @@ tests:
               privateKeyFile: "/etc/gateway/tls/tls.key"
 
             webApp:
-              headers:
+              requestHeaders:
                 X-Groups: '{{groups}}'
                 X-User: '{{username}}'
   - it: should not render webApp when disabled

--- a/deploy/gateway/values.schema.json
+++ b/deploy/gateway/values.schema.json
@@ -313,7 +313,7 @@
           "description": "Enable HTTP web app proxying.",
           "default": false
         },
-        "headers": {
+        "requestHeaders": {
           "type": "object",
           "description": "Custom HTTP headers to inject into proxied requests. Values may use template expressions with the twingate namespace (e.g. {{username}}, {{groups}}, {{jwt}}, {{clientGeoLoc}}).",
           "additionalProperties": {

--- a/deploy/gateway/values.yaml
+++ b/deploy/gateway/values.yaml
@@ -99,7 +99,7 @@ webApp:
   enabled: false
 
   # Custom HTTP headers to inject into proxied requests.
-  headers: {}
+  requestHeaders: {}
 
 clusterDomain: cluster.local
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,7 +53,7 @@ type Config struct {
 }
 
 type WebAppConfig struct {
-	Headers map[string]string `yaml:"headers,omitempty"`
+	RequestHeaders map[string]string `yaml:"requestHeaders,omitempty"`
 }
 
 type TwingateConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -328,7 +328,7 @@ func TestConfig_Validate(t *testing.T) {
 				},
 				Kubernetes: &KubernetesConfig{},
 				WebApp: &WebAppConfig{
-					Headers: map[string]string{"Authorization": "Bearer {{jwt}}"},
+					RequestHeaders: map[string]string{"Authorization": "Bearer {{jwt}}"},
 				},
 			},
 			wantErr: false,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -77,7 +77,7 @@ func NewProxy(config *gatewayconfig.Config, registry *prometheus.Registry, logge
 	}
 
 	if config.WebApp != nil {
-		webAppCfg, err := webapphandler.NewConfig(config.WebApp.Headers, roundTripperMetrics, logger)
+		webAppCfg, err := webapphandler.NewConfig(config.WebApp.RequestHeaders, roundTripperMetrics, logger)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create web app config: %w", err)
 		}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -77,7 +77,7 @@ func TestNewProxy_Success(t *testing.T) {
 func TestNewProxy_HTTPOnly(t *testing.T) {
 	config := fullConfig
 	config.SSH = nil
-	config.WebApp = &gatewayconfig.WebAppConfig{Headers: map[string]string{}}
+	config.WebApp = &gatewayconfig.WebAppConfig{RequestHeaders: map[string]string{}}
 
 	registry := prometheus.NewRegistry()
 	logger, err := NewLogger(DefaultLoggerName, false)

--- a/internal/webapphandler/config.go
+++ b/internal/webapphandler/config.go
@@ -14,15 +14,15 @@ import (
 )
 
 type Config struct {
-	headers             map[string]*template.Template
+	requestHeaders      map[string]*template.Template
 	roundTripperMetrics *metrics.RoundTripperMetrics
 	logger              *zap.Logger
 }
 
-func NewConfig(configHeaders map[string]string, roundTripperMetrics *metrics.RoundTripperMetrics, logger *zap.Logger) (*Config, error) {
-	headers := make(map[string]*template.Template, len(configHeaders))
+func NewConfig(configRequestHeaders map[string]string, roundTripperMetrics *metrics.RoundTripperMetrics, logger *zap.Logger) (*Config, error) {
+	headers := make(map[string]*template.Template, len(configRequestHeaders))
 
-	for name, value := range configHeaders {
+	for name, value := range configRequestHeaders {
 		tmpl, err := template.New(value)
 		if err != nil {
 			return nil, fmt.Errorf("header %q: %w", name, err)
@@ -35,5 +35,5 @@ func NewConfig(configHeaders map[string]string, roundTripperMetrics *metrics.Rou
 		headers[name] = tmpl
 	}
 
-	return &Config{headers: headers, roundTripperMetrics: roundTripperMetrics, logger: logger}, nil
+	return &Config{requestHeaders: headers, roundTripperMetrics: roundTripperMetrics, logger: logger}, nil
 }

--- a/internal/webapphandler/handler.go
+++ b/internal/webapphandler/handler.go
@@ -27,7 +27,7 @@ func NewHandler(cfg Config) *Handler {
 		Rewrite: func(r *httputil.ProxyRequest) {
 			conn := httpproxy.ProxyConnFromContext(r.In.Context())
 
-			if err := rewrite(r, conn, cfg.headers); err != nil {
+			if err := rewrite(r, conn, cfg.requestHeaders); err != nil {
 				cfg.logger.Error("failed to rewrite headers", zap.Error(err))
 				panic(err)
 			}

--- a/internal/webapphandler/handler_test.go
+++ b/internal/webapphandler/handler_test.go
@@ -50,7 +50,7 @@ func TestNewHandler_PanicsOnRewriteError(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := NewHandler(Config{
-		headers:             map[string]*template.Template{"X-Bad": unknownKeyTemplate},
+		requestHeaders:      map[string]*template.Template{"X-Bad": unknownKeyTemplate},
 		roundTripperMetrics: metrics.RegisterRoundTripperMetrics(prometheus.NewRegistry()),
 		logger:              zap.NewNop(),
 	})

--- a/test/integration/web_app_test.go
+++ b/test/integration/web_app_test.go
@@ -46,7 +46,7 @@ func TestWebApp(t *testing.T) {
 			PrivateKeyFile:  "../data/proxy/tls.key",
 		},
 		WebApp: &gatewayconfig.WebAppConfig{
-			Headers: map[string]string{
+			RequestHeaders: map[string]string{
 				"Authorization":                 "Bearer {{jwt}}",
 				"X-Twingate-Groups":             "{{groups}}",
 				"X-Twingate-Client-Geo-LatLong": "{{clientGeoLatLong}}",


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: N/A

## Changes

Renames the webApp static header-injection config key from `headers` to `requestHeaders`, so it reads consistently alongside the `RequestHeaderRewrites` GAT claim used for the same Web App traffic