### PR TITLE
feat(ssh): end session channel when source closes before session start

### DIFF
--- a/internal/sshhandler/channel_pair.go
+++ b/internal/sshhandler/channel_pair.go
@@ -156,6 +156,11 @@ func (c *SSHChannelPair) serve() {
 		case command = <-sourceSessionSignals.started:
 			logger.Debug("Source session started", zap.String("command", command))
 			asciinemaHeader.Command = command
+		case <-sourceSessionSignals.finished:
+			// Source ended before starting a session; nothing to record or copy.
+			logger.Debug("Source ended before session start")
+
+			return
 		case <-time.After(c.sessionStartTimeout):
 			logger.Error("Timeout waiting for source session to start")
 

--- a/internal/sshhandler/channel_pair_test.go
+++ b/internal/sshhandler/channel_pair_test.go
@@ -437,6 +437,19 @@ func TestChannelPair_RejectsDuplicateSessionStart(t *testing.T) {
 	}
 }
 
+func TestChannelPair_SourceClosesBeforeStart(t *testing.T) {
+	// A session channel whose source closes before any session-start request must not hold
+	// serve() open for the full sessionStartTimeout: the closed source ends it promptly, with
+	// nothing recorded.
+	channels := newProxyChannels(t, "session")
+	done := channels.serve(t)
+
+	require.NoError(t, channels.source.ch.Close())
+
+	waitDone(t, done)
+	assert.Equal(t, recorderState{}, channels.recorder.state(), "no session => no recorder")
+}
+
 func TestChannelPair_SessionStartTimeout(t *testing.T) {
 	channels := newProxyChannels(t, "session")
 	channels.sessionStartTimeout = shortTimeout


### PR DESCRIPTION
## Related Tickets & Documents

Issue: https://github.com/Twingate/gateway/issues/396

## Changes

- End `serve()` promptly when a session channel's source closes before sending a session-start request (`shell`/`exec`/`subsystem`), instead of blocking until `sessionStartTimeout` and logging a spurious timeout error. Nothing is recorded or copied.