### PR TITLE
feat: redirect plaintext HTTP to HTTPS for downstream-TLS web apps

### DIFF
--- a/internal/connect/conn.go
+++ b/internal/connect/conn.go
@@ -261,7 +261,14 @@ func (p *ProxyConn) UpgradeToTLS() error {
 		}
 
 		if firstByte[0] != tlsRecordTypeHandshake {
-			return p.redirectToHTTPS(bufConn.reader)
+			req, err := http.ReadRequest(bufConn.reader)
+			if err != nil {
+				p.Logger.Error("failed to parse plaintext HTTP request", zap.Error(err))
+
+				return err
+			}
+
+			return p.redirectToHTTPS(req)
 		}
 
 		conn = bufConn
@@ -282,14 +289,7 @@ func (p *ProxyConn) UpgradeToTLS() error {
 
 // redirectToHTTPS answers the plaintext HTTP request with a permanent redirect
 // to the same authority over https.
-func (p *ProxyConn) redirectToHTTPS(b *bufio.Reader) error {
-	req, err := http.ReadRequest(b)
-	if err != nil {
-		p.Logger.Error("failed to parse plaintext HTTP request", zap.Error(err))
-
-		return err
-	}
-
+func (p *ProxyConn) redirectToHTTPS(req *http.Request) error {
 	host := req.Host
 	if host == "" {
 		host = p.DownstreamAddress

--- a/internal/connect/conn.go
+++ b/internal/connect/conn.go
@@ -28,6 +28,12 @@ const (
 
 const defaultTimeout = 10 * time.Second
 
+// tlsRecordTypeHandshake is the TLS record-layer ContentType of a handshake
+// record (RFC 8446 §5.1), which carries the ClientHello.
+const tlsRecordTypeHandshake = 0x16
+
+var errRedirectedToHTTPS = errors.New("http request redirected to https")
+
 func httpResponseString(httpCode int) string {
 	return fmt.Sprintf("HTTP/1.1 %d %s\r\n\r\n", httpCode, http.StatusText(httpCode))
 }
@@ -54,16 +60,33 @@ type ProxyConn struct {
 	ConnectValidator Validator
 	Logger           *zap.Logger
 
-	ID      string
-	Address string
-	Claims  *token.GATClaims
-	Token   string
+	ID                string
+	Address           string
+	DownstreamAddress string
+	Claims            *token.GATClaims
+	Token             string
 
 	Timer *time.Timer
 	Mu    sync.Mutex
 
 	tracker *ProxyConnMetricsTracker
 	once    sync.Once
+}
+
+// bufferedConn reads through a bufio.Reader so bytes peeked from the
+// connection remain available to subsequent reads.
+type bufferedConn struct {
+	net.Conn
+
+	reader *bufio.Reader
+}
+
+func newBufferedConn(conn net.Conn) *bufferedConn {
+	return &bufferedConn{Conn: conn, reader: bufio.NewReader(conn)}
+}
+
+func (c *bufferedConn) Read(b []byte) (int, error) {
+	return c.reader.Read(b)
 }
 
 func NewProxyConn(conn net.Conn, tlsConfig *tls.Config, validator Validator, logger *zap.Logger, metrics *ProxyConnMetrics) *ProxyConn {
@@ -225,7 +248,26 @@ func (p *ProxyConn) Authenticate() error {
 }
 
 func (p *ProxyConn) UpgradeToTLS() error {
-	tlsConn := tls.Server(p.Conn, p.TLSConfig)
+	conn := p.Conn
+
+	if p.Claims.EnforcesDownstreamTLS() {
+		bufConn := newBufferedConn(p.Conn)
+
+		firstByte, err := bufConn.reader.Peek(1)
+		if err != nil {
+			p.Logger.Error("failed to peek first downstream client byte", zap.Error(err))
+
+			return err
+		}
+
+		if firstByte[0] != tlsRecordTypeHandshake {
+			return p.redirectToHTTPS(bufConn.reader)
+		}
+
+		conn = bufConn
+	}
+
+	tlsConn := tls.Server(conn, p.TLSConfig)
 	if err := tlsConn.Handshake(); err != nil {
 		p.Logger.Error("failed to upgrade TLS", zap.Error(err))
 
@@ -238,9 +280,37 @@ func (p *ProxyConn) UpgradeToTLS() error {
 	return nil
 }
 
+// redirectToHTTPS answers the plaintext HTTP request with a permanent redirect
+// to the same authority over https.
+func (p *ProxyConn) redirectToHTTPS(b *bufio.Reader) error {
+	req, err := http.ReadRequest(b)
+	if err != nil {
+		p.Logger.Error("failed to parse plaintext HTTP request", zap.Error(err))
+
+		return err
+	}
+
+	host := req.Host
+	if host == "" {
+		host = p.DownstreamAddress
+	}
+
+	responseStr := fmt.Sprintf("HTTP/1.1 %d %s\r\nLocation: https://%s%s\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+		http.StatusPermanentRedirect, http.StatusText(http.StatusPermanentRedirect), host, req.URL.RequestURI())
+
+	if _, err := p.Write([]byte(responseStr)); err != nil {
+		p.Logger.Error("failed to write redirect response", zap.Error(err))
+
+		return err
+	}
+
+	return errRedirectedToHTTPS
+}
+
 func (p *ProxyConn) setConnectInfo(connectInfo Info) {
 	p.ID = connectInfo.ConnID
 	p.Address = connectInfo.Address
+	p.DownstreamAddress = connectInfo.DownstreamAddress
 	p.Claims = connectInfo.Claims
 	p.Token = connectInfo.Token
 	p.Timer = time.AfterFunc(time.Until(connectInfo.Claims.ExpiresAt.Time), func() {

--- a/internal/connect/conn_test.go
+++ b/internal/connect/conn_test.go
@@ -163,9 +163,10 @@ func startMockListener(t *testing.T) (net.Listener, string) {
 	return listener, addr
 }
 
-func createProxyConn(t *testing.T, conn net.Conn, resourceType token.ResourceType) *ProxyConn {
+func createProxyConn(t *testing.T, conn net.Conn, resourceType token.ResourceType, connectValidator *mockValidator) *ProxyConn {
 	t.Helper()
 
+	// Server TLS config
 	serverCert, err := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
 	require.NoError(t, err)
 
@@ -175,6 +176,7 @@ func createProxyConn(t *testing.T, conn net.Conn, resourceType token.ResourceTyp
 			Certificates: []tls.Certificate{serverCert},
 			MinVersion:   tls.VersionTLS13,
 		},
+		ConnectValidator:  connectValidator,
 		Logger:            zap.NewNop(),
 		DownstreamAddress: "my-app.int:443",
 		Claims: &token.GATClaims{
@@ -235,9 +237,8 @@ func TestProxyConn_Authenticate_BadRequest(t *testing.T) {
 	conn, _ := listener.Accept()
 
 	// Create the ProxyConn from the accepted connection
-	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp)
+	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp, &mockValidator{shouldFail: false})
 
-	proxyConn.ConnectValidator = &mockValidator{shouldFail: false}
 	defer proxyConn.Close()
 
 	// Perform connection auth logic
@@ -300,9 +301,8 @@ func TestProxyConn_Authenticate_HealthCheck(t *testing.T) {
 	conn, _ := listener.Accept()
 
 	// Create the ProxyConn from the accepted connection
-	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp)
+	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp, &mockValidator{shouldFail: false})
 
-	proxyConn.ConnectValidator = &mockValidator{shouldFail: false}
 	defer proxyConn.Close()
 
 	// Perform connection auth logic
@@ -358,9 +358,8 @@ func TestProxyConn_Authenticate_ValidConnectRequest(t *testing.T) {
 	conn, _ := listener.Accept()
 
 	// Create the ProxyConn from the accepted connection
-	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp)
+	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp, &mockValidator{shouldFail: false})
 
-	proxyConn.ConnectValidator = &mockValidator{shouldFail: false}
 	defer proxyConn.Close()
 
 	// Perform connection auth logic
@@ -417,10 +416,9 @@ func TestProxyConn_Authenticate_FailedValidation(t *testing.T) {
 
 	// Create the ProxyConn from the accepted connection, without claims so the
 	// failed validation below must leave them unset
-	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp)
-	proxyConn.ConnectValidator = &mockValidator{shouldFail: true}
-
+	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp, &mockValidator{shouldFail: true})
 	proxyConn.Claims = nil
+
 	defer proxyConn.Close()
 
 	// Perform connection auth logic
@@ -520,7 +518,7 @@ func TestProxyConn_UpgradeToTLS_PlaintextHTTPRedirect(t *testing.T) {
 			conn, err := listener.Accept()
 			require.NoError(t, err)
 
-			proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp)
+			proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp, nil)
 			defer proxyConn.Close()
 
 			assert.ErrorIs(t, proxyConn.UpgradeToTLS(), errRedirectedToHTTPS)
@@ -586,7 +584,7 @@ func TestProxyConn_UpgradeToTLS_TLSHandshake(t *testing.T) {
 			conn, err := listener.Accept()
 			require.NoError(t, err)
 
-			proxyConn := createProxyConn(t, conn, tt.resourceType)
+			proxyConn := createProxyConn(t, conn, tt.resourceType, nil)
 			defer proxyConn.Close()
 
 			require.NoError(t, proxyConn.UpgradeToTLS())
@@ -623,7 +621,7 @@ func TestProxyConn_UpgradeToTLS_MalformedPlaintextRequest(t *testing.T) {
 	conn, err := listener.Accept()
 	require.NoError(t, err)
 
-	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp)
+	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp, nil)
 	defer proxyConn.Close()
 
 	err = proxyConn.UpgradeToTLS()
@@ -653,7 +651,7 @@ func TestProxyConn_UpgradeToTLS_ClosedBeforeFirstByte(t *testing.T) {
 	conn, err := listener.Accept()
 	require.NoError(t, err)
 
-	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp)
+	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp, nil)
 	defer proxyConn.Close()
 
 	assert.ErrorIs(t, proxyConn.UpgradeToTLS(), io.EOF)

--- a/internal/connect/conn_test.go
+++ b/internal/connect/conn_test.go
@@ -163,6 +163,33 @@ func startMockListener(t *testing.T) (net.Listener, string) {
 	return listener, addr
 }
 
+func createProxyConn(t *testing.T, conn net.Conn, resourceType token.ResourceType) *ProxyConn {
+	t.Helper()
+
+	serverCert, err := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
+	require.NoError(t, err)
+
+	return &ProxyConn{
+		Conn: conn,
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{serverCert},
+			MinVersion:   tls.VersionTLS13,
+		},
+		Logger:            zap.NewNop(),
+		DownstreamAddress: "my-app.int:443",
+		Claims: &token.GATClaims{
+			Resource: token.Resource{
+				Type:    resourceType,
+				Address: "10.0.0.1",
+				GatewayMetadata: token.GatewayMetadata{
+					Downstream: token.Downstream{TLS: true},
+				},
+			},
+		},
+		tracker: NewProxyConnMetricsTracker(ConnCategoryUnknown, CreateProxyConnMetrics(prometheus.NewRegistry())),
+	}
+}
+
 func TestProxyConn_Authenticate_BadRequest(t *testing.T) {
 	listener, addr := startMockListener(t)
 
@@ -207,30 +234,10 @@ func TestProxyConn_Authenticate_BadRequest(t *testing.T) {
 	// Accept the incoming connection from the downstream client
 	conn, _ := listener.Accept()
 
-	// Server TLS config
-	serverCert, err := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
-	require.NoError(t, err)
-
-	serverTLSConfig := &tls.Config{
-		Certificates: []tls.Certificate{serverCert},
-		MinVersion:   tls.VersionTLS13,
-	}
-
-	// Mock CONNECT validator
-	mockValidator := &mockValidator{
-		shouldFail: false,
-	}
-
 	// Create the ProxyConn from the accepted connection
-	metrics := CreateProxyConnMetrics(prometheus.NewRegistry())
+	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp)
 
-	proxyConn := &ProxyConn{
-		Conn:             conn,
-		TLSConfig:        serverTLSConfig,
-		ConnectValidator: mockValidator,
-		Logger:           zap.NewNop(),
-		tracker:          NewProxyConnMetricsTracker(ConnCategoryUnknown, metrics),
-	}
+	proxyConn.ConnectValidator = &mockValidator{shouldFail: false}
 	defer proxyConn.Close()
 
 	// Perform connection auth logic
@@ -292,30 +299,10 @@ func TestProxyConn_Authenticate_HealthCheck(t *testing.T) {
 	// Accept the incoming connection from the downstream client
 	conn, _ := listener.Accept()
 
-	// Server TLS config
-	serverCert, err := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
-	require.NoError(t, err)
-
-	serverTLSConfig := &tls.Config{
-		Certificates: []tls.Certificate{serverCert},
-		MinVersion:   tls.VersionTLS13,
-	}
-
-	// Mock CONNECT validator
-	mockValidator := &mockValidator{
-		shouldFail: false,
-	}
-
 	// Create the ProxyConn from the accepted connection
-	metrics := CreateProxyConnMetrics(prometheus.NewRegistry())
+	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp)
 
-	proxyConn := &ProxyConn{
-		Conn:             conn,
-		TLSConfig:        serverTLSConfig,
-		ConnectValidator: mockValidator,
-		Logger:           zap.NewNop(),
-		tracker:          NewProxyConnMetricsTracker(ConnCategoryUnknown, metrics),
-	}
+	proxyConn.ConnectValidator = &mockValidator{shouldFail: false}
 	defer proxyConn.Close()
 
 	// Perform connection auth logic
@@ -370,30 +357,10 @@ func TestProxyConn_Authenticate_ValidConnectRequest(t *testing.T) {
 	// Accept the incoming connection from the downstream client
 	conn, _ := listener.Accept()
 
-	// Server TLS config
-	serverCert, err := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
-	require.NoError(t, err)
-
-	serverTLSConfig := &tls.Config{
-		Certificates: []tls.Certificate{serverCert},
-		MinVersion:   tls.VersionTLS13,
-	}
-
-	// Mock CONNECT validator
-	mockValidator := &mockValidator{
-		shouldFail: false,
-	}
-
 	// Create the ProxyConn from the accepted connection
-	metrics := CreateProxyConnMetrics(prometheus.NewRegistry())
+	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp)
 
-	proxyConn := &ProxyConn{
-		Conn:             conn,
-		TLSConfig:        serverTLSConfig,
-		ConnectValidator: mockValidator,
-		Logger:           zap.NewNop(),
-		tracker:          NewProxyConnMetricsTracker(ConnCategoryUnknown, metrics),
-	}
+	proxyConn.ConnectValidator = &mockValidator{shouldFail: false}
 	defer proxyConn.Close()
 
 	// Perform connection auth logic
@@ -448,30 +415,12 @@ func TestProxyConn_Authenticate_FailedValidation(t *testing.T) {
 	// Accept the incoming connection from the downstream client
 	conn, _ := listener.Accept()
 
-	// Server TLS config
-	serverCert, err := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
-	require.NoError(t, err)
+	// Create the ProxyConn from the accepted connection, without claims so the
+	// failed validation below must leave them unset
+	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp)
+	proxyConn.ConnectValidator = &mockValidator{shouldFail: true}
 
-	serverTLSConfig := &tls.Config{
-		Certificates: []tls.Certificate{serverCert},
-		MinVersion:   tls.VersionTLS13,
-	}
-
-	// Mock CONNECT validator
-	mockValidator := &mockValidator{
-		shouldFail: true,
-	}
-
-	// Create the ProxyConn from the accepted connection
-	metrics := CreateProxyConnMetrics(prometheus.NewRegistry())
-
-	proxyConn := &ProxyConn{
-		Conn:             conn,
-		TLSConfig:        serverTLSConfig,
-		ConnectValidator: mockValidator,
-		Logger:           zap.NewNop(),
-		tracker:          NewProxyConnMetricsTracker(ConnCategoryUnknown, metrics),
-	}
+	proxyConn.Claims = nil
 	defer proxyConn.Close()
 
 	// Perform connection auth logic
@@ -508,33 +457,6 @@ func TestIsHealthCheckRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, isHealthCheckRequest(tc.request))
 		})
-	}
-}
-
-func createProxyConn(t *testing.T, conn net.Conn, resourceType token.ResourceType) *ProxyConn {
-	t.Helper()
-
-	serverCert, err := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
-	require.NoError(t, err)
-
-	return &ProxyConn{
-		Conn: conn,
-		TLSConfig: &tls.Config{
-			Certificates: []tls.Certificate{serverCert},
-			MinVersion:   tls.VersionTLS13,
-		},
-		Logger:            zap.NewNop(),
-		DownstreamAddress: "my-app.int:443",
-		Claims: &token.GATClaims{
-			Resource: token.Resource{
-				Type:    resourceType,
-				Address: "10.0.0.1",
-				GatewayMetadata: token.GatewayMetadata{
-					Downstream: token.Downstream{TLS: true},
-				},
-			},
-		},
-		tracker: NewProxyConnMetricsTracker(ConnCategoryUnknown, CreateProxyConnMetrics(prometheus.NewRegistry())),
 	}
 }
 

--- a/internal/connect/conn_test.go
+++ b/internal/connect/conn_test.go
@@ -68,12 +68,14 @@ func TestProxyConn_setConnectInfo(t *testing.T) {
 			defer proxyConn.Mu.Unlock()
 
 			proxyConn.setConnectInfo(Info{
-				Claims: claims,
-				ConnID: connID,
+				DownstreamAddress: "my-app.int:443",
+				Claims:            claims,
+				ConnID:            connID,
 			})
 		}()
 
 		assert.Equal(t, connID, proxyConn.ID)
+		assert.Equal(t, "my-app.int:443", proxyConn.DownstreamAddress)
 		assert.Equal(t, claims, proxyConn.Claims)
 
 		// Wait for expiry timer to happen, the connection should be closed
@@ -507,4 +509,232 @@ func TestIsHealthCheckRequest(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, isHealthCheckRequest(tc.request))
 		})
 	}
+}
+
+func createProxyConn(t *testing.T, conn net.Conn, resourceType token.ResourceType) *ProxyConn {
+	t.Helper()
+
+	serverCert, err := tls.X509KeyPair(data.ProxyCert, data.ProxyKey)
+	require.NoError(t, err)
+
+	return &ProxyConn{
+		Conn: conn,
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{serverCert},
+			MinVersion:   tls.VersionTLS13,
+		},
+		Logger:            zap.NewNop(),
+		DownstreamAddress: "my-app.int:443",
+		Claims: &token.GATClaims{
+			Resource: token.Resource{
+				Type:    resourceType,
+				Address: "10.0.0.1",
+				GatewayMetadata: token.GatewayMetadata{
+					Downstream: token.Downstream{TLS: true},
+				},
+			},
+		},
+		tracker: NewProxyConnMetricsTracker(ConnCategoryUnknown, CreateProxyConnMetrics(prometheus.NewRegistry())),
+	}
+}
+
+func TestProxyConn_UpgradeToTLS_PlaintextHTTPRedirect(t *testing.T) {
+	tests := []struct {
+		name         string
+		request      string
+		wantLocation string
+	}{
+		{
+			name:         "redirects to the host header",
+			request:      "GET / HTTP/1.1\r\nHost: my-app.int\r\n\r\n",
+			wantLocation: "https://my-app.int/",
+		},
+		{
+			name:         "preserves the host header port, path and query",
+			request:      "GET /path?q=1 HTTP/1.1\r\nHost: my-app.int:8443\r\n\r\n",
+			wantLocation: "https://my-app.int:8443/path?q=1",
+		},
+		{
+			name:         "falls back to the CONNECT requested host when host header is missing",
+			request:      "GET /login HTTP/1.0\r\n\r\n",
+			wantLocation: "https://my-app.int:443/login",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listener, addr := startMockListener(t)
+			defer listener.Close()
+
+			done := make(chan struct{})
+
+			// Downstream client logic on separate goroutine
+			go func() {
+				conn, err := net.Dial("tcp", addr)
+				assert.NoError(t, err)
+
+				defer conn.Close()
+
+				_, err = conn.Write([]byte(tt.request))
+				assert.NoError(t, err)
+
+				resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+				if err != nil {
+					assert.NoError(t, err)
+
+					done <- struct{}{}
+
+					return
+				}
+
+				defer resp.Body.Close()
+
+				assert.Equal(t, http.StatusPermanentRedirect, resp.StatusCode)
+				assert.Equal(t, tt.wantLocation, resp.Header.Get("Location"))
+
+				done <- struct{}{}
+			}()
+
+			conn, err := listener.Accept()
+			require.NoError(t, err)
+
+			proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp)
+			defer proxyConn.Close()
+
+			assert.ErrorIs(t, proxyConn.UpgradeToTLS(), errRedirectedToHTTPS)
+
+			<-done
+		})
+	}
+}
+
+func TestProxyConn_UpgradeToTLS_TLSHandshake(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType token.ResourceType
+	}{
+		{
+			name:         "web app with downstream TLS peeks and handshakes",
+			resourceType: token.ResourceTypeWebApp,
+		},
+		{
+			name:         "kubernetes handshakes without peeking",
+			resourceType: token.ResourceTypeKubernetes,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listener, addr := startMockListener(t)
+			defer listener.Close()
+
+			// Client TLS config
+			caCertPool := x509.NewCertPool()
+			caCertPool.AppendCertsFromPEM(data.ProxyCert)
+			clientTLSConfig := &tls.Config{
+				ServerName: "127.0.0.1",
+				RootCAs:    caCertPool,
+				MinVersion: tls.VersionTLS13,
+			}
+
+			done := make(chan struct{})
+
+			// Downstream client logic on separate goroutine
+			go func() {
+				conn, err := net.Dial("tcp", addr)
+				assert.NoError(t, err)
+
+				defer conn.Close()
+
+				tlsConn := tls.Client(conn, clientTLSConfig)
+				if err := tlsConn.Handshake(); err != nil {
+					assert.NoError(t, err)
+
+					done <- struct{}{}
+
+					return
+				}
+
+				_, err = tlsConn.Write([]byte("ping"))
+				assert.NoError(t, err)
+
+				done <- struct{}{}
+			}()
+
+			conn, err := listener.Accept()
+			require.NoError(t, err)
+
+			proxyConn := createProxyConn(t, conn, tt.resourceType)
+			defer proxyConn.Close()
+
+			require.NoError(t, proxyConn.UpgradeToTLS())
+
+			buf := make([]byte, 4)
+			_, err = io.ReadFull(proxyConn, buf)
+			require.NoError(t, err)
+			assert.Equal(t, "ping", string(buf))
+
+			<-done
+		})
+	}
+}
+
+func TestProxyConn_UpgradeToTLS_MalformedPlaintextRequest(t *testing.T) {
+	listener, addr := startMockListener(t)
+	defer listener.Close()
+
+	done := make(chan struct{})
+
+	// Downstream client logic on separate goroutine
+	go func() {
+		conn, err := net.Dial("tcp", addr)
+		assert.NoError(t, err)
+
+		defer conn.Close()
+
+		_, err = conn.Write([]byte("\x00garbage\r\n\r\n"))
+		assert.NoError(t, err)
+
+		done <- struct{}{}
+	}()
+
+	conn, err := listener.Accept()
+	require.NoError(t, err)
+
+	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp)
+	defer proxyConn.Close()
+
+	err = proxyConn.UpgradeToTLS()
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, errRedirectedToHTTPS)
+
+	<-done
+}
+
+func TestProxyConn_UpgradeToTLS_ClosedBeforeFirstByte(t *testing.T) {
+	listener, addr := startMockListener(t)
+	defer listener.Close()
+
+	done := make(chan struct{})
+
+	// Downstream client logic on separate goroutine
+	go func() {
+		conn, err := net.Dial("tcp", addr)
+		assert.NoError(t, err)
+
+		// Close without sending anything so the peek sees EOF
+		assert.NoError(t, conn.Close())
+
+		done <- struct{}{}
+	}()
+
+	conn, err := listener.Accept()
+	require.NoError(t, err)
+
+	proxyConn := createProxyConn(t, conn, token.ResourceTypeWebApp)
+	defer proxyConn.Close()
+
+	assert.ErrorIs(t, proxyConn.UpgradeToTLS(), io.EOF)
+
+	<-done
 }

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -28,10 +28,11 @@ const AuthSignatureHeaderKey string = "X-Token-Signature"
 const ConnIDHeaderKey string = "X-Connection-Id"
 
 type Info struct {
-	Address string
-	Claims  *token.GATClaims
-	ConnID  string
-	Token   string
+	Address           string
+	DownstreamAddress string
+	Claims            *token.GATClaims
+	ConnID            string
+	Token             string
 }
 
 type HTTPError struct {
@@ -140,10 +141,11 @@ func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (connectI
 	}
 
 	return Info{
-		Address: address,
-		Claims:  gatClaims,
-		ConnID:  connID,
-		Token:   bearerToken,
+		Address:           address,
+		DownstreamAddress: req.RequestURI,
+		Claims:            gatClaims,
+		ConnID:            connID,
+		Token:             bearerToken,
 	}, nil
 }
 

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -116,6 +116,7 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, "Example.com:443", connectInfo.Address)
+		assert.Equal(t, "Example.com:443", connectInfo.DownstreamAddress)
 		assert.Equal(t, *connectInfo.Claims, gatClaims)
 		assert.Equal(t, "conn-id", connectInfo.ConnID)
 		assert.Equal(t, signedToken, connectInfo.Token)

