### PR TITLE
feat: validate the GAT token type from the payload claim

### DIFF
--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -50,6 +50,7 @@ func newGATTokenClaims(clientPublicKey token.PublicKey) token.GATClaims {
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 		},
+		Type:            "GAT",
 		Version:         "1",
 		RenewAt:         jwt.NewNumericDate(time.Now().Add(time.Minute)),
 		ClientPublicKey: clientPublicKey,

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -89,7 +89,6 @@ func createParserAndGATToken(t *testing.T, claims token.GATClaims) (*token.Parse
 	require.NoError(t, err)
 
 	gatToken := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
-	gatToken.Header["typ"] = "GAT"
 	tokenStr, err := gatToken.SignedString(privateKey)
 	require.NoError(t, err)
 

--- a/internal/token/gat_claims.go
+++ b/internal/token/gat_claims.go
@@ -16,6 +16,8 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+const gatTokenType = "GAT"
+
 const supportedVersion = "1"
 
 const (
@@ -25,6 +27,7 @@ const (
 
 var (
 	errInvalidPublicKey   = errors.New("not a valid public key")
+	errInvalidTokenType   = errors.New("token type is invalid")
 	errUnsupportedVersion = errors.New("unsupported version")
 	errInvalidPort        = errors.New("invalid port")
 )
@@ -32,6 +35,7 @@ var (
 type GATClaims struct {
 	jwt.RegisteredClaims
 
+	Type            string           `json:"typ"`
 	Version         string           `json:"ver"`
 	RenewAt         *jwt.NumericDate `json:"rnw"`
 	ClientPublicKey PublicKey        `json:"cpk"`
@@ -45,6 +49,7 @@ func (p GATClaims) Validate() error {
 		condition bool
 		fieldName string
 	}{
+		{p.Type == "", "typ"},
 		{p.Version == "", "ver"},
 		{p.RenewAt == nil, "rnw"},
 		{p.ClientPublicKey == (PublicKey{}), "cpk"},
@@ -58,6 +63,10 @@ func (p GATClaims) Validate() error {
 		if v.condition {
 			return fmt.Errorf("%w \"%s\"", jwt.ErrTokenRequiredClaimMissing, v.fieldName)
 		}
+	}
+
+	if p.Type != gatTokenType {
+		return fmt.Errorf("%w: %w %q", jwt.ErrTokenInvalidClaims, errInvalidTokenType, p.Type)
 	}
 
 	if p.Version != supportedVersion {
@@ -83,10 +92,6 @@ func validatePort(port int, fieldName string) error {
 
 func (p GATClaims) ShouldUpgradeTLS() bool {
 	return p.Resource.Type == ResourceTypeKubernetes
-}
-
-func (p GATClaims) getHeaderType() string {
-	return "GAT"
 }
 
 type User struct {

--- a/internal/token/gat_claims_test.go
+++ b/internal/token/gat_claims_test.go
@@ -54,6 +54,7 @@ func TestGATTokenClaims_Validate(t *testing.T) {
 	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 
 	var validClaims = GATClaims{
+		Type:            "GAT",
 		Version:         "1",
 		RenewAt:         jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		ClientPublicKey: PublicKey{privateKey.PublicKey},
@@ -94,6 +95,14 @@ func TestGATTokenClaims_Validate(t *testing.T) {
 		expectedError        error
 		expectedErrorMessage string
 	}{
+		{
+			name: "Missing token type",
+			setupFn: func(claims *GATClaims) {
+				claims.Type = ""
+			},
+			expectedError:        jwt.ErrTokenRequiredClaimMissing,
+			expectedErrorMessage: "\"typ\"",
+		},
 		{
 			name: "Missing version",
 			setupFn: func(claims *GATClaims) {
@@ -149,6 +158,14 @@ func TestGATTokenClaims_Validate(t *testing.T) {
 			},
 			expectedError:        jwt.ErrTokenRequiredClaimMissing,
 			expectedErrorMessage: "\"resource.address\"",
+		},
+		{
+			name: "Invalid token type",
+			setupFn: func(claims *GATClaims) {
+				claims.Type = "JWT"
+			},
+			expectedError:        jwt.ErrTokenInvalidClaims,
+			expectedErrorMessage: "token type is invalid \"JWT\"",
 		},
 		{
 			name: "Unsupported version",

--- a/internal/token/parser.go
+++ b/internal/token/parser.go
@@ -4,20 +4,13 @@
 package token
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/MicahParks/keyfunc/v3"
 	"github.com/golang-jwt/jwt/v5"
 )
 
-var errInvalidTokenType = errors.New("token type is invalid")
-
 var allowedSigningMethods = []string{jwt.SigningMethodES256.Alg()}
-
-type ClaimsWithHeaderType interface {
-	getHeaderType() string
-}
 
 type ParserConfig struct {
 	// Issuer is the expected JWT issuer (iss claim).
@@ -61,12 +54,6 @@ func (p *Parser) ParseWithClaims(tokenString string, claims jwt.Claims) (*jwt.To
 	token, err := p.parser.ParseWithClaims(tokenString, claims, p.config.Keyfunc)
 	if err != nil {
 		return nil, err
-	}
-
-	if claim, ok := claims.(ClaimsWithHeaderType); ok {
-		if headerTyp, ok := token.Header["typ"].(string); !ok || headerTyp != claim.getHeaderType() {
-			return nil, errInvalidTokenType
-		}
 	}
 
 	return token, nil

--- a/internal/token/parser_test.go
+++ b/internal/token/parser_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"maps"
 	"testing"
 	"time"
 
@@ -58,68 +57,6 @@ func newTokenService() *tokenService {
 	return &tokenService{
 		signingKey: privateKey,
 		keyfunc:    func(_token *jwt.Token) (any, error) { return &privateKey.PublicKey, nil },
-	}
-}
-
-type CustomClaims struct {
-	jwt.RegisteredClaims
-}
-
-func (c *CustomClaims) getHeaderType() string {
-	return "custom"
-}
-
-func TestParser_ParseWithClaims(t *testing.T) {
-	tokenService := newTokenService()
-	parser, _ := NewParser(ParserConfig{
-		Issuer:   "twingate",
-		Audience: "acme",
-		Keyfunc:  tokenService.keyfunc,
-	})
-
-	t.Run("Valid token type", func(t *testing.T) {
-		claims := &CustomClaims{}
-		headers := map[string]any{"typ": "custom", "alg": "ES256"}
-		tokenStr, err := tokenService.signToken(jwt.MapClaims{}, headers)
-		require.NoError(t, err)
-
-		token, err := parser.ParseWithClaims(tokenStr, claims)
-
-		require.NoError(t, err)
-		require.NotNil(t, token)
-		require.True(t, token.Valid)
-	})
-
-	tests := []struct {
-		name          string
-		headers       map[string]any
-		expectedError error
-	}{
-		{
-			name:          "Missing token type",
-			headers:       map[string]any{},
-			expectedError: errInvalidTokenType,
-		},
-		{
-			name:          "Invalid token type",
-			headers:       map[string]any{"typ": "invalid"},
-			expectedError: errInvalidTokenType,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			claims := &CustomClaims{}
-			headers := map[string]any{"alg": "ES256"}
-			maps.Copy(headers, tt.headers)
-			tokenStr, err := tokenService.signToken(jwt.MapClaims{}, headers)
-			require.NoError(t, err)
-
-			token, err := parser.ParseWithClaims(tokenStr, claims)
-
-			require.ErrorIs(t, err, tt.expectedError)
-			require.Nil(t, token)
-		})
 	}
 }
 

--- a/test/fake/controller.go
+++ b/test/fake/controller.go
@@ -82,6 +82,7 @@ func NewController(network string, port int) *httptest.Server {
 				IssuedAt:  jwt.NewNumericDate(time.Now()),
 				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
 			},
+			Type:            "GAT",
 			Version:         "1",
 			RenewAt:         jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 			ClientPublicKey: *requestBody.ClientPublicKey,

--- a/test/fake/controller.go
+++ b/test/fake/controller.go
@@ -93,7 +93,7 @@ func NewController(network string, port int) *httptest.Server {
 
 		token := &jwt.Token{
 			Header: map[string]any{
-				"typ": "GAT",
+				"typ": "JWT",
 				"alg": jwt.SigningMethodES256.Alg(),
 				"kid": keyID,
 			},


### PR DESCRIPTION
## Related Tickets & Documents

- Issue: #444

## Changes

- Validate a GAT's token type from the `typ` payload claim instead of the JWT header

## Notes

- Do not release before the controller change that emits the payload claim reaches production.
