### PR TITLE
feat(ssh): log channel request outcomes in audit logs

### DIFF
--- a/internal/sshhandler/channel_pair_test.go
+++ b/internal/sshhandler/channel_pair_test.go
@@ -136,7 +136,7 @@ func TestChannelPair_RequestLogsCarryChannelExtraBothDirections(t *testing.T) {
 
 	channels.close(t, done)
 
-	channelField, isMap := observedSSHField(t, logs, "Channel request")["channel"].(map[string]any)
+	channelField, isMap := observedSSHField(t, logs, "SSH channel request")["channel"].(map[string]any)
 	require.True(t, isMap)
 	assert.Equal(t, "test-value", channelField["test-extra"])
 	assert.Equal(t, labelUpstream, channelField["source"], "target-side logs swap the direction labels")

--- a/internal/sshhandler/channel_pair_test.go
+++ b/internal/sshhandler/channel_pair_test.go
@@ -184,8 +184,6 @@ func TestChannelPair_SessionRequestLogsAcceptedOnlyWithReply(t *testing.T) {
 }
 
 func TestChannelPair_RequestLogLevelByType(t *testing.T) {
-	// None of these requests starts a session. On a session channel, serve() would then wait on
-	// the session-start gate until sessionStartTimeout, so the test uses a direct-tcpip channel.
 	tests := []struct {
 		name      string
 		reqType   string
@@ -199,17 +197,74 @@ func TestChannelPair_RequestLogLevelByType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			core, logs := observer.New(zap.DebugLevel)
-			channels := newProxyChannels(t, channelTypeDirectTCPIP)
+			channels := newProxyChannels(t, channelTypeSession)
 			channels.logger = zap.New(core)
 			done := channels.serve(t)
 
 			channels.sendRequestAwaitReply(t, tt.reqType, tt.payload)
 
-			channels.close(t, done)
-
+			// Assert before the shell below adds a log entry of its own.
 			entries := logs.FilterMessage("SSH channel request").All()
 			require.Len(t, entries, 1)
 			assert.Equal(t, tt.wantLevel, entries[0].Level)
+
+			// Neither request starts the session; without the shell, serve() waits out
+			// sessionStartTimeout.
+			channels.sendRequestAwaitReply(t, requestTypeShell, nil)
+
+			channels.close(t, done)
+		})
+	}
+}
+
+func TestChannelPair_RequestLogFieldsByType(t *testing.T) {
+	tests := []struct {
+		name          string
+		reqType       string
+		payload       []byte
+		startsSession bool
+		wantFields    map[string]any
+	}{
+		{
+			name: "environment variable", reqType: requestTypeEnv,
+			payload:    ssh.Marshal(envReq{Name: "LD_PRELOAD", Value: "/tmp/evil.so"}),
+			wantFields: map[string]any{"name": "LD_PRELOAD", "value": "/tmp/evil.so"},
+		},
+		{
+			name: "command", reqType: requestTypeExec,
+			payload:       ssh.Marshal(execReq{Command: "whoami"}),
+			startsSession: true,
+			wantFields:    map[string]any{"command": "whoami"},
+		},
+		{
+			name: "subsystem", reqType: requestTypeSubsystem,
+			payload:       ssh.Marshal(subsystemReq{Name: "sftp"}),
+			startsSession: true,
+			wantFields:    map[string]any{"name": "sftp"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, logs := observer.New(zap.DebugLevel)
+			channels := newProxyChannels(t, channelTypeSession)
+			channels.logger = zap.New(core)
+			done := channels.serve(t)
+
+			channels.sendRequestAwaitReply(t, tt.reqType, tt.payload)
+
+			// Assert before the shell below adds a log entry of its own.
+			requestField, isMap := observedSSHField(t, logs, "SSH channel request")["request"].(map[string]any)
+			require.True(t, isMap)
+			assert.Subset(t, requestField, tt.wantFields)
+
+			// A shell starts the session so serve() need not wait out sessionStartTimeout.
+			// exec and subsystem already started one, and a duplicate would be rejected.
+			if !tt.startsSession {
+				channels.sendRequestAwaitReply(t, requestTypeShell, nil)
+			}
+
+			channels.close(t, done)
 		})
 	}
 }

--- a/internal/sshhandler/channel_pair_test.go
+++ b/internal/sshhandler/channel_pair_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 	"golang.org/x/crypto/ssh"
@@ -182,17 +183,17 @@ func TestChannelPair_SessionRequestLogsAcceptedOnlyWithReply(t *testing.T) {
 	}
 }
 
