### PR TITLE
feat(helm): support specifying the Twingate Remote Network

### DIFF
--- a/deploy/gateway/templates/twingate-cr.yaml
+++ b/deploy/gateway/templates/twingate-cr.yaml
@@ -5,7 +5,7 @@ CRDs in the cluster, so rendering is gated behind twingateOperator.gateway.enabl
 {{- if and .Values.twingateOperator.kubernetesResource.enabled (not .Values.twingateOperator.gateway.enabled) }}
 {{- fail "twingateOperator.kubernetesResource.enabled=true requires twingateOperator.gateway.enabled=true" }}
 {{- end }}
-{{- if .Values.twingateOperator.kubernetesResource.remoteNetworkId }}
+{{- if hasKey .Values.twingateOperator.kubernetesResource "remoteNetworkId" }}
 {{- fail "twingateOperator.kubernetesResource.remoteNetworkId is not supported, set twingateOperator.remoteNetworkId instead" }}
 {{- end }}
 {{- if .Values.twingateOperator.gateway.enabled }}
@@ -60,7 +60,7 @@ spec:
   gatewayRef:
     name: {{ include "gateway.fullname" . }}
     namespace: {{ .Release.Namespace }}
-  {{- with omit .Values.twingateOperator.kubernetesResource "type" "address" "gatewayRef" "enabled" "name" "remoteNetworkId" }}
+  {{- with omit .Values.twingateOperator.kubernetesResource "type" "address" "gatewayRef" "enabled" "name" }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
 {{- end }}

--- a/deploy/gateway/templates/twingate-cr.yaml
+++ b/deploy/gateway/templates/twingate-cr.yaml
@@ -5,6 +5,9 @@ CRDs in the cluster, so rendering is gated behind twingateOperator.gateway.enabl
 {{- if and .Values.twingateOperator.kubernetesResource.enabled (not .Values.twingateOperator.gateway.enabled) }}
 {{- fail "twingateOperator.kubernetesResource.enabled=true requires twingateOperator.gateway.enabled=true" }}
 {{- end }}
+{{- if .Values.twingateOperator.kubernetesResource.remoteNetworkId }}
+{{- fail "twingateOperator.kubernetesResource.remoteNetworkId is not supported, set twingateOperator.remoteNetworkId instead" }}
+{{- end }}
 {{- if .Values.twingateOperator.gateway.enabled }}
 apiVersion: twingate.com/v1beta
 kind: TwingateCertificateAuthority
@@ -26,6 +29,9 @@ metadata:
   labels:
     {{- include "gateway.labels" . | nindent 4 }}
 spec:
+  {{- with .Values.twingateOperator.remoteNetworkId }}
+  remoteNetworkId: {{ . | quote }}
+  {{- end }}
   serviceRef:
     name: {{ include "gateway.fullname" . }}
     namespace: {{ .Release.Namespace }}
@@ -45,13 +51,16 @@ metadata:
   labels:
     {{- include "gateway.labels" . | nindent 4 }}
 spec:
+  {{- with .Values.twingateOperator.remoteNetworkId }}
+  remoteNetworkId: {{ . | quote }}
+  {{- end }}
   type: Kubernetes
   address: kubernetes.default.svc.cluster.local
   name: {{ .Values.twingateOperator.kubernetesResource.name | default (printf "%s Kubernetes cluster" (include "gateway.fullname" .)) | quote }}
   gatewayRef:
     name: {{ include "gateway.fullname" . }}
     namespace: {{ .Release.Namespace }}
-  {{- with omit .Values.twingateOperator.kubernetesResource "type" "address" "gatewayRef" "enabled" "name" }}
+  {{- with omit .Values.twingateOperator.kubernetesResource "type" "address" "gatewayRef" "enabled" "name" "remoteNetworkId" }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
 {{- end }}

--- a/deploy/gateway/tests/twingate-cr_test.yaml
+++ b/deploy/gateway/tests/twingate-cr_test.yaml
@@ -14,6 +14,17 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: twingateOperator.kubernetesResource.enabled=true requires twingateOperator.gateway.enabled=true
+  - it: fails when the in-cluster resource sets its own remote network
+    set:
+      twingateOperator:
+        gateway:
+          enabled: true
+        kubernetesResource:
+          enabled: true
+          remoteNetworkId: "UmVtb3RlTmV0d29yazo0NTYK"
+    asserts:
+      - failedTemplate:
+          errorMessage: twingateOperator.kubernetesResource.remoteNetworkId is not supported, set twingateOperator.remoteNetworkId instead
   - it: renders the CA and Gateway when gateway is enabled
     set:
       twingateOperator:
@@ -62,6 +73,47 @@ tests:
       - equal:
           path: spec.name
           value: "RELEASE-NAME-gateway Kubernetes cluster"
+  - it: omits remoteNetworkId when none is set, leaving the operator's default
+    set:
+      twingateOperator:
+        gateway:
+          enabled: true
+        kubernetesResource:
+          enabled: true
+    kubernetesProvider: *clusterNamespace
+    asserts:
+      - notExists:
+          path: spec.remoteNetworkId
+  - it: sets remoteNetworkId on the gateway
+    set:
+      twingateOperator:
+        remoteNetworkId: "UmVtb3RlTmV0d29yazoxMjMK"
+        gateway:
+          enabled: true
+    kubernetesProvider: *clusterNamespace
+    documentSelector:
+      path: kind
+      value: TwingateGateway
+    asserts:
+      - equal:
+          path: spec.remoteNetworkId
+          value: "UmVtb3RlTmV0d29yazoxMjMK"
+  - it: sets the same remoteNetworkId on the in-cluster resource
+    set:
+      twingateOperator:
+        remoteNetworkId: "UmVtb3RlTmV0d29yazoxMjMK"
+        gateway:
+          enabled: true
+        kubernetesResource:
+          enabled: true
+    kubernetesProvider: *clusterNamespace
+    documentSelector:
+      path: kind
+      value: TwingateResource
+    asserts:
+      - equal:
+          path: spec.remoteNetworkId
+          value: "UmVtb3RlTmV0d29yazoxMjMK"
   - it: suffixes the CA name with a hash of the cluster and namespace
     set:
       twingateOperator:

--- a/deploy/gateway/tests/twingate-cr_test.yaml
+++ b/deploy/gateway/tests/twingate-cr_test.yaml
@@ -14,14 +14,14 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: twingateOperator.kubernetesResource.enabled=true requires twingateOperator.gateway.enabled=true
-  - it: fails when the in-cluster resource sets its own remote network
+  - it: fails when the in-cluster resource sets its own remote network, even to an empty value
     set:
       twingateOperator:
         gateway:
           enabled: true
         kubernetesResource:
           enabled: true
-          remoteNetworkId: "UmVtb3RlTmV0d29yazo0NTYK"
+          remoteNetworkId: ""
     asserts:
       - failedTemplate:
           errorMessage: twingateOperator.kubernetesResource.remoteNetworkId is not supported, set twingateOperator.remoteNetworkId instead

--- a/deploy/gateway/values.schema.json
+++ b/deploy/gateway/values.schema.json
@@ -24,6 +24,11 @@
       "type": "object",
       "description": "Twingate Kubernetes Operator integration: render Twingate Custom Resources reconciled by the operator.",
       "properties": {
+        "remoteNetworkId": {
+          "type": "string",
+          "description": "Remote Network the TwingateGateway and the in-cluster Kubernetes TwingateResource are created in. Twingate requires both to be in the same Remote Network. Empty uses the operator's own TWINGATE_REMOTE_NETWORK_ID.",
+          "default": ""
+        },
         "gateway": {
           "type": "object",
           "required": ["enabled"],

--- a/deploy/gateway/values.yaml
+++ b/deploy/gateway/values.yaml
@@ -10,9 +10,9 @@ twingate:
   network: ""
 
 twingateOperator:
-  # Remote Network the Gateway and the in-cluster Kubernetes resource are created in.
-  # Empty uses the operator's own TWINGATE_REMOTE_NETWORK_ID.
-  remoteNetworkId: ""
+  # The Gateway and the in-cluster Kubernetes resource are created in the operator's own
+  # TWINGATE_REMOTE_NETWORK_ID. Set this only to place them in a different Remote Network.
+  # remoteNetworkId: "<remote network id>"
   gateway:
     # Render the TwingateGateway + its TwingateCertificateAuthority. Off for
     # standalone installs with no operator/CRDs.

--- a/deploy/gateway/values.yaml
+++ b/deploy/gateway/values.yaml
@@ -10,6 +10,9 @@ twingate:
   network: ""
 
 twingateOperator:
+  # Remote Network the Gateway and the in-cluster Kubernetes resource are created in.
+  # Empty uses the operator's own TWINGATE_REMOTE_NETWORK_ID.
+  remoteNetworkId: ""
   gateway:
     # Render the TwingateGateway + its TwingateCertificateAuthority. Off for
     # standalone installs with no operator/CRDs.


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: https://github.com/Twingate/gateway/issues/330
- Requires Twingate/kubernetes-operator#1109

## Changes

- `twingateOperator.remoteNetworkId`: Remote Network the `TwingateGateway` and the
  in-cluster Kubernetes `TwingateResource` are created in
  - empty (default) falls back to the operator's `TWINGATE_REMOTE_NETWORK_ID`
- error when `twingateOperator.kubernetesResource.remoteNetworkId` is set

## Notes

- One shared key rather than one per CR: Twingate requires the resource to be in
  its gateway's Remote Network, and the gateway can be rendered without the
  resource. Setting it under `kubernetesResource` fails rather than being
  silently overridden by the shared value.
- The operator CRD makes the field immutable once set, so changing the value on
  an existing release is rejected on upgrade.