### PR TITLE
refactor(ssh): replace caConfig struct with a caProvider interface

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,6 +46,8 @@ linters:
         - stdlib
         # custom values
         - Recorder
+        - ca
+        - caProvider
         # golang.org/x/crypto/ssh
         - Signer
         - PublicKey

--- a/internal/sshhandler/ca.go
+++ b/internal/sshhandler/ca.go
@@ -44,8 +44,7 @@ type rotatingCA interface {
 }
 
 // caProvider supplies the CAs for SSH authentication and runs any background
-// maintenance a specific CA backend needs. Each backend is its own
-// implementation so backend-specific state stays out of a shared type.
+// maintenance a specific CA backend needs.
 type caProvider interface {
 	// Start runs background CA maintenance until the context is canceled.
 	Start(ctx context.Context) error

--- a/internal/sshhandler/ca.go
+++ b/internal/sshhandler/ca.go
@@ -43,41 +43,26 @@ type rotatingCA interface {
 	rotated() <-chan struct{}
 }
 
-// caConfig contains the CAs needed for SSH authentication operations.
-type caConfig struct {
-	GatewayHostCA  ca // Signs Gateway's host certificates (presented to clients)
-	GatewayUserCA  ca // Signs Gateway's user certificates (presented to upstreams)
-	UpstreamHostCA ca // Verifies upstream host certificates (only publicKey is used). If nil, defaults to TOFU verification with upstream's public key.
+// caProvider supplies the CAs for SSH authentication and runs any background
+// maintenance a specific CA backend needs. Each backend is its own
+// implementation so backend-specific state stays out of a shared type.
+type caProvider interface {
+	// Start runs background CA maintenance until the context is canceled.
+	Start(ctx context.Context) error
 
-	vault       *Vault       // Vault client for token lifecycle management (nil for Manual CAs)
-	keyReloader *keyReloader // Reloads the CA private key on file change (nil for Vault CA)
+	// gatewayHostCA signs the Gateway's host certificates (presented to clients).
+	gatewayHostCA() ca
+	// gatewayUserCA signs the Gateway's user certificates (presented to upstreams).
+	gatewayUserCA() ca
+	// upstreamHostCA verifies upstream host certificates (only its publicKey is used).
+	// A nil result selects TOFU verification with the upstream's public key.
+	upstreamHostCA() ca
 }
 
-// Start performs initial Vault authentication and starts the token renewal loop.
-// For manual CA, it starts background CA maintenance to reloads the CA private key on file change.
-func (c *caConfig) Start(ctx context.Context) error {
-	if c.keyReloader != nil {
-		c.keyReloader.Run(ctx)
-	}
-
-	if c.vault == nil || c.vault.authMethod == nil {
-		return nil
-	}
-
-	secret, err := c.vault.client.Auth().Login(ctx, c.vault.authMethod)
-	if err != nil {
-		return fmt.Errorf("failed to login to Vault: %w", err)
-	}
-
-	go c.vault.runTokenRenewalLoop(ctx, secret)
-
-	return nil
-}
-
-// newCAFromConfig creates CAs based on the provided configuration.
+// newCAFromConfig creates a caProvider based on the provided configuration.
 // - If config.Manual is set, creates an embedded CA with the provided key files.
 // - If config.Vault is set, creates Vault-backed CAs.
-func newCAFromConfig(config gatewayconfig.SSHCAConfig, logger *zap.Logger) (*caConfig, error) {
+func newCAFromConfig(config gatewayconfig.SSHCAConfig, logger *zap.Logger) (caProvider, error) {
 	switch {
 	case config.Manual != nil:
 		return newManualCA(config.Manual.PrivateKeyFile, logger)
@@ -88,10 +73,15 @@ func newCAFromConfig(config gatewayconfig.SSHCAConfig, logger *zap.Logger) (*caC
 	}
 }
 
-// newManualCA creates an embedded CA with keys loaded from files. The private key is
-// reloaded when the file changes, so it can be rotated without a restart.
-// The CA signs gateway host and user certificates, and upstream host authentication is verified using TOFU.
-func newManualCA(privateKeyFile string, logger *zap.Logger) (*caConfig, error) {
+// manualCAProvider signs with an embedded key reloaded from a file, so the CA key
+// can be rotated without a restart. Upstream host authentication uses TOFU.
+type manualCAProvider struct {
+	ca          *embeddedCA
+	keyReloader *keyReloader
+}
+
+// newManualCA creates an embedded CA with keys loaded from files.
+func newManualCA(privateKeyFile string, logger *zap.Logger) (*manualCAProvider, error) {
 	reloader := newKeyReloader(privateKeyFile, logger)
 	if err := reloader.load(); err != nil {
 		return nil, err
@@ -105,53 +95,89 @@ func newManualCA(privateKeyFile string, logger *zap.Logger) (*caConfig, error) {
 	publicKeyStr := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(reloader.getSigner().PublicKey())))
 	logger.Info("Using manual CA for SSH authentication", zap.String("ca_public_key", publicKeyStr))
 
-	return &caConfig{
-		GatewayHostCA: ca,
-		GatewayUserCA: ca,
-		keyReloader:   reloader,
+	return &manualCAProvider{
+		ca:          ca,
+		keyReloader: reloader,
 	}, nil
 }
 
+func (p *manualCAProvider) Start(ctx context.Context) error {
+	p.keyReloader.Run(ctx)
+
+	return nil
+}
+
+func (p *manualCAProvider) gatewayHostCA() ca  { return p.ca }
+func (p *manualCAProvider) gatewayUserCA() ca  { return p.ca }
+func (p *manualCAProvider) upstreamHostCA() ca { return nil }
+
+// vaultCAProvider is backed by Vault, with independent CAs for Gateway host and
+// user certificates and upstream host verification.
+type vaultCAProvider struct {
+	vault *Vault
+
+	host     *vaultCA
+	user     *vaultCA
+	upstream *vaultCA
+}
+
 // newVaultCA creates Vault-backed CAs.
-// Vault config allows setting different CAs for Gateway host and user certificates, and upstream host authentication.
-func newVaultCA(vaultConfig *gatewayconfig.SSHCAVaultConfig, logger *zap.Logger) (*caConfig, error) {
+func newVaultCA(vaultConfig *gatewayconfig.SSHCAVaultConfig, logger *zap.Logger) (*vaultCAProvider, error) {
 	v, err := newVault(vaultConfig, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Vault client: %w", err)
 	}
 
-	gatewayHostCA := &vaultCA{
-		client: v.client,
-		mount:  vaultConfig.GetGatewayHostCAMount(),
-		role:   vaultConfig.GetGatewayHostCARole(),
-	}
-	gatewayUserCA := &vaultCA{
-		client: v.client,
-		mount:  vaultConfig.GetGatewayUserCAMount(),
-		role:   vaultConfig.GetGatewayUserCARole(),
-	}
-	upstreamHostCA := &vaultCA{
-		client: v.client,
-		mount:  vaultConfig.GetUpstreamHostCAMount(),
-		role:   "", // No role needed - only used for publicKey retrieval
-	}
-
-	return &caConfig{
-		GatewayHostCA:  gatewayHostCA,
-		GatewayUserCA:  gatewayUserCA,
-		UpstreamHostCA: upstreamHostCA,
-		vault:          v,
+	return &vaultCAProvider{
+		vault: v,
+		host: &vaultCA{
+			client: v.client,
+			mount:  vaultConfig.GetGatewayHostCAMount(),
+			role:   vaultConfig.GetGatewayHostCARole(),
+		},
+		user: &vaultCA{
+			client: v.client,
+			mount:  vaultConfig.GetGatewayUserCAMount(),
+			role:   vaultConfig.GetGatewayUserCARole(),
+		},
+		upstream: &vaultCA{
+			client: v.client,
+			mount:  vaultConfig.GetUpstreamHostCAMount(),
+			role:   "", // No role needed - only used for publicKey retrieval
+		},
 	}, nil
 }
 
-func (c *caConfig) upstreamHostKeyCallback(ctx context.Context, upstreamAddress string) (ssh.HostKeyCallback, error) {
-	if c.UpstreamHostCA == nil {
+// Start performs initial Vault authentication and starts the token renewal loop.
+func (p *vaultCAProvider) Start(ctx context.Context) error {
+	if p.vault == nil || p.vault.authMethod == nil {
+		return nil
+	}
+
+	secret, err := p.vault.client.Auth().Login(ctx, p.vault.authMethod)
+	if err != nil {
+		return fmt.Errorf("failed to login to Vault: %w", err)
+	}
+
+	go p.vault.runTokenRenewalLoop(ctx, secret)
+
+	return nil
+}
+
+func (p *vaultCAProvider) gatewayHostCA() ca  { return p.host }
+func (p *vaultCAProvider) gatewayUserCA() ca  { return p.user }
+func (p *vaultCAProvider) upstreamHostCA() ca { return p.upstream }
+
+// upstreamHostKeyCallback verifies the upstream host key. A nil upstreamCA selects
+// TOFU verification with the upstream's presented public key.
+func upstreamHostKeyCallback(ctx context.Context, upstreamCA ca, upstreamAddress string) (ssh.HostKeyCallback, error) {
+	if upstreamCA == nil {
 		tofuHostKey := newTOFUHostKey(upstreamAddress)
 
 		return tofuHostKey.checkHostKey, nil
 	}
 
-	caPublicKey, err := c.UpstreamHostCA.publicKey(ctx)
+	caPublicKey, err := upstreamCA.publicKey(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ca public key: %w", err)
 	}

--- a/internal/sshhandler/ca.go
+++ b/internal/sshhandler/ca.go
@@ -150,7 +150,7 @@ func newVaultCA(vaultConfig *gatewayconfig.SSHCAVaultConfig, logger *zap.Logger)
 
 // Start performs initial Vault authentication and starts the token renewal loop.
 func (p *vaultCAProvider) Start(ctx context.Context) error {
-	if p.vault == nil || p.vault.authMethod == nil {
+	if p.vault.authMethod == nil {
 		return nil
 	}
 

--- a/internal/sshhandler/ca_test.go
+++ b/internal/sshhandler/ca_test.go
@@ -90,20 +90,20 @@ func TestNewManualCA_Success(t *testing.T) {
 	core, logs := observer.New(zapcore.InfoLevel)
 	logger := zap.New(core)
 
-	caConfig, err := newManualCA("../../test/data/ssh/ca/ca", logger)
+	provider, err := newManualCA("../../test/data/ssh/ca/ca", logger)
 	require.NoError(t, err)
 
-	require.NotNil(t, caConfig.GatewayHostCA)
-	require.NotNil(t, caConfig.GatewayUserCA)
-	require.Nil(t, caConfig.UpstreamHostCA, "UpstreamHostCA should be nil for TOFU mode")
-	require.NotNil(t, caConfig.keyReloader, "keyReloader should watch the manual CA key file")
+	require.NotNil(t, provider.gatewayHostCA())
+	require.NotNil(t, provider.gatewayUserCA())
+	require.Nil(t, provider.upstreamHostCA(), "upstreamHostCA should be nil for TOFU mode")
+	require.NotNil(t, provider.keyReloader, "keyReloader should watch the manual CA key file")
 
-	require.Same(t, caConfig.GatewayHostCA, caConfig.GatewayUserCA, "GatewayHostCA and GatewayUserCA should be the same instance")
+	require.Same(t, provider.gatewayHostCA(), provider.gatewayUserCA(), "gatewayHostCA and gatewayUserCA should be the same instance")
 
 	expectedPubKey, err := parsePublicKey(data.SSHCAPublicKey)
 	require.NoError(t, err)
 
-	pubKey, err := caConfig.GatewayHostCA.publicKey(context.Background())
+	pubKey, err := provider.gatewayHostCA().publicKey(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, expectedPubKey.Marshal(), pubKey.Marshal())
 
@@ -119,11 +119,11 @@ func TestNewManualCA_ReloadsPrivateKey(t *testing.T) {
 	keyPEM, publicKey := generateCAKey(t)
 	keyFile := createCAKeyFile(t, keyPEM)
 
-	caConfig, err := newManualCA(keyFile, zap.NewNop())
+	provider, err := newManualCA(keyFile, zap.NewNop())
 	require.NoError(t, err)
-	require.NoError(t, caConfig.Start(t.Context()))
+	require.NoError(t, provider.Start(t.Context()))
 
-	initialPublicKey, err := caConfig.GatewayHostCA.publicKey(t.Context())
+	initialPublicKey, err := provider.gatewayHostCA().publicKey(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, publicKey.Marshal(), initialPublicKey.Marshal())
 
@@ -131,7 +131,7 @@ func TestNewManualCA_ReloadsPrivateKey(t *testing.T) {
 	replaceCAKeyFile(t, keyFile, newKeyPEM)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		reloadedPublicKey, err := caConfig.GatewayHostCA.publicKey(t.Context())
+		reloadedPublicKey, err := provider.gatewayHostCA().publicKey(t.Context())
 		require.NoError(c, err)
 
 		require.Equal(c, newPublicKey.Marshal(), reloadedPublicKey.Marshal())
@@ -141,7 +141,7 @@ func TestNewManualCA_ReloadsPrivateKey(t *testing.T) {
 	_, subjectPublicKey, err := keyConfig{}.Generate(rand.Reader)
 	require.NoError(t, err)
 
-	cert, err := caConfig.GatewayUserCA.sign(t.Context(), &certificateRequest{
+	cert, err := provider.gatewayUserCA().sign(t.Context(), &certificateRequest{
 		certType:  UserCert,
 		publicKey: subjectPublicKey,
 		ttl:       time.Minute,
@@ -168,21 +168,18 @@ func TestNewCAFromConfig_ManualConfig(t *testing.T) {
 		},
 	}
 
-	caConfig, err := newCAFromConfig(config, zap.NewNop())
+	provider, err := newCAFromConfig(config, zap.NewNop())
 	require.NoError(t, err)
 
-	require.IsType(t, &embeddedCA{}, caConfig.GatewayHostCA)
-	require.IsType(t, &embeddedCA{}, caConfig.GatewayUserCA)
-	require.Nil(t, caConfig.UpstreamHostCA)
+	require.IsType(t, &embeddedCA{}, provider.gatewayHostCA())
+	require.IsType(t, &embeddedCA{}, provider.gatewayUserCA())
+	require.Nil(t, provider.upstreamHostCA())
 }
 
 func TestUpstreamHostKeyCallback_NilUpstreamHostCA(t *testing.T) {
 	upstreamAddress := "10.0.0.1:22"
-	caConfig := &caConfig{
-		UpstreamHostCA: nil,
-	}
 
-	callback, err := caConfig.upstreamHostKeyCallback(context.Background(), upstreamAddress)
+	callback, err := upstreamHostKeyCallback(context.Background(), nil, upstreamAddress)
 	require.NoError(t, err)
 	require.NotNil(t, callback)
 
@@ -203,11 +200,7 @@ func TestUpstreamHostKeyCallback_WithUpstreamHostCA(t *testing.T) {
 		getSigner: staticSigner(caSigner),
 	}
 
-	caConfig := &caConfig{
-		UpstreamHostCA: upstreamCA,
-	}
-
-	callback, err := caConfig.upstreamHostKeyCallback(context.Background(), upstreamAddress)
+	callback, err := upstreamHostKeyCallback(context.Background(), upstreamCA, upstreamAddress)
 	require.NoError(t, err)
 	require.NotNil(t, callback)
 
@@ -239,11 +232,7 @@ func TestUpstreamHostKeyCallback_WithUpstreamHostCA_RejectsPublicKey(t *testing.
 		getSigner: staticSigner(caSigner),
 	}
 
-	caConfig := &caConfig{
-		UpstreamHostCA: upstreamCA,
-	}
-
-	callback, err := caConfig.upstreamHostKeyCallback(context.Background(), upstreamAddress)
+	callback, err := upstreamHostKeyCallback(context.Background(), upstreamCA, upstreamAddress)
 	require.NoError(t, err)
 
 	pubKey, err := parsePublicKey(data.SSHHostPublicKey)
@@ -282,6 +271,39 @@ func staticSigner(signer ssh.Signer) func() ssh.Signer {
 	return func() ssh.Signer {
 		return signer
 	}
+}
+
+// fakeCAProvider is a caProvider whose CAs and Start behavior a test sets directly,
+// so failure paths can inject stub CAs without a real backend.
+type fakeCAProvider struct {
+	host, user, upstream ca
+	start                func(ctx context.Context) error
+}
+
+func (p *fakeCAProvider) Start(ctx context.Context) error {
+	if p.start == nil {
+		return nil
+	}
+
+	return p.start(ctx)
+}
+
+func (p *fakeCAProvider) gatewayHostCA() ca  { return p.host }
+func (p *fakeCAProvider) gatewayUserCA() ca  { return p.user }
+func (p *fakeCAProvider) upstreamHostCA() ca { return p.upstream }
+
+// overrideCAProvider swaps the proxy's caProvider for a fake seeded with the current
+// CAs and returns it, so a test can replace a single CA while leaving the rest intact.
+func overrideCAProvider(sshProxy *SSHProxy) *fakeCAProvider {
+	current := sshProxy.config.caProvider
+	fake := &fakeCAProvider{
+		host:     current.gatewayHostCA(),
+		user:     current.gatewayUserCA(),
+		upstream: current.upstreamHostCA(),
+	}
+	sshProxy.config.caProvider = fake
+
+	return fake
 }
 
 // newVaultTestCA returns a vaultCA whose client talks to a test server running handler.

--- a/internal/sshhandler/ca_test.go
+++ b/internal/sshhandler/ca_test.go
@@ -4,7 +4,6 @@
 package sshhandler
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/json"
 	"net/http"
@@ -34,7 +33,7 @@ func TestEmbeddedCA_PublicKey(t *testing.T) {
 		getSigner: staticSigner(signer),
 	}
 
-	got, err := ca.publicKey(context.Background())
+	got, err := ca.publicKey(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, pubKey.Marshal(), got.Marshal())
 }
@@ -70,7 +69,7 @@ func TestEmbeddedCA_Sign(t *testing.T) {
 				},
 			}
 
-			cert, err := ca.sign(context.Background(), req)
+			cert, err := ca.sign(t.Context(), req)
 			require.NoError(t, err)
 
 			require.Equal(t, uint32(tt.certType), cert.CertType)
@@ -103,7 +102,7 @@ func TestNewManualCA_Success(t *testing.T) {
 	expectedPubKey, err := parsePublicKey(data.SSHCAPublicKey)
 	require.NoError(t, err)
 
-	pubKey, err := provider.gatewayHostCA().publicKey(context.Background())
+	pubKey, err := provider.gatewayHostCA().publicKey(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, expectedPubKey.Marshal(), pubKey.Marshal())
 
@@ -179,7 +178,7 @@ func TestNewCAFromConfig_ManualConfig(t *testing.T) {
 func TestUpstreamHostKeyCallback_NilUpstreamHostCA(t *testing.T) {
 	upstreamAddress := "10.0.0.1:22"
 
-	callback, err := upstreamHostKeyCallback(context.Background(), nil, upstreamAddress)
+	callback, err := upstreamHostKeyCallback(t.Context(), nil, upstreamAddress)
 	require.NoError(t, err)
 	require.NotNil(t, callback)
 
@@ -200,7 +199,7 @@ func TestUpstreamHostKeyCallback_WithUpstreamHostCA(t *testing.T) {
 		getSigner: staticSigner(caSigner),
 	}
 
-	callback, err := upstreamHostKeyCallback(context.Background(), upstreamCA, upstreamAddress)
+	callback, err := upstreamHostKeyCallback(t.Context(), upstreamCA, upstreamAddress)
 	require.NoError(t, err)
 	require.NotNil(t, callback)
 
@@ -213,7 +212,7 @@ func TestUpstreamHostKeyCallback_WithUpstreamHostCA(t *testing.T) {
 		ttl:       1 * time.Hour,
 	}
 
-	cert, err := upstreamCA.sign(context.Background(), req)
+	cert, err := upstreamCA.sign(t.Context(), req)
 	require.NoError(t, err)
 
 	certSigner, err := ssh.NewCertSigner(cert, hostSigner)
@@ -232,7 +231,7 @@ func TestUpstreamHostKeyCallback_WithUpstreamHostCA_RejectsPublicKey(t *testing.
 		getSigner: staticSigner(caSigner),
 	}
 
-	callback, err := upstreamHostKeyCallback(context.Background(), upstreamCA, upstreamAddress)
+	callback, err := upstreamHostKeyCallback(t.Context(), upstreamCA, upstreamAddress)
 	require.NoError(t, err)
 
 	pubKey, err := parsePublicKey(data.SSHHostPublicKey)
@@ -271,39 +270,6 @@ func staticSigner(signer ssh.Signer) func() ssh.Signer {
 	return func() ssh.Signer {
 		return signer
 	}
-}
-
-// fakeCAProvider is a caProvider whose CAs and Start behavior a test sets directly,
-// so failure paths can inject stub CAs without a real backend.
-type fakeCAProvider struct {
-	host, user, upstream ca
-	start                func(ctx context.Context) error
-}
-
-func (p *fakeCAProvider) Start(ctx context.Context) error {
-	if p.start == nil {
-		return nil
-	}
-
-	return p.start(ctx)
-}
-
-func (p *fakeCAProvider) gatewayHostCA() ca  { return p.host }
-func (p *fakeCAProvider) gatewayUserCA() ca  { return p.user }
-func (p *fakeCAProvider) upstreamHostCA() ca { return p.upstream }
-
-// overrideCAProvider swaps the proxy's caProvider for a fake seeded with the current
-// CAs and returns it, so a test can replace a single CA while leaving the rest intact.
-func overrideCAProvider(sshProxy *SSHProxy) *fakeCAProvider {
-	current := sshProxy.config.caProvider
-	fake := &fakeCAProvider{
-		host:     current.gatewayHostCA(),
-		user:     current.gatewayUserCA(),
-		upstream: current.upstreamHostCA(),
-	}
-	sshProxy.config.caProvider = fake
-
-	return fake
 }
 
 // newVaultTestCA returns a vaultCA whose client talks to a test server running handler.

--- a/internal/sshhandler/config.go
+++ b/internal/sshhandler/config.go
@@ -53,7 +53,7 @@ type upstream struct {
 }
 
 type Config struct {
-	caConfig *caConfig
+	caProvider caProvider
 
 	hostSigner    ssh.Signer
 	hostPublicKey ssh.PublicKey
@@ -71,7 +71,7 @@ type Config struct {
 
 // NewConfig creates an SSH handler config from the config package types.
 func NewConfig(auditLogConfig *config.AuditLogConfig, sshCfg *config.SSHConfig, logger *zap.Logger) (*Config, error) {
-	caConfig, err := newCAFromConfig(sshCfg.CA, logger)
+	caProvider, err := newCAFromConfig(sshCfg.CA, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ca: %w", err)
 	}
@@ -103,7 +103,7 @@ func NewConfig(auditLogConfig *config.AuditLogConfig, sshCfg *config.SSHConfig, 
 	}
 
 	return &Config{
-		caConfig:        caConfig,
+		caProvider:      caProvider,
 		hostSigner:      hostSigner,
 		hostPublicKey:   hostPublicKey,
 		hostCertTTL:     hostCertTTL,
@@ -140,7 +140,7 @@ func (c *Config) GetDownstreamConfig(ctx context.Context) (*ssh.ServerConfig, er
 		ttl:       c.hostCertTTL,
 	}
 
-	hostCertSigner, err := newAutoRenewingCertSigner(ctx, c.caConfig.GatewayHostCA, hostCertRequest, c.hostSigner, c.logger)
+	hostCertSigner, err := newAutoRenewingCertSigner(ctx, c.caProvider.gatewayHostCA(), hostCertRequest, c.hostSigner, c.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Gateway's host cert signer: %w", err)
 	}
@@ -173,7 +173,7 @@ func (c *Config) GetUpstreamConfig(ctx context.Context, upstream upstream) (*ssh
 		},
 	}
 
-	userCert, err := c.caConfig.GatewayUserCA.sign(ctx, userCertRequest)
+	userCert, err := c.caProvider.gatewayUserCA().sign(ctx, userCertRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign user certificate: %w", err)
 	}
@@ -183,7 +183,7 @@ func (c *Config) GetUpstreamConfig(ctx context.Context, upstream upstream) (*ssh
 		return nil, fmt.Errorf("failed to create Gateway's user certificate: %w", err)
 	}
 
-	hostKeyCallback, err := c.caConfig.upstreamHostKeyCallback(ctx, upstream.address)
+	hostKeyCallback, err := upstreamHostKeyCallback(ctx, c.caProvider.upstreamHostCA(), upstream.address)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sshhandler/proxy.go
+++ b/internal/sshhandler/proxy.go
@@ -47,7 +47,7 @@ func NewProxy(config Config) *SSHProxy {
 }
 
 func (p *SSHProxy) Start(ctx context.Context, listener net.Listener) error {
-	if err := p.config.caConfig.Start(ctx); err != nil {
+	if err := p.config.caProvider.Start(ctx); err != nil {
 		return err
 	}
 

--- a/internal/sshhandler/proxy_test.go
+++ b/internal/sshhandler/proxy_test.go
@@ -31,7 +31,7 @@ func TestProxy_ProxiesConnection(t *testing.T) {
 	// The one intentional overlap with the lower layers: a real client handshake through the
 	// accept loop, then a direct-tcpip round-trip to the echo upstream, proving the full wiring.
 	sshProxy := newTestProxy(t)
-	upstream := newEchoServer(t, caPublicKey(t, sshProxy.config.caConfig.GatewayUserCA))
+	upstream := newEchoServer(t, caPublicKey(t, sshProxy.config.caProvider.gatewayUserCA()))
 	listener := newTestListener(t, upstream.addr)
 
 	startDone := make(chan error, 1)
@@ -78,12 +78,12 @@ func TestProxy_StartFailure(t *testing.T) {
 	// before the accept loop, so these cases call it directly and assert the returned error.
 	tests := []struct {
 		name    string
-		setup   func(t *testing.T, caConfig *caConfig)
+		setup   func(t *testing.T, sshProxy *SSHProxy)
 		wantErr string
 	}{
 		{
 			name: "CA start failure",
-			setup: func(t *testing.T, caConfig *caConfig) {
+			setup: func(t *testing.T, sshProxy *SSHProxy) {
 				t.Helper()
 
 				authMethod, err := newAppRoleAuthMethod(&gatewayconfig.SSHCAVaultAppRoleConfig{
@@ -92,20 +92,22 @@ func TestProxy_StartFailure(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				caConfig.vault = &Vault{
-					client:     newDeadVaultCA(t).client,
-					authMethod: authMethod,
-					logger:     zap.NewNop(),
+				sshProxy.config.caProvider = &vaultCAProvider{
+					vault: &Vault{
+						client:     newDeadVaultCA(t).client,
+						authMethod: authMethod,
+						logger:     zap.NewNop(),
+					},
 				}
 			},
 			wantErr: "failed to login to Vault",
 		},
 		{
 			name: "downstream config failure",
-			setup: func(t *testing.T, caConfig *caConfig) {
+			setup: func(t *testing.T, sshProxy *SSHProxy) {
 				t.Helper()
 
-				caConfig.GatewayHostCA = &stubCA{
+				overrideCAProvider(sshProxy).host = &stubCA{
 					signer:     testSigner(t),
 					errOnCalls: map[int]error{1: errors.New("sign failed")},
 				}
@@ -117,7 +119,7 @@ func TestProxy_StartFailure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sshProxy := newTestProxy(t)
-			tt.setup(t, sshProxy.config.caConfig)
+			tt.setup(t, sshProxy)
 
 			err := sshProxy.Start(t.Context(), newTestListener(t, "unused:22"))
 			require.ErrorContains(t, err, tt.wantErr)
@@ -153,7 +155,7 @@ func TestProxy_ServeConnPanicRecovered(t *testing.T) {
 	// A panic while serving one connection is recovered: the accept loop keeps running and
 	// the next connection is served end to end.
 	sshProxy := newTestProxy(t)
-	upstream := newEchoServer(t, caPublicKey(t, sshProxy.config.caConfig.GatewayUserCA))
+	upstream := newEchoServer(t, caPublicKey(t, sshProxy.config.caProvider.gatewayUserCA()))
 	listener := newTestListener(t, upstream.addr)
 	listener.panicConns = 1
 
@@ -271,7 +273,7 @@ func TestProxy_UpstreamFailures(t *testing.T) {
 
 				// The proxy signs a fresh user certificate per connection; a stub CA that
 				// fails to sign breaks that before anything is dialed.
-				sshProxy.config.caConfig.GatewayUserCA = &stubCA{
+				overrideCAProvider(sshProxy).user = &stubCA{
 					signer:     testSigner(t),
 					errOnCalls: map[int]error{1: errors.New("sign failed")},
 				}
@@ -321,9 +323,9 @@ func TestProxy_UpstreamFailures(t *testing.T) {
 
 				// The proxy requires host certificates from this CA, but the upstream presents
 				// a plain host key, so host verification fails.
-				sshProxy.config.caConfig.UpstreamHostCA = &embeddedCA{getSigner: staticSigner(testSigner(t))}
+				overrideCAProvider(sshProxy).upstream = &embeddedCA{getSigner: staticSigner(testSigner(t))}
 
-				return newEchoServer(t, caPublicKey(t, sshProxy.config.caConfig.GatewayUserCA)).addr
+				return newEchoServer(t, caPublicKey(t, sshProxy.config.caProvider.gatewayUserCA())).addr
 			},
 			wantErr: "ssh: handshake failed",
 		},
@@ -411,7 +413,7 @@ func TestProxy_RejectsWhenShuttingDown(t *testing.T) {
 
 func TestProxy_Shutdown_ClosesActiveConnection(t *testing.T) {
 	sshProxy := newTestProxy(t)
-	upstream := newEchoServer(t, caPublicKey(t, sshProxy.config.caConfig.GatewayUserCA))
+	upstream := newEchoServer(t, caPublicKey(t, sshProxy.config.caProvider.gatewayUserCA()))
 
 	clientConn, serverConn := newDownstreamConn(t, upstream.addr)
 
@@ -663,7 +665,7 @@ func (l *testListener) Accept() (net.Conn, error) {
 func dialDownstream(t *testing.T, sshProxy *SSHProxy, clientConn net.Conn) (*ssh.Client, error) {
 	t.Helper()
 
-	hostCAPub := caPublicKey(t, sshProxy.config.caConfig.GatewayHostCA)
+	hostCAPub := caPublicKey(t, sshProxy.config.caProvider.gatewayHostCA())
 	checker := &ssh.CertChecker{
 		IsHostAuthority: func(auth ssh.PublicKey, _ string) bool {
 			return keysEqual(auth, hostCAPub)

--- a/internal/sshhandler/proxy_test.go
+++ b/internal/sshhandler/proxy_test.go
@@ -108,10 +108,12 @@ func TestProxy_StartFailure(t *testing.T) {
 			setup: func(t *testing.T, sshProxy *SSHProxy) {
 				t.Helper()
 
-				overrideCAProvider(sshProxy).host = &stubCA{
+				fake := newFakeCAProvider(sshProxy.config.caProvider)
+				fake.host = &stubCA{
 					signer:     testSigner(t),
 					errOnCalls: map[int]error{1: errors.New("sign failed")},
 				}
+				sshProxy.config.caProvider = fake
 			},
 			wantErr: "host cert signer",
 		},
@@ -274,10 +276,12 @@ func TestProxy_UpstreamFailures(t *testing.T) {
 
 				// The proxy signs a fresh user certificate per connection; a stub CA that
 				// fails to sign breaks that before anything is dialed.
-				overrideCAProvider(sshProxy).user = &stubCA{
+				fake := newFakeCAProvider(sshProxy.config.caProvider)
+				fake.user = &stubCA{
 					signer:     testSigner(t),
 					errOnCalls: map[int]error{1: errors.New("sign failed")},
 				}
+				sshProxy.config.caProvider = fake
 
 				return "unused:22"
 			},
@@ -324,7 +328,9 @@ func TestProxy_UpstreamFailures(t *testing.T) {
 
 				// The proxy requires host certificates from this CA, but the upstream presents
 				// a plain host key, so host verification fails.
-				overrideCAProvider(sshProxy).upstream = &embeddedCA{getSigner: staticSigner(testSigner(t))}
+				fake := newFakeCAProvider(sshProxy.config.caProvider)
+				fake.upstream = &embeddedCA{getSigner: staticSigner(testSigner(t))}
+				sshProxy.config.caProvider = fake
 
 				return newEchoServer(t, caPublicKey(t, sshProxy.config.caProvider.gatewayUserCA())).addr
 			},
@@ -443,37 +449,28 @@ func TestProxy_Shutdown_ClosesActiveConnection(t *testing.T) {
 // testProxyUsername is the username the test proxy presents to upstream servers.
 const testProxyUsername = "proxy-user"
 
-// fakeCAProvider is a caProvider whose CAs and Start behavior a test sets directly,
-// so failure paths can inject stub CAs without a real backend.
+// fakeCAProvider is a caProvider whose CAs a test sets directly, so failure paths can
+// inject stub CAs without a real backend.
 type fakeCAProvider struct {
 	host, user, upstream ca
-	start                func(ctx context.Context) error
 }
 
-func (p *fakeCAProvider) Start(ctx context.Context) error {
-	if p.start == nil {
-		return nil
-	}
-
-	return p.start(ctx)
+func (p *fakeCAProvider) Start(_ context.Context) error {
+	return nil
 }
 
 func (p *fakeCAProvider) gatewayHostCA() ca  { return p.host }
 func (p *fakeCAProvider) gatewayUserCA() ca  { return p.user }
 func (p *fakeCAProvider) upstreamHostCA() ca { return p.upstream }
 
-// overrideCAProvider swaps the proxy's caProvider for a fake seeded with the current
-// CAs and returns it, so a test can replace a single CA while leaving the rest intact.
-func overrideCAProvider(sshProxy *SSHProxy) *fakeCAProvider {
-	current := sshProxy.config.caProvider
-	fake := &fakeCAProvider{
+// newFakeCAProvider returns a fake seeded with the given provider's CAs, so a test can
+// replace a single CA while leaving the rest intact.
+func newFakeCAProvider(current caProvider) *fakeCAProvider {
+	return &fakeCAProvider{
 		host:     current.gatewayHostCA(),
 		user:     current.gatewayUserCA(),
 		upstream: current.upstreamHostCA(),
 	}
-	sshProxy.config.caProvider = fake
-
-	return fake
 }
 
 // newTestProxy builds an SSHProxy in manual CA mode with its downstream config ready, so tests

--- a/internal/sshhandler/proxy_test.go
+++ b/internal/sshhandler/proxy_test.go
@@ -5,6 +5,7 @@ package sshhandler
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net"
@@ -441,6 +442,39 @@ func TestProxy_Shutdown_ClosesActiveConnection(t *testing.T) {
 
 // testProxyUsername is the username the test proxy presents to upstream servers.
 const testProxyUsername = "proxy-user"
+
+// fakeCAProvider is a caProvider whose CAs and Start behavior a test sets directly,
+// so failure paths can inject stub CAs without a real backend.
+type fakeCAProvider struct {
+	host, user, upstream ca
+	start                func(ctx context.Context) error
+}
+
+func (p *fakeCAProvider) Start(ctx context.Context) error {
+	if p.start == nil {
+		return nil
+	}
+
+	return p.start(ctx)
+}
+
+func (p *fakeCAProvider) gatewayHostCA() ca  { return p.host }
+func (p *fakeCAProvider) gatewayUserCA() ca  { return p.user }
+func (p *fakeCAProvider) upstreamHostCA() ca { return p.upstream }
+
+// overrideCAProvider swaps the proxy's caProvider for a fake seeded with the current
+// CAs and returns it, so a test can replace a single CA while leaving the rest intact.
+func overrideCAProvider(sshProxy *SSHProxy) *fakeCAProvider {
+	current := sshProxy.config.caProvider
+	fake := &fakeCAProvider{
+		host:     current.gatewayHostCA(),
+		user:     current.gatewayUserCA(),
+		upstream: current.upstreamHostCA(),
+	}
+	sshProxy.config.caProvider = fake
+
+	return fake
+}
 
 // newTestProxy builds an SSHProxy in manual CA mode with its downstream config ready, so tests
 // can drive Serve/serveConn directly without going through Start. The proxy logs to a nop


### PR DESCRIPTION
## Related Tickets & Documents

- Closes: https://github.com/Twingate/gateway/issues/375
- Follow-up for review comment: https://github.com/Twingate/gateway/pull/376#discussion_r3609571905

## Changes

- Replace the `caConfig` struct, which mixed the exposed CAs with backend-specific fields (`vault`, `keyReloader`), with a `caProvider` interface implemented by `manualCAProvider` and `vaultCAProvider`.
- Each provider owns its own `Start`, removing the nil-field branching in the old shared `Start`. `newCAFromConfig` returns the interface.
- Turn `upstreamHostKeyCallback` into a package function taking the upstream CA (nil selects TOFU), since it was the only reader of the old `UpstreamHostCA` field.