-func TestChannelPair_AuditsRequestsExceptKnownMechanics(t *testing.T) {
-	// A forwarding channel keeps this off the session-start gate and shows the audit no longer
-	// depends on channel type.
+func TestChannelPair_RequestLogLevelByType(t *testing.T) {
+	// None of these requests starts a session. On a session channel, serve() would then wait on
+	// the session-start gate until sessionStartTimeout, so the test uses a direct-tcpip channel.
 	tests := []struct {
-		name    string
-		reqType string
-		payload []byte
-		audited bool
+		name      string
+		reqType   string
+		payload   []byte
+		wantLevel zapcore.Level
 	}{
-		{name: "unknown custom type", reqType: "probe@example.com", audited: true},
-		{name: "terminal mechanic", reqType: requestTypeWindowChange, payload: ssh.Marshal(windowChangeReq{WidthColumns: 80, HeightRows: 24}), audited: false},
+		{name: "unknown custom type", reqType: "probe@example.com", wantLevel: zap.InfoLevel},
+		{name: "terminal mechanic", reqType: requestTypeWindowChange, payload: ssh.Marshal(windowChangeReq{WidthColumns: 80, HeightRows: 24}), wantLevel: zap.DebugLevel},
 	}
 
 	for _, tt := range tests {
@@ -208,13 +209,7 @@ func TestChannelPair_AuditsRequestsExceptKnownMechanics(t *testing.T) {
 
 			entries := logs.FilterMessage("SSH channel request").All()
 			require.Len(t, entries, 1)
-
-			wantLevel := zap.DebugLevel
-			if tt.audited {
-				wantLevel = zap.InfoLevel
-			}
-
-			assert.Equal(t, wantLevel, entries[0].Level)
+			assert.Equal(t, tt.wantLevel, entries[0].Level)
 		})
 	}
 }

--- a/internal/sshhandler/channel_pair_test.go
+++ b/internal/sshhandler/channel_pair_test.go
@@ -142,6 +142,83 @@ func TestChannelPair_RequestLogsCarryChannelExtraBothDirections(t *testing.T) {
 	assert.Equal(t, labelUpstream, channelField["source"], "target-side logs swap the direction labels")
 }
 
+func TestChannelPair_SessionRequestLogsAcceptedOnlyWithReply(t *testing.T) {
+	tests := []struct {
+		name      string
+		wantReply bool
+	}{
+		{name: "with reply records outcome", wantReply: true},
+		{name: "without reply omits outcome", wantReply: false},
+	}
+
+	payload := ssh.Marshal(execReq{Command: "whoami"})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, logs := observer.New(zap.DebugLevel)
+			channels := newProxyChannels(t, channelTypeSession)
+			channels.logger = zap.New(core)
+			done := channels.serve(t)
+
+			if tt.wantReply {
+				channels.sendRequestAwaitReply(t, requestTypeExec, payload)
+			} else {
+				_, err := channels.source.ch.SendRequest(requestTypeExec, false, payload)
+				require.NoError(t, err)
+				assertSentRequest(t, channels.target.requests, requestTypeExec)
+			}
+
+			channels.close(t, done)
+
+			requestField, isMap := observedSSHField(t, logs, "SSH channel request")["request"].(map[string]any)
+			require.True(t, isMap)
+
+			if tt.wantReply {
+				assert.Equal(t, true, requestField["accepted"])
+			} else {
+				assert.NotContains(t, requestField, "accepted")
+			}
+		})
+	}
+}
+
+func TestChannelPair_AuditsRequestsExceptKnownMechanics(t *testing.T) {
+	// A forwarding channel keeps this off the session-start gate and shows the audit no longer
+	// depends on channel type.
+	tests := []struct {
+		name    string
+		reqType string
+		payload []byte
+		audited bool
+	}{
+		{name: "unknown custom type", reqType: "probe@example.com", audited: true},
+		{name: "terminal mechanic", reqType: requestTypeWindowChange, payload: ssh.Marshal(windowChangeReq{WidthColumns: 80, HeightRows: 24}), audited: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, logs := observer.New(zap.DebugLevel)
+			channels := newProxyChannels(t, channelTypeDirectTCPIP)
+			channels.logger = zap.New(core)
+			done := channels.serve(t)
+
+			channels.sendRequestAwaitReply(t, tt.reqType, tt.payload)
+
+			channels.close(t, done)
+
+			entries := logs.FilterMessage("SSH channel request").All()
+			require.Len(t, entries, 1)
+
+			wantLevel := zap.DebugLevel
+			if tt.audited {
+				wantLevel = zap.InfoLevel
+			}
+
+			assert.Equal(t, wantLevel, entries[0].Level)
+		})
+	}
+}
+
 func TestChannelPair_ForwardsTargetPtyAndWindowChange(t *testing.T) {
 	// The target-side request handler has no pty/window-change callbacks: requests of those
 	// types arriving from the target must hit the nil-callback guards and forward cleanly

--- a/internal/sshhandler/conn_pair.go
+++ b/internal/sshhandler/conn_pair.go
@@ -265,8 +265,7 @@ func (c *SSHConnPair) handleGlobalRequest(req *ssh.Request, dst ssh.Conn, disall
 	}
 }
 