--- a/internal/connect/listener.go
+++ b/internal/connect/listener.go
@@ -185,9 +185,12 @@ func (l *Listener) Serve(ctx context.Context, listener net.Listener) error {
 			}
 
 			if proxyConn.GATClaims().ShouldUpgradeTLS() {
-				if err := proxyConn.UpgradeToTLS(); err != nil {
+				err := proxyConn.UpgradeToTLS()
+				if !errors.Is(err, errRedirectedToHTTPS) {
 					l.logger.Error("Failed to upgrade to TLS", zap.Error(err))
+				}
 
+				if err != nil {
 					_ = proxyConn.Close()
 
 					return

--- a/internal/connect/listener.go
+++ b/internal/connect/listener.go
@@ -184,17 +184,10 @@ func (l *Listener) Serve(ctx context.Context, listener net.Listener) error {
 				return
 			}
 
-			if proxyConn.GATClaims().ShouldUpgradeTLS() {
-				err := proxyConn.UpgradeToTLS()
-				if !errors.Is(err, errRedirectedToHTTPS) {
-					l.logger.Error("Failed to upgrade to TLS", zap.Error(err))
-				}
+			if err := l.upgradeDownstreamTLS(proxyConn); err != nil {
+				_ = proxyConn.Close()
 
-				if err != nil {
-					_ = proxyConn.Close()
-
-					return
-				}
+				return
 			}
 
 			select {
@@ -207,6 +200,20 @@ func (l *Listener) Serve(ctx context.Context, listener net.Listener) error {
 			}
 		})
 	}
+}
+
+// upgradeDownstreamTLS upgrades the connection when the resource enforces TLS.
+func (l *Listener) upgradeDownstreamTLS(proxyConn Conn) error {
+	if !proxyConn.GATClaims().ShouldUpgradeTLS() {
+		return nil
+	}
+
+	err := proxyConn.UpgradeToTLS()
+	if err != nil && !errors.Is(err, errRedirectedToHTTPS) {
+		l.logger.Error("Failed to upgrade to TLS", zap.Error(err))
+	}
+
+	return err
 }
 
 func (l *Listener) closeChannels() {

--- a/internal/connect/listener_test.go
+++ b/internal/connect/listener_test.go
@@ -29,7 +29,8 @@ type mockProxyConn struct {
 
 	isClosed atomic.Bool
 
-	isHealthz bool
+	isHealthz     bool
+	upgradeTLSErr error
 }
 
 func (m *mockProxyConn) Close() error {
@@ -74,7 +75,7 @@ func (m *mockProxyConn) Authenticate() error {
 }
 
 func (m *mockProxyConn) UpgradeToTLS() error {
-	return nil
+	return m.upgradeTLSErr
 }
 
 func createMockListener(t *testing.T) (net.Listener, string) {
@@ -377,6 +378,62 @@ func TestListener_UnsupportedResourceType(t *testing.T) {
 
 	// Channel should be empty (connection was not routed)
 	require.Empty(t, httpChannel)
+
+	// Close the listener
+	_ = tcpListener.Close()
+}
+
+func TestListener_Serve_RedirectedToHTTPS(t *testing.T) {
+	tcpListener, addr := createMockListener(t)
+
+	webAppChannel := make(chan Conn, 1)
+	channels := map[token.ResourceType]chan<- Conn{
+		token.ResourceTypeWebApp: webAppChannel,
+	}
+
+	registry := prometheus.NewRegistry()
+	logger := zap.NewNop()
+	certReloader := NewCertReloader("../../test/data/proxy/tls.crt", "../../test/data/proxy/tls.key", zap.NewNop())
+
+	listener := &Listener{
+		channels:     channels,
+		logger:       logger,
+		metrics:      CreateProxyConnMetrics(registry),
+		certReloader: certReloader,
+	}
+
+	webAppClaims := createClaims(t, token.ResourceTypeWebApp)
+	webAppClaims.Resource.GatewayMetadata.Downstream.TLS = true
+
+	// Use a channel to safely pass the connection from the factory
+	connCreated := make(chan *mockProxyConn, 1)
+	listener.proxyConnFactory = func(conn net.Conn, _ *tls.Config, _ Validator, _ *zap.Logger) Conn {
+		mockConn := &mockProxyConn{
+			Conn:          conn,
+			Claims:        webAppClaims,
+			upgradeTLSErr: errRedirectedToHTTPS,
+		}
+		connCreated <- mockConn
+
+		return mockConn
+	}
+
+	go func() {
+		_ = listener.Serve(t.Context(), tcpListener)
+	}()
+
+	// Open TCP connection
+	go func() {
+		_, err := net.Dial("tcp", addr)
+		assert.NoError(t, err)
+	}()
+
+	// Wait for connection to be created
+	closedConn := <-connCreated
+
+	// Connection should be closed without being routed to the web app channel
+	require.Eventually(t, closedConn.IsClosed, time.Second, 10*time.Millisecond)
+	require.Empty(t, webAppChannel)
 
 	// Close the listener
 	_ = tcpListener.Close()

--- a/internal/token/gat_claims.go
+++ b/internal/token/gat_claims.go
@@ -82,8 +82,13 @@ func validatePort(port int, fieldName string) error {
 }
 
 func (p GATClaims) ShouldUpgradeTLS() bool {
-	return p.Resource.Type == ResourceTypeKubernetes ||
-		(p.Resource.Type == ResourceTypeWebApp && p.Resource.GatewayMetadata.Downstream.TLS)
+	return p.Resource.Type == ResourceTypeKubernetes || p.EnforcesDownstreamTLS()
+}
+
+// EnforcesDownstreamTLS reports whether the resource is a web app whose GAT
+// requires the downstream client connection to be TLS.
+func (p GATClaims) EnforcesDownstreamTLS() bool {
+	return p.Resource.Type == ResourceTypeWebApp && p.Resource.GatewayMetadata.Downstream.TLS
 }
 
 func (p GATClaims) getHeaderType() string {

--- a/internal/token/gat_claims_test.go
+++ b/internal/token/gat_claims_test.go
@@ -64,6 +64,53 @@ func TestGATClaims_ShouldUpgradeTLS(t *testing.T) {
 	}
 }
 
+func TestGATClaims_EnforcesDownstreamTLS(t *testing.T) {
+	tests := []struct {
+		name          string
+		resourceType  ResourceType
+		downstreamTLS bool
+		expected      bool
+	}{
+		{
+			name:          "Kubernetes does not enforce downstream TLS",
+			resourceType:  ResourceTypeKubernetes,
+			downstreamTLS: true,
+			expected:      false,
+		},
+		{
+			name:          "SSH does not enforce downstream TLS",
+			resourceType:  ResourceTypeSSH,
+			downstreamTLS: true,
+			expected:      false,
+		},
+		{
+			name:         "Web app without downstream TLS does not enforce downstream TLS",
+			resourceType: ResourceTypeWebApp,
+			expected:     false,
+		},
+		{
+			name:          "Web app with downstream TLS enforces downstream TLS",
+			resourceType:  ResourceTypeWebApp,
+			downstreamTLS: true,
+			expected:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := &GATClaims{
+				Resource: Resource{
+					Type: tt.resourceType,
+					GatewayMetadata: GatewayMetadata{
+						Downstream: Downstream{TLS: tt.downstreamTLS},
+					},
+				},
+			}
+			assert.Equal(t, tt.expected, claims.EnforcesDownstreamTLS())
+		})
+	}
+}
+
 func TestGATTokenClaims_Validate(t *testing.T) {
 	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 

--- a/tools/local/main.go
+++ b/tools/local/main.go
@@ -228,6 +228,9 @@ Twingate local dev environment running!
   Over HTTPS:
   curl --cacert ./test/data/proxy/tls.crt https://%s
 
+  Or with redirect from HTTP to HTTPS:
+  curl -L --cacert ./test/data/proxy/tls.crt http://%s
+
 -----------------------------------------------------
 Press Ctrl+C to stop
 =====================================================
@@ -237,7 +240,7 @@ Press Ctrl+C to stop
 		kubeConfigFile, kindClusterName,
 		sshClientPort, sshKnownHostFile,
 		webAppClient.Address,
-		webAppTLSClient.Address,
+		webAppTLSClient.Address, webAppTLSClient.Address,
 	)
 
 	//nolint:forbidigo


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: Closes #433

## Changes

When a plaintext HTTP request is sent for TLS-enforced web app resources, Gateway should issue a 308 redirect to HTTPS.

- Browsing or curling an `http://` URL of a web app whose GAT enforces downstream TLS now receives a `308 Permanent Redirect` to the same URL over `https://`, instead of a failed TLS handshake.
- The redirect preserves the authority the client used (Host header, including non-default ports) as well as the path and query; requests without a Host header fall back to the validated CONNECT target.
