### PR TITLE
refactor(connect): store the requested host from the CONNECT message

### DIFF
--- a/internal/connect/conn.go
+++ b/internal/connect/conn.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -33,13 +34,14 @@ func httpResponseString(httpCode int) string {
 }
 
 // Conn is a custom connection that wraps the underlying TCP net.Conn, handling downstream
-// proxy (Twingate Client)'s authentication via the initial CONNECT message. It handles 2 TLS
-// upgrades: with downstream proxy and then optionally with downstream client e.g. `kubectl`.
+// proxy (Twingate Client)'s authentication via the initial CONNECT message.
 type Conn interface {
 	net.Conn
 	GATClaims() *token.GATClaims
 	GetID() string
-	GetAddress() string
+	// GetRequestedHost returns the host from the CONNECT target.
+	GetRequestedHost() string
+	GetUpstreamAddress() string
 	GetToken() string
 	Authenticate() error
 	UpgradeToTLS() error
@@ -54,10 +56,11 @@ type ProxyConn struct {
 	ConnectValidator Validator
 	Logger           *zap.Logger
 
-	ID      string
-	Address string
-	Claims  *token.GATClaims
-	Token   string
+	ID            string
+	RequestedHost string
+	UpstreamHost  string
+	Claims        *token.GATClaims
+	Token         string
 
 	Timer *time.Timer
 	Mu    sync.Mutex
@@ -99,8 +102,14 @@ func (p *ProxyConn) GetID() string {
 	return p.ID
 }
 
-func (p *ProxyConn) GetAddress() string {
-	return p.Address
+func (p *ProxyConn) GetRequestedHost() string {
+	return p.RequestedHost
+}
+
+func (p *ProxyConn) GetUpstreamAddress() string {
+	upstreamPort := p.Claims.Resource.GatewayMetadata.Upstream.Port
+
+	return net.JoinHostPort(p.UpstreamHost, strconv.Itoa(upstreamPort))
 }
 
 func (p *ProxyConn) GetToken() string {
@@ -240,7 +249,8 @@ func (p *ProxyConn) UpgradeToTLS() error {
 
 func (p *ProxyConn) setConnectInfo(connectInfo Info) {
 	p.ID = connectInfo.ConnID
-	p.Address = connectInfo.Address
+	p.RequestedHost = connectInfo.RequestedHost
+	p.UpstreamHost = connectInfo.UpstreamHost
 	p.Claims = connectInfo.Claims
 	p.Token = connectInfo.Token
 	p.Timer = time.AfterFunc(time.Until(connectInfo.Claims.ExpiresAt.Time), func() {

--- a/internal/connect/conn_test.go
+++ b/internal/connect/conn_test.go
@@ -52,6 +52,12 @@ func TestProxyConn_setConnectInfo(t *testing.T) {
 			RegisteredClaims: jwt.RegisteredClaims{
 				ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
 			},
+			Resource: token.Resource{
+				GatewayMetadata: token.GatewayMetadata{
+					Downstream: token.Downstream{Port: 443},
+					Upstream:   token.Upstream{Port: 8443},
+				},
+			},
 		}
 		connID := "conn-id-1"
 
@@ -68,13 +74,17 @@ func TestProxyConn_setConnectInfo(t *testing.T) {
 			defer proxyConn.Mu.Unlock()
 
 			proxyConn.setConnectInfo(Info{
-				Claims: claims,
-				ConnID: connID,
+				RequestedHost: "app.internal",
+				UpstreamHost:  "example.com",
+				Claims:        claims,
+				ConnID:        connID,
 			})
 		}()
 
 		assert.Equal(t, connID, proxyConn.ID)
 		assert.Equal(t, claims, proxyConn.Claims)
+		assert.Equal(t, "app.internal", proxyConn.GetRequestedHost())
+		assert.Equal(t, "example.com:8443", proxyConn.GetUpstreamAddress())
 
 		// Wait for expiry timer to happen, the connection should be closed
 		time.Sleep(1 * time.Hour)

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -28,10 +28,11 @@ const AuthSignatureHeaderKey string = "X-Token-Signature"
 const ConnIDHeaderKey string = "X-Connection-Id"
 
 type Info struct {
-	Address string
-	Claims  *token.GATClaims
-	ConnID  string
-	Token   string
+	RequestedHost string
+	UpstreamHost  string
+	Claims        *token.GATClaims
+	ConnID        string
+	Token         string
 }
 
 type HTTPError struct {
@@ -130,8 +131,8 @@ func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (connectI
 			}
 	}
 
-	// verify the CONNECT target against the GAT token and map it to the upstream address
-	address, httpErr := resolveUpstreamAddress(req.RequestURI, gatClaims.Resource)
+	// verify the CONNECT target against the GAT token and resolve the upstream host
+	requestedHost, upstreamHost, httpErr := resolveUpstream(req.RequestURI, gatClaims.Resource)
 	if httpErr != nil {
 		return Info{
 			Claims: gatClaims,
@@ -140,66 +141,68 @@ func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (connectI
 	}
 
 	return Info{
-		Address: address,
-		Claims:  gatClaims,
-		ConnID:  connID,
-		Token:   bearerToken,
+		RequestedHost: requestedHost,
+		UpstreamHost:  upstreamHost,
+		Claims:        gatClaims,
+		ConnID:        connID,
+		Token:         bearerToken,
 	}, nil
 }
 
-// resolveUpstreamAddress verifies the CONNECT target against the GAT
-// resource and maps it to the upstream address for backend forwarding.
-func resolveUpstreamAddress(address string, resource token.Resource) (string, *HTTPError) {
-	host, port, err := net.SplitHostPort(address)
+// resolveUpstream verifies the CONNECT target against the GAT resource, returning the host the
+// client asked for and the host the Gateway forwards to.
+func resolveUpstream(target string, resource token.Resource) (requestedHost, upstreamHost string, _ *HTTPError) {
+	host, port, err := net.SplitHostPort(target)
 	if err != nil {
-		return "", &HTTPError{
+		return "", "", &HTTPError{
 			Code:    http.StatusBadRequest,
 			Message: fmt.Sprintf("failed to parse CONNECT target: %v", err),
 			Err:     err,
 		}
 	}
 
+	upstreamHost = host
+
 	switch {
 	case matchResourceAddress(resource.Address, host):
 		// host matches the resource address; forward to the same host
 	case matchResourceAliases(resource.Aliases, host):
 		// host matches an alias; forward to the resource's address
-		host = resource.Address
+		upstreamHost = resource.Address
 	default:
-		return "", &HTTPError{
+		return "", "", &HTTPError{
 			Code:    http.StatusBadRequest,
 			Message: fmt.Sprintf("CONNECT host %s does not match resource address %s or aliases %v", host, resource.Address, resource.Aliases),
 			Err:     nil,
 		}
 	}
 
-	if !config.HostnameRegexp.MatchString(host) {
-		return "", &HTTPError{
+	if !config.HostnameRegexp.MatchString(upstreamHost) {
+		return "", "", &HTTPError{
 			Code:    http.StatusBadRequest,
-			Message: "CONNECT host resolves to an invalid host: " + host,
+			Message: "CONNECT host resolves to an invalid host: " + upstreamHost,
 			Err:     nil,
 		}
 	}
 
 	requestedPort, err := strconv.Atoi(port)
 	if err != nil {
-		return "", &HTTPError{
+		return "", "", &HTTPError{
 			Code:    http.StatusBadRequest,
 			Message: fmt.Sprintf("failed to parse CONNECT target port: %v", err),
 			Err:     err,
 		}
 	}
 
-	metadata := resource.GatewayMetadata
-	if requestedPort != metadata.Downstream.Port {
-		return "", &HTTPError{
+	if downstreamPort := resource.GatewayMetadata.Downstream.Port; requestedPort != downstreamPort {
+		return "", "", &HTTPError{
 			Code:    http.StatusBadRequest,
-			Message: fmt.Sprintf("CONNECT port %d does not match token downstream port %d", requestedPort, metadata.Downstream.Port),
+			Message: fmt.Sprintf("CONNECT port %d does not match token downstream port %d", requestedPort, downstreamPort),
 			Err:     nil,
 		}
 	}
 
-	return net.JoinHostPort(host, strconv.Itoa(metadata.Upstream.Port)), nil
+	return host, upstreamHost, nil
 }
 
 var validDNSLabel = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$`)

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -115,21 +115,21 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		connectInfo, err := validator.ParseConnect(req, []byte(sigData))
 
 		require.NoError(t, err)
-		assert.Equal(t, "Example.com:443", connectInfo.Address)
+		assert.Equal(t, "Example.com", connectInfo.RequestedHost)
+		assert.Equal(t, "Example.com", connectInfo.UpstreamHost)
 		assert.Equal(t, *connectInfo.Claims, gatClaims)
 		assert.Equal(t, "conn-id", connectInfo.ConnID)
 		assert.Equal(t, signedToken, connectInfo.Token)
 	})
 
-	t.Run("Rewrites target port to upstream port", func(t *testing.T) {
+	t.Run("Alias resolves to the resource address", func(t *testing.T) {
 		claims := newGATTokenClaims(c.getPublicKey())
-		claims.Resource.GatewayMetadata.Upstream = token.Upstream{Port: 8443}
-		parserRewrite, tokenRewrite := createParserAndGATToken(t, claims)
-		validator := &MessageValidator{TokenParser: parserRewrite}
+		claims.Resource.Aliases = []string{"app.internal"}
+		parser, signedToken := createParserAndGATToken(t, claims)
+		validator := &MessageValidator{TokenParser: parser}
 
-		// client targets the downstream port 443; backend must be dialed on upstream 8443
-		req := httptest.NewRequest(http.MethodConnect, "example.com:443", nil)
-		req.Header.Set(AuthHeaderKey, "Bearer "+tokenRewrite)
+		req := httptest.NewRequest(http.MethodConnect, "app.internal:443", nil)
+		req.Header.Set(AuthHeaderKey, "Bearer "+signedToken)
 
 		signature := c.sign(sigData)
 		req.Header.Set(AuthSignatureHeaderKey, signature)
@@ -138,7 +138,8 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		connectInfo, err := validator.ParseConnect(req, []byte(sigData))
 
 		require.NoError(t, err)
-		assert.Equal(t, "example.com:8443", connectInfo.Address)
+		assert.Equal(t, "app.internal", connectInfo.RequestedHost)
+		assert.Equal(t, "example.com", connectInfo.UpstreamHost)
 		assert.Equal(t, "conn-id", connectInfo.ConnID)
 	})
 
@@ -381,37 +382,41 @@ func TestHTTPError_Error(t *testing.T) {
 	}
 }
 
-func TestResolveUpstreamAddress(t *testing.T) {
+func TestResolveUpstream(t *testing.T) {
 	metadata := token.GatewayMetadata{
 		Downstream: token.Downstream{Port: 443},
 		Upstream:   token.Upstream{Port: 8443},
 	}
 
 	tests := []struct {
-		name        string
-		address     string
-		resource    token.Resource
-		wantAddress string
-		wantCode    int
-		wantMessage string
+		name              string
+		address           string
+		resource          token.Resource
+		wantRequestedHost string
+		wantUpstreamHost  string
+		wantCode          int
+		wantMessage       string
 	}{
 		{
-			name:        "maps downstream port to upstream port",
-			address:     "example.com:443",
-			resource:    token.Resource{Address: "example.com", GatewayMetadata: metadata},
-			wantAddress: "example.com:8443",
+			name:              "host matches the resource address",
+			address:           "example.com:443",
+			resource:          token.Resource{Address: "example.com", GatewayMetadata: metadata},
+			wantRequestedHost: "example.com",
+			wantUpstreamHost:  "example.com",
 		},
 		{
-			name:        "wildcard address keeps requested host",
-			address:     "api.example.com:443",
-			resource:    token.Resource{Address: "*.example.com", GatewayMetadata: metadata},
-			wantAddress: "api.example.com:8443",
+			name:              "wildcard address keeps requested host",
+			address:           "api.example.com:443",
+			resource:          token.Resource{Address: "*.example.com", GatewayMetadata: metadata},
+			wantRequestedHost: "api.example.com",
+			wantUpstreamHost:  "api.example.com",
 		},
 		{
-			name:        "alias maps to upstream resource address",
-			address:     "second.internal:443",
-			resource:    token.Resource{Address: "10.0.0.5", Aliases: []string{"first.internal", "second.internal"}, GatewayMetadata: metadata},
-			wantAddress: "10.0.0.5:8443",
+			name:              "alias maps to upstream resource address",
+			address:           "second.internal:443",
+			resource:          token.Resource{Address: "10.0.0.5", Aliases: []string{"first.internal", "second.internal"}, GatewayMetadata: metadata},
+			wantRequestedHost: "second.internal",
+			wantUpstreamHost:  "10.0.0.5",
 		},
 		{
 			name:        "host matches neither address nor alias",
@@ -459,19 +464,21 @@ func TestResolveUpstreamAddress(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, httpErr := resolveUpstreamAddress(tt.address, tt.resource)
+			requestedHost, upstreamHost, httpErr := resolveUpstream(tt.address, tt.resource)
 
 			if tt.wantCode != 0 {
 				require.NotNil(t, httpErr)
 				assert.Equal(t, tt.wantCode, httpErr.Code)
 				assert.Contains(t, httpErr.Message, tt.wantMessage)
-				assert.Empty(t, got)
+				assert.Empty(t, requestedHost)
+				assert.Empty(t, upstreamHost)
 
 				return
 			}
 
 			require.Nil(t, httpErr)
-			assert.Equal(t, tt.wantAddress, got)
+			assert.Equal(t, tt.wantRequestedHost, requestedHost)
+			assert.Equal(t, tt.wantUpstreamHost, upstreamHost)
 		})
 	}
 }

--- a/internal/connect/listener_test.go
+++ b/internal/connect/listener_test.go
@@ -51,8 +51,12 @@ func (m *mockProxyConn) GetID() string {
 	return "mock"
 }
 
-func (m *mockProxyConn) GetAddress() string {
+func (m *mockProxyConn) GetRequestedHost() string {
 	return "mock"
+}
+
+func (m *mockProxyConn) GetUpstreamAddress() string {
+	return "mock:22"
 }
 
 func (m *mockProxyConn) GetToken() string {

--- a/internal/httpproxy/proxy_test.go
+++ b/internal/httpproxy/proxy_test.go
@@ -33,7 +33,8 @@ func (l *mockConnListener) Accept() (net.Conn, error) {
 	connMetrics := connect.CreateProxyConnMetrics(prometheus.NewRegistry())
 	proxyConn := connect.NewProxyConn(conn, nil, nil, zap.NewNop(), connMetrics)
 	proxyConn.ID = "test-conn"
-	proxyConn.Address = "localhost"
+	proxyConn.RequestedHost = "localhost"
+	proxyConn.UpstreamHost = "localhost"
 	proxyConn.Claims = &token.GATClaims{
 		User:     token.User{Username: "test@acme.com"},
 		Resource: token.Resource{Type: token.ResourceTypeKubernetes},

--- a/internal/kuberneteshandler/handler.go
+++ b/internal/kuberneteshandler/handler.go
@@ -80,7 +80,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func rewrite(r *httputil.ProxyRequest, conn *connect.ProxyConn) {
 	targetURL := &url.URL{
 		Scheme: "https",
-		Host:   conn.GetAddress(),
+		Host:   conn.GetUpstreamAddress(),
 	}
 	r.SetURL(targetURL)
 

--- a/internal/kuberneteshandler/handler_test.go
+++ b/internal/kuberneteshandler/handler_test.go
@@ -21,14 +21,16 @@ import (
 func TestRewrite(t *testing.T) {
 	connMetrics := connect.CreateProxyConnMetrics(prometheus.NewRegistry())
 	conn := connect.NewProxyConn(nil, nil, nil, zap.NewNop(), connMetrics)
-	conn.Address = "kubernetes.default.svc"
+	conn.RequestedHost = "kubernetes.default.svc"
+	conn.UpstreamHost = "kubernetes.default.svc"
 	conn.Claims = &token.GATClaims{
 		User: token.User{
 			Username: "user@acme.com",
 			Groups:   []string{"Everyone", "Engineering"},
 		},
 		Resource: token.Resource{
-			Address: "kubernetes.default.svc",
+			Address:         "kubernetes.default.svc",
+			GatewayMetadata: token.GatewayMetadata{Upstream: token.Upstream{Port: 443}},
 		},
 	}
 

--- a/internal/sshhandler/proxy.go
+++ b/internal/sshhandler/proxy.go
@@ -119,7 +119,7 @@ func (p *SSHProxy) serveConn(ctx context.Context, conn connect.Conn) error {
 	)
 
 	upstream := upstream{
-		address:  conn.GetAddress(),
+		address:  conn.GetUpstreamAddress(),
 		username: p.config.gatewayUsername,
 	}
 

--- a/internal/sshhandler/proxy_test.go
+++ b/internal/sshhandler/proxy_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -636,10 +637,17 @@ func (s *echoServer) identity() (username string, userCert *ssh.Certificate) {
 // newProxyConn wraps conn in the connect.ProxyConn the proxy serves, with test GAT claims and
 // the address of the upstream the proxy dials.
 func newProxyConn(conn net.Conn, upstreamAddr string) *connect.ProxyConn {
+	upstreamHost, port, _ := net.SplitHostPort(upstreamAddr)
+	upstreamPort, _ := strconv.Atoi(port)
+
 	proxyConn := connect.NewProxyConn(conn, nil, nil, zap.NewNop(),
 		connect.CreateProxyConnMetrics(prometheus.NewRegistry()))
-	proxyConn.Claims = &token.GATClaims{}
-	proxyConn.Address = upstreamAddr
+	proxyConn.Claims = &token.GATClaims{
+		Resource: token.Resource{
+			GatewayMetadata: token.GatewayMetadata{Upstream: token.Upstream{Port: upstreamPort}},
+		},
+	}
+	proxyConn.UpstreamHost = upstreamHost
 	proxyConn.ID = "test-conn-id"
 
 	return proxyConn

--- a/internal/webapphandler/handler.go
+++ b/internal/webapphandler/handler.go
@@ -70,7 +70,7 @@ var clientIdentityHeaders = []string{"X-Real-IP", "X-Forwarded-Port", "X-Forward
 func rewrite(r *httputil.ProxyRequest, conn *connect.ProxyConn, headers map[string]*template.Template) error {
 	targetURL := &url.URL{
 		Scheme: "http", // plain HTTP — no upstream TLS
-		Host:   conn.GetAddress(),
+		Host:   conn.GetUpstreamAddress(),
 	}
 	r.SetURL(targetURL)
 	r.Out.Host = r.In.Host // preserve the client's Host

--- a/internal/webapphandler/handler_test.go
+++ b/internal/webapphandler/handler_test.go
@@ -85,12 +85,12 @@ func TestRewrite(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		address     string
-		jwtToken    string
-		claims      *token.GATClaims
-		headers     map[string]string
-		wantHeaders map[string]string
+		name         string
+		upstreamHost string
+		jwtToken     string
+		claims       *token.GATClaims
+		headers      map[string]string
+		wantHeaders  map[string]string
 	}{
 		{
 			name:     "resolves all header templates",
@@ -199,7 +199,7 @@ func TestRewrite(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			connMetrics := connect.CreateProxyConnMetrics(prometheus.NewRegistry())
 			conn := connect.NewProxyConn(nil, nil, nil, zap.NewNop(), connMetrics)
-			conn.Address = tt.address
+			conn.UpstreamHost = tt.upstreamHost
 			conn.Token = tt.jwtToken
 			conn.Claims = tt.claims
 
@@ -225,8 +225,10 @@ func TestRewrite(t *testing.T) {
 func TestRewrite_PreservesClientHost(t *testing.T) {
 	connMetrics := connect.CreateProxyConnMetrics(prometheus.NewRegistry())
 	conn := connect.NewProxyConn(nil, nil, nil, zap.NewNop(), connMetrics)
-	conn.Address = "admin.example.int:80"
-	conn.Claims = &token.GATClaims{}
+	conn.UpstreamHost = "admin.example.int"
+	conn.Claims = &token.GATClaims{
+		Resource: token.Resource{GatewayMetadata: token.GatewayMetadata{Upstream: token.Upstream{Port: 80}}},
+	}
 
 	proxyReq := &httputil.ProxyRequest{
 		In:  httptest.NewRequest(http.MethodGet, "http://admin.example.int/path", nil),
@@ -243,8 +245,10 @@ func TestRewrite_PreservesClientHost(t *testing.T) {
 func TestRewrite_StripsClientIdentityHeaders(t *testing.T) {
 	connMetrics := connect.CreateProxyConnMetrics(prometheus.NewRegistry())
 	conn := connect.NewProxyConn(nil, nil, nil, zap.NewNop(), connMetrics)
-	conn.Address = "admin.example.int:80"
-	conn.Claims = &token.GATClaims{}
+	conn.UpstreamHost = "admin.example.int"
+	conn.Claims = &token.GATClaims{
+		Resource: token.Resource{GatewayMetadata: token.GatewayMetadata{Upstream: token.Upstream{Port: 80}}},
+	}
 
 	outReq := httptest.NewRequest(http.MethodGet, "http://admin.example.int/path", nil)
 	for _, headerName := range clientIdentityHeaders {


### PR DESCRIPTION
## Changes

- `connect.Conn` keeps the host from the CONNECT target alongside the upstream host it resolves to;
  previously alias resolution overwrote it and only the upstream address was stored

## Notes

The requested host will be needed for https://github.com/Twingate/gateway/pull/450