-// forwardGlobalRequest forwards a global request to dst and returns the reply to send back. The
-// named returns default to a rejection, so every early return rejects the request.
+// forwardGlobalRequest forwards a global request to dst and returns the reply to send back.
 func (c *SSHConnPair) forwardGlobalRequest(req *ssh.Request, dst ssh.Conn, disallowedTypes map[string]bool, source, target string) (accepted bool, replyPayload []byte) {
 	extra, parseErr := globalRequestLogFields(req.Type, req.Payload)
 

--- a/internal/sshhandler/conn_pair.go
+++ b/internal/sshhandler/conn_pair.go
@@ -156,13 +156,13 @@ func (c *SSHConnPair) serve() {
 	c.wg.Go(func() {
 		defer closeOnPanic(c.logger, c.close)
 
-		c.forwardGlobalRequests(c.downstream.requests, c.upstream.conn, disallowedDownstreamGlobalRequests, labelDownstream, labelUpstream)
+		c.handleGlobalRequests(c.downstream.requests, c.upstream.conn, disallowedDownstreamGlobalRequests, labelDownstream, labelUpstream)
 	})
 
 	c.wg.Go(func() {
 		defer closeOnPanic(c.logger, c.close)
 
-		c.forwardGlobalRequests(c.upstream.requests, c.downstream.conn, disallowedUpstreamGlobalRequests, labelUpstream, labelDownstream)
+		c.handleGlobalRequests(c.upstream.requests, c.downstream.conn, disallowedUpstreamGlobalRequests, labelUpstream, labelDownstream)
 	})
 
 	// Forward channels in both directions
@@ -250,13 +250,24 @@ func (c *SSHConnPair) forwardChannels(channels <-chan ssh.NewChannel, targetConn
 	}
 }
 
-func (c *SSHConnPair) forwardGlobalRequests(requests <-chan *ssh.Request, dst ssh.Conn, disallowedTypes map[string]bool, source, target string) {
+func (c *SSHConnPair) handleGlobalRequests(requests <-chan *ssh.Request, dst ssh.Conn, disallowedTypes map[string]bool, source, target string) {
 	for req := range requests {
-		c.forwardGlobalRequest(req, dst, disallowedTypes, source, target)
+		c.handleGlobalRequest(req, dst, disallowedTypes, source, target)
 	}
 }
 
-func (c *SSHConnPair) forwardGlobalRequest(req *ssh.Request, dst ssh.Conn, disallowedTypes map[string]bool, source, target string) {
+func (c *SSHConnPair) handleGlobalRequest(req *ssh.Request, dst ssh.Conn, disallowedTypes map[string]bool, source, target string) {
+	accepted, replyPayload := c.forwardGlobalRequest(req, dst, disallowedTypes, source, target)
+
+	if err := req.Reply(accepted, replyPayload); err != nil {
+		c.logger.Error("Failed to reply to global request",
+			zap.Any("ssh", c.sshCtx.withGlobalRequest(req.Type, source, target, nil)), zap.Error(err))
+	}
+}
+
+// forwardGlobalRequest forwards a global request to dst and returns the reply to send back. The
+// named returns default to a rejection, so every early return rejects the request.
+func (c *SSHConnPair) forwardGlobalRequest(req *ssh.Request, dst ssh.Conn, disallowedTypes map[string]bool, source, target string) (accepted bool, replyPayload []byte) {
 	extra, parseErr := globalRequestLogFields(req.Type, req.Payload)
 
 	// logger derives the fields on each call so every log line carries the detail accumulated
@@ -265,19 +276,6 @@ func (c *SSHConnPair) forwardGlobalRequest(req *ssh.Request, dst ssh.Conn, disal
 		return c.logger.With(zap.Any("ssh", c.sshCtx.withGlobalRequest(req.Type, source, target, extra)))
 	}
 
-	var (
-		accepted     bool
-		replyPayload []byte
-		err          error
-	)
-
-	// Reply exactly once, on every path; early returns leave the defaults, which reject the request.
-	defer func() {
-		if err := req.Reply(accepted, replyPayload); err != nil {
-			logger().Error("Failed to reply to global request", zap.Error(err))
-		}
-	}()
-
 	if parseErr != nil {
 		logger().Error("Failed to parse global request", zap.Error(parseErr))
 	}
@@ -285,14 +283,14 @@ func (c *SSHConnPair) forwardGlobalRequest(req *ssh.Request, dst ssh.Conn, disal
 	if disallowedTypes[req.Type] {
 		logger().Warn("SSH global request rejected")
 
-		return
+		return false, nil
 	}
 
-	accepted, replyPayload, err = dst.SendRequest(req.Type, req.WantReply, req.Payload)
+	accepted, replyPayload, err := dst.SendRequest(req.Type, req.WantReply, req.Payload)
 	if err != nil {
 		logger().Error("Failed to forward global request", zap.Error(err))
 
-		return
+		return false, nil
 	}
 
 	// SendRequest's accepted result is meaningless when no reply was asked for.
@@ -310,6 +308,8 @@ func (c *SSHConnPair) forwardGlobalRequest(req *ssh.Request, dst ssh.Conn, disal
 	}
 
 	logger().Info("SSH global request")
+
+	return accepted, replyPayload
 }
 
 func (c *SSHConnPair) close() {

--- a/internal/sshhandler/conn_pair_test.go
+++ b/internal/sshhandler/conn_pair_test.go
@@ -449,7 +449,7 @@ func TestConnPair_GlobalRequestPolicy(t *testing.T) {
 
 func TestConnPair_GlobalRequestSendError(t *testing.T) {
 	// SendRequest fails only on a dead transport, and killing the upstream mid-serve races the
-	// cross-close teardown of the downstream side, so this drives forwardGlobalRequests
+	// cross-close teardown of the downstream side, so this drives handleGlobalRequests
 	// directly: a real pending request from a live source connection, forwarded to a real but
 	// already-closed target connection.
 	downstreamClient, proxyDownstream := sshPipe(t)
@@ -466,7 +466,7 @@ func TestConnPair_GlobalRequestSendError(t *testing.T) {
 
 	core, logs := observer.New(zap.DebugLevel)
 	pair := NewSSHConnPair(zap.New(core), testSSHContext, *proxyDownstream, *proxyUpstream)
-	pair.forwardGlobalRequests(requests, proxyUpstream.conn, nil, labelDownstream, labelUpstream)
+	pair.handleGlobalRequests(requests, proxyUpstream.conn, nil, labelDownstream, labelUpstream)
 
 	// The failed forward is logged and the origin gets a failure reply.
 	ok, _, err := awaitReply(t)

--- a/internal/sshhandler/request_handler.go
+++ b/internal/sshhandler/request_handler.go
@@ -68,15 +68,30 @@ func (h *SSHRequestHandler) parseRequestPayload(req *ssh.Request, target any) {
 
 // handleRequest processes and forwards a single SSH request, returning session info if applicable.
 func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSessionSignals) {
-	h.logger.Debug("Channel request", zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, nil)))
-
 	// A shell, exec, or subsystem request starts the session
 	// see: https://datatracker.ietf.org/doc/html/rfc4254#section-6.5
 	isSessionStartReq := false
 	command := ""
-
-	shouldLog := false
 	extra := map[string]any{}
+
+	// logger derives the fields on each call so every log line carries the detail accumulated
+	// in extra so far.
+	logger := func() *zap.Logger {
+		return h.logger.With(zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, extra)))
+	}
+
+	var (
+		accepted bool
+		err      error
+	)
+
+	// Reply exactly once, on every path; early returns leave the default, which rejects the
+	// request.
+	defer func() {
+		if err := req.Reply(accepted, nil); err != nil {
+			logger().Error("Failed to reply to request", zap.Error(err))
+		}
+	}()
 
 	switch req.Type {
 	case requestTypePty:
@@ -86,13 +101,9 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 		if h.onPtyRequest != nil {
 			h.onPtyRequest(ptyReq)
 		}
-
-		shouldLog = true
 	case requestTypeShell:
 		isSessionStartReq = true
 		command = req.Type
-
-		shouldLog = true
 	case requestTypeExec:
 		isSessionStartReq = true
 
@@ -100,8 +111,6 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 		h.parseRequestPayload(req, &execReq)
 
 		command = req.Type + " " + execReq.Command
-
-		shouldLog = true
 		extra["command"] = execReq.Command
 	case requestTypeSubsystem:
 		isSessionStartReq = true
@@ -110,8 +119,6 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 		h.parseRequestPayload(req, &subsystemReq)
 
 		command = req.Type + " " + subsystemReq.Name
-
-		shouldLog = true
 		extra["name"] = subsystemReq.Name
 	case requestTypeWindowChange:
 		var windowChangeReq windowChangeReq
@@ -128,31 +135,24 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 	// Reject duplicates without forwarding: signaling a second session start would send on
 	// the already-closed started channel.
 	if isSessionStartReq && h.sessionStarted {
-		h.logger.Warn("Rejecting duplicate session start request",
-			zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, extra)))
-
-		if err := req.Reply(false, nil); err != nil {
-			h.logger.Error("Failed to reply to request",
-				zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, nil)),
-				zap.Error(err))
-		}
+		logger().Warn("Rejecting duplicate session start request")
 
 		return
 	}
 
-	if shouldLog {
-		h.logger.Info("SSH channel request",
-			zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, extra)))
-	}
-
-	accepted, err := forwardRequest(h.targetChannel, req)
+	accepted, err = h.targetChannel.SendRequest(req.Type, req.WantReply, req.Payload)
 	if err != nil {
-		h.logger.Error("Failed to forward request",
-			zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, nil)),
-			zap.Error(err))
+		logger().Error("Failed to forward request", zap.Error(err))
 
 		return
 	}
