### PR TITLE
fix(helm): make the certificate authority name unique per cluster and namespace

### DIFF
--- a/deploy/gateway/templates/_helpers.tpl
+++ b/deploy/gateway/templates/_helpers.tpl
@@ -161,6 +161,38 @@ Create the name of the SSH Vault AppRole secret ID secret to use
 
 
 {{/*
+Return the UID of the kube-system namespace, or "" when it cannot be read
+*/}}
+{{- define "gateway.clusterUID" -}}
+{{- $namespace := lookup "v1" "Namespace" "" "kube-system" }}
+{{- if and $namespace $namespace.metadata }}
+{{- $namespace.metadata.uid }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name the TwingateCertificateAuthority is registered under in Twingate
+
+Twingate rejects duplicate Certificate Authority names and the CR's `spec.name` is
+immutable, so separate installs must not derive the same name. kube-system's UID stands
+in for the cluster because Helm renders before `--create-namespace` creates the release
+namespace, so the release namespace's own UID is not always readable.
+*/}}
+{{- define "gateway.certificateAuthorityName" -}}
+{{- $certificateAuthority := .Values.twingateOperator.gateway.certificateAuthority | default dict }}
+{{- if $certificateAuthority.name }}
+{{- $certificateAuthority.name }}
+{{- else }}
+{{- $clusterUID := include "gateway.clusterUID" . }}
+{{- if not $clusterUID }}
+{{- fail "Set twingateOperator.gateway.certificateAuthority.name to a name unique within your Twingate network. The chart derives one from the kube-system namespace UID, which is unavailable when rendering without cluster access such as helm template, --dry-run=client or Argo CD." }}
+{{- end }}
+{{- printf "%s-ca-%s" (include "gateway.fullname" .) (sha256sum (printf "%s/%s" $clusterUID .Release.Namespace) | trunc 16) }}
+{{- end }}
+{{- end }}
+
+
+{{/*
 Get the alias of the in-cluster Kubernetes resource
 */}}
 {{- define "gateway.resourceAlias" -}}

--- a/deploy/gateway/templates/twingate-cr.yaml
+++ b/deploy/gateway/templates/twingate-cr.yaml
@@ -13,7 +13,7 @@ metadata:
   labels:
     {{- include "gateway.labels" . | nindent 4 }}
 spec:
-  name: {{ include "gateway.fullname" . }}-ca
+  name: {{ include "gateway.certificateAuthorityName" . | quote }}
   type: X509
   secretRef:
     name: {{ include "gateway.tlsSecretName" . }}

--- a/deploy/gateway/tests/__snapshot__/twingate-cr_test.yaml.snap
+++ b/deploy/gateway/tests/__snapshot__/twingate-cr_test.yaml.snap
@@ -11,7 +11,7 @@ renders the CA and Gateway when gateway is enabled:
         helm.sh/chart: gateway-0.1.0
       name: RELEASE-NAME-gateway-ca
     spec:
-      name: RELEASE-NAME-gateway-ca
+      name: RELEASE-NAME-gateway-ca-ae3f578ff6303ac5
       secretRef:
         name: RELEASE-NAME-gateway-tls
         namespace: NAMESPACE
@@ -48,7 +48,7 @@ renders the in-cluster Kubernetes resource when enabled:
         helm.sh/chart: gateway-0.1.0
       name: RELEASE-NAME-gateway-ca
     spec:
-      name: RELEASE-NAME-gateway-ca
+      name: RELEASE-NAME-gateway-ca-ae3f578ff6303ac5
       secretRef:
         name: RELEASE-NAME-gateway-tls
         namespace: NAMESPACE

--- a/deploy/gateway/tests/twingate-cr_test.yaml
+++ b/deploy/gateway/tests/twingate-cr_test.yaml
@@ -19,6 +19,19 @@ tests:
       twingateOperator:
         gateway:
           enabled: true
