### PR TITLE
chore: upgrade Go toolchain to 1.26.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GOLANG_VERSION: 1.26.5
+  GOLANG_VERSION: 1.26.6
   CADDY_VERSION: 2.10.2
 
 permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 env:
-  GOLANG_VERSION: 1.26.5
+  GOLANG_VERSION: 1.26.6
 
 jobs:
   goreleaser:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.5
+golang 1.26.6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Zero-trust access gateway bridging Twingate with L7 resources such as Kubernetes
 
 - **License**: MPL-2.0
 - **Repository**: <https://github.com/Twingate/gateway>
-- **Language**: Go 1.26.5
+- **Language**: Go 1.26.6
 - **Build**: goreleaser, Docker buildx, kind (testing)
 - **Linting**: golangci-lint v2.11.1
 - **Testing**: testify, helm-unittest
@@ -105,7 +105,7 @@ main.go → cmd/start.go → proxy.NewProxy() → proxy.Start()
 ### Setup
 
 ```bash
-asdf install golang 1.26.5
+asdf install golang 1.26.6
 ```
 
 Versions tracked in `.tool-versions`.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gateway
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/MicahParks/jwkset v0.11.3


### PR DESCRIPTION
## Related Tickets & Documents

- Closes #447

## Changes

- Bump `go` directive in `go.mod` from 1.26.5 to 1.26.6
- Bump `golang` in `.tool-versions` (asdf) to 1.26.6
- Bump `GOLANG_VERSION` in CI and release workflows to 1.26.6
- Update Go version references in `CLAUDE.md`