+
+	// SendRequest's accepted result is meaningless when no reply was asked for.
+	if req.WantReply {
+		extra["accepted"] = accepted
+	}
+
+	logger().Info("SSH channel request")
 
 	// A session starts only when the target accepted the request; without WantReply there is
 	// no confirmation and the session starts unconditionally (RFC 4254, Section 6.5).
@@ -245,17 +245,4 @@ func (h *SSHRequestHandler) handleRequests() SSHSessionSignals {
 	}()
 
 	return sessionSignals
-}
-
-// forwardRequest relays a request to the channel and the reply back; the returned accepted
-// result is meaningless when the request does not want a reply.
-func forwardRequest(channel ssh.Channel, request *ssh.Request) (bool, error) {
-	reply, requestErr := channel.SendRequest(request.Type, request.WantReply, request.Payload)
-	if requestErr != nil {
-		_ = request.Reply(false, nil)
-
-		return false, requestErr
-	}
-
-	return reply, request.Reply(reply, nil)
 }

--- a/internal/sshhandler/request_handler.go
+++ b/internal/sshhandler/request_handler.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	requestTypePty          = "pty-req"
+	requestTypeEnv          = "env"
 	requestTypeShell        = "shell"
 	requestTypeExec         = "exec"
 	requestTypeSubsystem    = "subsystem"