+    kubernetesProvider: &clusterNamespace
+      scheme:
+        "v1/Namespace":
+          gvr:
+            version: "v1"
+            resource: "namespaces"
+          namespaced: false
+      objects:
+        - kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: kube-system
+            uid: 11111111-2222-3333-4444-555555555555
     asserts:
       - matchSnapshot: {}
   - it: renders the in-cluster Kubernetes resource when enabled
@@ -31,6 +44,7 @@ tests:
           name: "My cluster"
           alias: cluster.int
           securityPolicyId: "U2VjdXJpdHlQb2xpY3k6MTIz"
+    kubernetesProvider: *clusterNamespace
     asserts:
       - matchSnapshot: {}
   - it: defaults the resource name when none is provided
@@ -40,6 +54,7 @@ tests:
           enabled: true
         kubernetesResource:
           enabled: true
+    kubernetesProvider: *clusterNamespace
     documentSelector:
       path: kind
       value: TwingateResource
@@ -47,3 +62,39 @@ tests:
       - equal:
           path: spec.name
           value: "RELEASE-NAME-gateway Kubernetes cluster"
+  - it: suffixes the CA name with a hash of the cluster and namespace
+    set:
+      twingateOperator:
+        gateway:
+          enabled: true
+    kubernetesProvider: *clusterNamespace
+    documentSelector:
+      path: kind
+      value: TwingateCertificateAuthority
+    asserts:
+      - equal:
+          path: spec.name
+          # first 16 chars of sha256("11111111-2222-3333-4444-555555555555/NAMESPACE")
+          value: RELEASE-NAME-gateway-ca-ae3f578ff6303ac5
+  - it: uses the CA name when provided, without reading the cluster
+    set:
+      twingateOperator:
+        gateway:
+          enabled: true
+          certificateAuthority:
+            name: "acme prod cluster CA"
+    documentSelector:
+      path: kind
+      value: TwingateCertificateAuthority
+    asserts:
+      - equal:
+          path: spec.name
+          value: "acme prod cluster CA"
+  - it: fails when the cluster cannot be read and no CA name is set
+    set:
+      twingateOperator:
+        gateway:
+          enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: Set twingateOperator.gateway.certificateAuthority.name to a name unique within your Twingate network

--- a/deploy/gateway/values.schema.json
+++ b/deploy/gateway/values.schema.json
@@ -32,6 +32,17 @@
               "type": "boolean",
               "description": "Render the TwingateGateway and its TwingateCertificateAuthority CRs.",
               "default": false
+            },
+            "certificateAuthority": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name the CA is registered under in Twingate. Must be unique across the Twingate network and is immutable after install. Defaults to \"<fullname>-ca-<hash of the cluster and namespace>\"; must be set explicitly when rendering without cluster access (helm template, --dry-run=client, Argo CD).",
+                  "default": ""
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/deploy/gateway/values.yaml
+++ b/deploy/gateway/values.yaml
@@ -14,6 +14,12 @@ twingateOperator:
     # Render the TwingateGateway + its TwingateCertificateAuthority. Off for
     # standalone installs with no operator/CRDs.
     enabled: false
+    certificateAuthority:
+      # Name the CA is registered under in Twingate, unique across the network and
+      # immutable after install. Defaults to "<fullname>-ca-<hash of the cluster and
+      # namespace>"; set it explicitly when rendering without cluster access (helm
+      # template, --dry-run=client, Argo CD), where the hash cannot be computed.
+      name: ""
   kubernetesResource:
     # Render a Kubernetes TwingateResource for the in-cluster API server,
     # bound to this gateway via gatewayRef. Requires gateway.enabled=true.


### PR DESCRIPTION
## Related Tickets & Documents

- #330

## Changes

Handle the Twingate constraint that certificate authority names must be unique.

- `twingateOperator.gateway.certificateAuthority.name` sets the registered name explicitly
- otherwise it is generated as `<fullname>-ca-<hash>`, hashing the kube-system namespace UID and the release namespace
  - rendering fails when the kube-system lookup returns nothing (`helm template`, `--dry-run=client`, Argo CD); the name has to be set explicitly there

## Notes

- v0.22.0 was never made public and will be re-released with this change, so the un-suffixed `spec.name` it rendered needs no migration despite being immutable.
