### PR TITLE
fix: forward client Host and strip client identity headers for Web App

### DIFF
--- a/internal/webapphandler/handler.go
+++ b/internal/webapphandler/handler.go
@@ -62,12 +62,22 @@ func buildVariables(conn *connect.ProxyConn) map[string]string {
 	}
 }
 
+// clientIdentityHeaders are stripped from the upstream request so a client cannot spoof its
+// identity. The stdlib reverse proxy already strips the standard Forwarded/X-Forwarded-* set;
+// these are the identity headers it leaves in place.
+var clientIdentityHeaders = []string{"X-Real-IP", "X-Forwarded-Port", "X-Forwarded-Server"}
+
 func rewrite(r *httputil.ProxyRequest, conn *connect.ProxyConn, headers map[string]*template.Template) error {
 	targetURL := &url.URL{
 		Scheme: "http", // plain HTTP — no upstream TLS
 		Host:   conn.GetAddress(),
 	}
 	r.SetURL(targetURL)
+	r.Out.Host = r.In.Host // preserve the client's Host
+
+	for _, headerName := range clientIdentityHeaders {
+		r.Out.Header.Del(headerName)
+	}
 
 	variables := buildVariables(conn)
 

--- a/internal/webapphandler/handler_test.go
+++ b/internal/webapphandler/handler_test.go
@@ -222,6 +222,48 @@ func TestRewrite(t *testing.T) {
 	}
 }
 
+func TestRewrite_PreservesClientHost(t *testing.T) {
+	connMetrics := connect.CreateProxyConnMetrics(prometheus.NewRegistry())
+	conn := connect.NewProxyConn(nil, nil, nil, zap.NewNop(), connMetrics)
+	conn.Address = "admin.example.int:80"
+	conn.Claims = &token.GATClaims{}
+
+	proxyReq := &httputil.ProxyRequest{
+		In:  httptest.NewRequest(http.MethodGet, "http://admin.example.int/path", nil),
+		Out: httptest.NewRequest(http.MethodGet, "http://admin.example.int/path", nil),
+	}
+
+	err := rewrite(proxyReq, conn, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "admin.example.int", proxyReq.Out.Host, "client Host must be preserved without the upstream port")
+	assert.Equal(t, "admin.example.int:80", proxyReq.Out.URL.Host, "dial target must keep the port")
+}
+
+func TestRewrite_StripsClientIdentityHeaders(t *testing.T) {
+	connMetrics := connect.CreateProxyConnMetrics(prometheus.NewRegistry())
+	conn := connect.NewProxyConn(nil, nil, nil, zap.NewNop(), connMetrics)
+	conn.Address = "admin.example.int:80"
+	conn.Claims = &token.GATClaims{}
+
+	outReq := httptest.NewRequest(http.MethodGet, "http://admin.example.int/path", nil)
+	for _, headerName := range clientIdentityHeaders {
+		outReq.Header.Set(headerName, "spoofed")
+	}
+
+	proxyReq := &httputil.ProxyRequest{
+		In:  httptest.NewRequest(http.MethodGet, "http://admin.example.int/path", nil),
+		Out: outReq,
+	}
+
+	err := rewrite(proxyReq, conn, nil)
+	require.NoError(t, err)
+
+	for _, headerName := range clientIdentityHeaders {
+		assert.Empty(t, proxyReq.Out.Header.Values(headerName), "client-supplied %s must be stripped", headerName)
+	}
+}
+
 func TestRewrite_SkipsInvalidGATHeaders(t *testing.T) {
 	baseClaims := &token.GATClaims{
 		User: token.User{ID: "user-1", Username: "alice@acme.com"},


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: [#309](https://github.com/Twingate/gateway/issues/309)

## Changes

- Preserve the client `Host` header on the outbound request instead of overwriting it with the upstream dial address (the `:80` port broke CSRF Origin checks in upstream apps like Django)
- Strip client-supplied identity headers not removed by the stdlib: `X-Real-IP`, `X-Forwarded-Port`, `X-Forwarded-Server`