@@ -46,6 +47,13 @@ type ptyReq struct {
 	WidthPixels  uint32
 	HeightPixels uint32
 	Modelist     string
+}
+
+// SSH env request structure
+// see: https://datatracker.ietf.org/doc/html/rfc4254#section-6.4
+type envReq struct {
+	Name  string
+	Value string
 }
 
 // SSH exec request structure
@@ -119,6 +127,12 @@ func (h *SSHRequestHandler) forwardRequest(req *ssh.Request) (accepted, startSes
 		if h.onPtyRequest != nil {
 			h.onPtyRequest(ptyReq)
 		}
+	case requestTypeEnv:
+		var envReq envReq
+		h.parseRequestPayload(req, &envReq)
+
+		extra["name"] = envReq.Name
+		extra["value"] = envReq.Value
 	case requestTypeShell:
 		isSessionStartReq = true
 		command = req.Type
@@ -170,10 +184,14 @@ func (h *SSHRequestHandler) forwardRequest(req *ssh.Request) (accepted, startSes
 		extra["accepted"] = accepted
 	}
 
+	level := zap.InfoLevel
 	if auditIgnoredChannelRequests[req.Type] {
-		logger().Debug("SSH channel request")
-	} else {
-		logger().Info("SSH channel request")
+		level = zap.DebugLevel
+	}
+
+	// Check first so withRequest only allocates when the entry is actually written.
+	if ce := h.logger.Check(level, "SSH channel request"); ce != nil {
+		ce.Write(zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, extra)))
 	}
 
 	// A session starts only when the target accepted the request; without WantReply there is

--- a/internal/sshhandler/request_handler.go
+++ b/internal/sshhandler/request_handler.go
@@ -16,6 +16,18 @@ const (
 	requestTypeWindowChange = "window-change"
 )
 
+// auditIgnoredChannelRequests holds the request types with no audit value. Any type not
+// listed, including unrecognized custom ones, is audited, so an unusual request stays visible.
+var auditIgnoredChannelRequests = map[string]bool{
+	requestTypePty:          true,
+	requestTypeWindowChange: true,
+	"signal":                true,
+	"xon-xoff":              true,
+	"break":                 true,
+	"exit-status":           true,
+	"exit-signal":           true,
+}
+
 type SSHSessionSignals struct {
 	started  chan string // The command that started the session
 	finished chan struct{}
@@ -66,12 +78,31 @@ func (h *SSHRequestHandler) parseRequestPayload(req *ssh.Request, target any) {
 	}
 }
 
-// handleRequest processes and forwards a single SSH request, returning session info if applicable.
 func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSessionSignals) {
+	accepted, startSession, command := h.forwardRequest(req)
+
+	// Reply before signaling session start: the signal unblocks serve() and lets upstream
+	// data flow to the client, which must not reach the client before the request reply.
+	if err := req.Reply(accepted, nil); err != nil {
+		h.logger.Error("Failed to reply to request",
+			zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, nil)), zap.Error(err))
+	}
+
+	if startSession {
+		h.sessionStarted = true
+
+		sessionSignals.started <- command
+
+		close(sessionSignals.started)
+	}
+}
+
+// forwardRequest forwards a channel request to the target. The named returns default to a
+// rejection, so every early return rejects the request without starting a session.
+func (h *SSHRequestHandler) forwardRequest(req *ssh.Request) (accepted, startSession bool, command string) {
 	// A shell, exec, or subsystem request starts the session
 	// see: https://datatracker.ietf.org/doc/html/rfc4254#section-6.5
 	isSessionStartReq := false
-	command := ""
 	extra := map[string]any{}
 
 	// logger derives the fields on each call so every log line carries the detail accumulated
@@ -79,19 +110,6 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 	logger := func() *zap.Logger {
 		return h.logger.With(zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, extra)))
 	}
-
-	var (
-		accepted bool
-		err      error
-	)
-
-	// Reply exactly once, on every path; early returns leave the default, which rejects the
-	// request.
-	defer func() {
-		if err := req.Reply(accepted, nil); err != nil {
-			logger().Error("Failed to reply to request", zap.Error(err))
-		}
-	}()
 
 	switch req.Type {
 	case requestTypePty:
@@ -137,14 +155,14 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 	if isSessionStartReq && h.sessionStarted {
 		logger().Warn("Rejecting duplicate session start request")
 
-		return
+		return false, false, ""
 	}
 
-	accepted, err = h.targetChannel.SendRequest(req.Type, req.WantReply, req.Payload)
+	accepted, err := h.targetChannel.SendRequest(req.Type, req.WantReply, req.Payload)
 	if err != nil {
 		logger().Error("Failed to forward request", zap.Error(err))
 
-		return
+		return false, false, ""
 	}
 
 	// SendRequest's accepted result is meaningless when no reply was asked for.
@@ -152,17 +170,17 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 		extra["accepted"] = accepted
 	}
 
-	logger().Info("SSH channel request")
+	if auditIgnoredChannelRequests[req.Type] {
+		logger().Debug("SSH channel request")
+	} else {
+		logger().Info("SSH channel request")
+	}
 
 	// A session starts only when the target accepted the request; without WantReply there is
 	// no confirmation and the session starts unconditionally (RFC 4254, Section 6.5).
-	if isSessionStartReq && (accepted || !req.WantReply) {
-		h.sessionStarted = true
+	startSession = isSessionStartReq && (accepted || !req.WantReply)
 
-		sessionSignals.started <- command
-
-		close(sessionSignals.started)
-	}
+	return accepted, startSession, command
 }
 
 type SSHRequestHandler struct {

--- a/internal/sshhandler/request_handler.go
+++ b/internal/sshhandler/request_handler.go
@@ -97,8 +97,8 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 	}
 }
 
-// forwardRequest forwards a channel request to the target. The named returns default to a
-// rejection, so every early return rejects the request without starting a session.
+// forwardRequest forwards a channel request to the target channel and reports whether the target
+// accepted it, along with the command to start a session with when the request starts one.
 func (h *SSHRequestHandler) forwardRequest(req *ssh.Request) (accepted, startSession bool, command string) {
 	// A shell, exec, or subsystem request starts the session
 	// see: https://datatracker.ietf.org/doc/html/rfc4254#section-6.5

--- a/internal/sshhandler/request_handler.go
+++ b/internal/sshhandler/request_handler.go
@@ -72,7 +72,7 @@ type windowChangeReq struct {
 // parseRequestPayload unmarshals request payload and logs error if parsing fails.
 func (h *SSHRequestHandler) parseRequestPayload(req *ssh.Request, target any) {
 	if err := ssh.Unmarshal(req.Payload, target); err != nil {
-		h.logger.Error("Failed to parse "+req.Type+" request",
+		h.logger.Error("Failed to parse channel request",
 			zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, nil)),
 			zap.Error(err))
 	}
@@ -84,7 +84,7 @@ func (h *SSHRequestHandler) handleRequest(req *ssh.Request, sessionSignals SSHSe
 	// Reply before signaling session start: the signal unblocks serve() and lets upstream
 	// data flow to the client, which must not reach the client before the request reply.
 	if err := req.Reply(accepted, nil); err != nil {
-		h.logger.Error("Failed to reply to request",
+		h.logger.Error("Failed to reply to channel request",
 			zap.Any("ssh", h.sshChannelCtx.withRequest(req.Type, nil)), zap.Error(err))
 	}
 
@@ -153,14 +153,14 @@ func (h *SSHRequestHandler) forwardRequest(req *ssh.Request) (accepted, startSes
 	// Reject duplicates without forwarding: signaling a second session start would send on
 	// the already-closed started channel.
 	if isSessionStartReq && h.sessionStarted {
-		logger().Warn("Rejecting duplicate session start request")
+		logger().Warn("SSH channel request rejected: duplicate session start")
 
 		return false, false, ""
 	}
 
 	accepted, err := h.targetChannel.SendRequest(req.Type, req.WantReply, req.Payload)
 	if err != nil {
-		logger().Error("Failed to forward request", zap.Error(err))
+		logger().Error("Failed to forward channel request", zap.Error(err))
 
 		return false, false, ""
 	}

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -128,18 +128,19 @@ func TestSSH(t *testing.T) {
 	// Wait for logs to be flushed
 	time.Sleep(100 * time.Millisecond)
 
-	expectedRequest := map[string]any{
-		"type":    "exec",
-		"command": "whoami",
-		"source":  "downstream",
-		"target":  "upstream",
-	}
 	expectedUser := map[string]any{
 		"id":       "user-ssh-1",
 		"username": "alex@acme.com",
 		"groups":   []any{"OnCall", "Engineering"},
 	}
-	testutil.AssertLogsForSSH(t, env.logs, expectedUser, expectedRequest)
+	testutil.AssertLogsForSSHChannelRequests(t, env.logs, expectedUser, []testutil.SSHChannelRequestLog{
+		{Level: zap.InfoLevel, Request: map[string]any{
+			"type": "exec", "command": "whoami", "source": "downstream", "target": "upstream", "accepted": true,
+		}},
+		{Level: zap.DebugLevel, Request: map[string]any{
+			"type": "exit-status", "source": "upstream", "target": "downstream",
+		}},
+	})
 
 	// Clear existing logs
 	env.logs.TakeAll()
@@ -162,13 +163,15 @@ func TestSSH(t *testing.T) {
 	// Wait for logs to be flushed
 	time.Sleep(100 * time.Millisecond)
 
-	expectedRequest = map[string]any{
-		"type":   "subsystem",
-		"name":   "sftp",
-		"source": "downstream",
-		"target": "upstream",
-	}
-	testutil.AssertLogsForSSH(t, env.logs, expectedUser, expectedRequest)
+	testutil.AssertLogsForSSHChannelRequests(t, env.logs, expectedUser, []testutil.SSHChannelRequestLog{
+		{Level: zap.InfoLevel, Request: map[string]any{
+			"type": "subsystem", "name": "sftp", "source": "downstream", "target": "upstream", "accepted": true,
+		}},
+		{Level: zap.DebugLevel, Request: map[string]any{
+			"type": "exit-status", "source": "upstream", "target": "downstream",
+		}},
+	})
+
 	// The gateway presents only its CA-signed host certificate, so a client that accepts
 	// only the plain ed25519 host key algorithm cannot negotiate a host key.
 	_, err = env.user.SSH.Command("-o", "HostKeyAlgorithms=ssh-ed25519", "whoami")

--- a/test/integration/testutil/assertions.go
+++ b/test/integration/testutil/assertions.go
@@ -84,8 +84,6 @@ func AssertLogsForExecOrAttach(t *testing.T, logs *observer.ObservedLogs, expect
 	assert.Equal(t, firstLog.ContextMap()["request_id"], secondLog.ContextMap()["request_id"])
 }
 
-// SSHChannelRequestLog is an expected "SSH channel request" audit log: the level it is logged at
-// and the whole ssh.request field it carries.
 type SSHChannelRequestLog struct {
 	Level   zapcore.Level
 	Request map[string]any

--- a/test/integration/testutil/assertions.go
+++ b/test/integration/testutil/assertions.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
 	authv1 "k8s.io/api/authentication/v1"
@@ -83,24 +84,36 @@ func AssertLogsForExecOrAttach(t *testing.T, logs *observer.ObservedLogs, expect
 	assert.Equal(t, firstLog.ContextMap()["request_id"], secondLog.ContextMap()["request_id"])
 }
 
-func AssertLogsForSSH(t *testing.T, logs *observer.ObservedLogs, expectedUser, expectedRequest map[string]any) {
+// SSHChannelRequestLog is an expected "SSH channel request" audit log: the level it is logged at
+// and the whole ssh.request field it carries.
+type SSHChannelRequestLog struct {
+	Level   zapcore.Level
+	Request map[string]any
+}
+
+// AssertLogsForSSHChannelRequests asserts that the observed "SSH channel request" logs are exactly
+// expectedRequests, in the order the gateway logged them. Each direction is logged by its own
+// goroutine, so an order across directions holds only for causally ordered requests, such as an
+// exec request and the exit-status that follows it.
+func AssertLogsForSSHChannelRequests(t *testing.T, logs *observer.ObservedLogs, expectedUser map[string]any, expectedRequests []SSHChannelRequestLog) {
 	t.Helper()
 
-	sessionLogs := logs.FilterMessage("SSH channel request").All()
-	assert.Len(t, sessionLogs, 1, "expected 1 log for SSH session, user %v", expectedUser)
+	requestLogs := logs.FilterMessage("SSH channel request").All()
+	actualRequests := make([]SSHChannelRequestLog, 0, len(requestLogs))
 
-	firstLog := sessionLogs[0]
-	assert.Equal(t, expectedUser, firstLog.ContextMap()["user"])
+	for _, log := range requestLogs {
+		assert.Equal(t, expectedUser, log.ContextMap()["user"])
 
-	sshField, ok := firstLog.ContextMap()["ssh"].(map[string]any)
-	require.True(t, ok, "ssh field should be a map")
+		sshField, ok := log.ContextMap()["ssh"].(map[string]any)
+		require.True(t, ok, "ssh field should be a map")
 
-	requestField, ok := sshField["request"].(map[string]any)
-	require.True(t, ok, "ssh.request field should be a map")
+		requestField, ok := sshField["request"].(map[string]any)
+		require.True(t, ok, "ssh.request field should be a map")
 
-	for k, v := range expectedRequest {
-		assert.Equal(t, v, requestField[k], "ssh.request.%s mismatch", k)
+		actualRequests = append(actualRequests, SSHChannelRequestLog{Level: log.Level, Request: requestField})
 	}
+
+	assert.Equal(t, expectedRequests, actualRequests)
 }
 
 func AssertLogsForSSHChannel(t *testing.T, logs *observer.ObservedLogs, expectedUser, expectedChannel map[string]any) {

--- a/test/integration/testutil/ssh_client.go
+++ b/test/integration/testutil/ssh_client.go
@@ -53,6 +53,10 @@ func (s *SSH) baseOptions() []string {
 		s.hostname,
 		"-l", s.username,
 		"-p", s.port,
+		// Ignore the system and user ssh_config so the requests the client sends, and therefore the
+		// audit logs the gateway emits, do not vary with the machine running the tests. In
+		// particular `SendEnv LANG LC_*` would add an env request whenever LANG is set.
+		"-F", "none",
 		"-o", "StrictHostKeyChecking=yes",
 		"-o", "UserKnownHostsFile=" + s.knownHostsFile,
 	}
@@ -68,6 +72,7 @@ func (s *SSH) executeSSH(ctx context.Context, cmdOptions ...string) ([]byte, err
 func (s *SSH) copy(ctx context.Context, source, target string, cmdOptions ...string) ([]byte, error) {
 	var options = []string{
 		"-P", s.port,
+		"-F", "none",
 		"-o", "StrictHostKeyChecking=yes",
 		"-o", "UserKnownHostsFile=" + s.knownHostsFile,
 	}


### PR DESCRIPTION
## Related Tickets & Documents

- Issue #396

## Changes

- Log one audit line per forwarded channel request, carrying the target's reply (`accepted`) when the request asked for one; previously the line was emitted before forwarding, so the outcome was never recorded.
- Log at Info by default, and at Debug for the request types with no audit value (`pty-req`, `window-change`, `signal`, `xon-xoff`, `break`, `exit-status`, `exit-signal`), so an unrecognized request type stays visible at Info.
  + Compared with the current behavior, `pty-req` moves from Info to Debug and unrecognized types move from Debug to Info.
- Reply exactly once per request, rejecting on the paths that do not forward (duplicate session start, forward error).

## Notes

- Mirrors the global-request audit logging from #390 (log every request and its outcome, including denied attempts) at the channel-request level.
