### PR TITLE
chore: upgrade Go toolchain to 1.27.0 and golangci-lint to v2.13.1

### DIFF
--- a/.claude/agents/golang-pro.md
+++ b/.claude/agents/golang-pro.md
@@ -17,7 +17,7 @@ When invoked:
 Go development checklist:
 
 - Idiomatic code following effective Go guidelines
-- gofmt and golangci-lint compliance
+- golangci-lint compliance
 - Context propagation in all APIs
 - Comprehensive error handling with wrapping
 - Table-driven tests with subtests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,8 +43,6 @@ jobs:
     - name: Verify dependencies
       run: go mod verify
     - run: go vet ./...
-    - name: Check Format
-      run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
     - name: golangci-lint
       uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GOLANG_VERSION: 1.26.6
+  GOLANG_VERSION: 1.27.0
   CADDY_VERSION: 2.10.2
 
 permissions:
@@ -48,7 +48,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
       with:
-        version: v2.11.1
+        version: v2.13.1
 
   lint-markdown:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 env:
-  GOLANG_VERSION: 1.26.6
+  GOLANG_VERSION: 1.27.0
 
 jobs:
   goreleaser:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,10 +10,12 @@ linters:
     - dupl
     - depguard
     - dogsled
-    - exhaustruct
+    - exhaustruct  # Deprecated since v2.13.0 and replaced by exhaustruct_v5
+    - exhaustruct_v5
     - forcetypeassert  # Covered by revive linter's unchecked-type-assertion rule
     - funlen
     - gochecknoglobals
+    - gomodguard  # Deprecated since v2.12.0 and replaced by gomodguard_v2
     - gosmopolitan
     - lll  # Covered by revive linter's line-length-limit rule
     - maintidx

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.6
+golang 1.27.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ Zero-trust access gateway bridging Twingate with L7 resources such as Kubernetes
 
 - **License**: MPL-2.0
 - **Repository**: <https://github.com/Twingate/gateway>
-- **Language**: Go 1.26.6
+- **Language**: Go 1.27.0
 - **Build**: goreleaser, Docker buildx, kind (testing)
-- **Linting**: golangci-lint v2.11.1
+- **Linting**: golangci-lint v2.13.1
 - **Testing**: testify, helm-unittest
 
 **Key Features**: TLS 1.3 mutual auth, K8s user impersonation, SSH certificate-based access, session recording, Prometheus metrics
@@ -105,7 +105,7 @@ main.go → cmd/start.go → proxy.NewProxy() → proxy.Start()
 ### Setup
 
 ```bash
-asdf install golang 1.26.6
+asdf install golang 1.27.0
 ```
 
 Versions tracked in `.tool-versions`.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GOLANG_VERSION 		?= $(shell cat .tool-versions | grep golang | cut -d' ' -f2)
-GOLANGCI_LINT_VERSION	?= v2.11.1
+GOLANGCI_LINT_VERSION	?= v2.13.1
 VERSION 			?= $(shell go tool svu current)
 REGISTRY 			?= twingate
 IMAGE				:= gateway

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gateway
 
-go 1.26.6
+go 1.27.0
 
 require (
 	github.com/MicahParks/jwkset v0.11.3

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -119,7 +119,7 @@ func TestResolveTwingateHostname(t *testing.T) {
 		t.Cleanup(shardServer.Close)
 
 		redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, shardServer.URL+r.URL.Path, http.StatusPermanentRedirect)
+			http.Redirect(w, r, shardServer.URL+r.URL.Path, http.StatusPermanentRedirect) //nolint:gosec // G710: redirects to the test server, not a caller-supplied host
 		}))
 		t.Cleanup(redirectServer.Close)
 

--- a/internal/connect/conn.go
+++ b/internal/connect/conn.go
@@ -187,8 +187,7 @@ func (p *ProxyConn) Authenticate() error {
 
 	connectInfo, err := p.ConnectValidator.ParseConnect(req, ekm)
 	if err != nil {
-		var httpErr *HTTPError
-		if errors.As(err, &httpErr) {
+		if httpErr, ok := errors.AsType[*HTTPError](err); ok {
 			httpCode = httpErr.Code
 		} else {
 			p.Logger.Error("failed to parse CONNECT:", zap.Error(err))

--- a/internal/connect/conn_test.go
+++ b/internal/connect/conn_test.go
@@ -49,9 +49,7 @@ func TestProxyConn_setConnectInfo(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		conn := &mockConn{}
 		claims := &token.GATClaims{
-			RegisteredClaims: jwt.RegisteredClaims{
-				ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
-			},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
 			Resource: token.Resource{
 				GatewayMetadata: token.GatewayMetadata{
 					Downstream: token.Downstream{Port: 443},
@@ -134,9 +132,7 @@ type mockValidator struct {
 }
 
 var claims = &token.GATClaims{
-	RegisteredClaims: jwt.RegisteredClaims{
-		ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
-	},
+	ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
 	User: token.User{
 		ID:       "user-1",
 		Username: "user@acme.com",

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -61,13 +61,13 @@ func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (connectI
 	if req.Method != http.MethodConnect {
 		// did not receive CONNECT, return 405 Method Not Allowed
 		return Info{
-				Claims: nil,
-				ConnID: "",
-			}, &HTTPError{
-				Code:    http.StatusMethodNotAllowed,
-				Message: "expected CONNECT request got " + req.Method,
-				Err:     nil,
-			}
+			Claims: nil,
+			ConnID: "",
+		}, &HTTPError{
+			Code:    http.StatusMethodNotAllowed,
+			Message: "expected CONNECT request got " + req.Method,
+			Err:     nil,
+		}
 	}
 
 	connID := req.Header.Get(ConnIDHeaderKey)
@@ -78,13 +78,13 @@ func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (connectI
 	if tokenErr != nil {
 		// did not receive identity header in CONNECT, return 407 Proxy Authentication Required
 		return Info{
-				Claims: nil,
-				ConnID: connID,
-			}, &HTTPError{
-				Code:    http.StatusProxyAuthRequired,
-				Message: fmt.Sprintf("missing identity header in CONNECT %v", tokenErr),
-				Err:     tokenErr,
-			}
+			Claims: nil,
+			ConnID: connID,
+		}, &HTTPError{
+			Code:    http.StatusProxyAuthRequired,
+			Message: fmt.Sprintf("missing identity header in CONNECT %v", tokenErr),
+			Err:     tokenErr,
+		}
 	}
 
 	gatClaims := &token.GATClaims{}
@@ -92,13 +92,13 @@ func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (connectI
 	_, tokenErr = v.TokenParser.ParseWithClaims(bearerToken, gatClaims)
 	if tokenErr != nil {
 		return Info{
-				Claims: nil,
-				ConnID: connID,
-			}, &HTTPError{
-				Code:    http.StatusUnauthorized,
-				Message: fmt.Sprintf("failed to parse token with error %v", tokenErr),
-				Err:     tokenErr,
-			}
+			Claims: nil,
+			ConnID: connID,
+		}, &HTTPError{
+			Code:    http.StatusUnauthorized,
+			Message: fmt.Sprintf("failed to parse token with error %v", tokenErr),
+			Err:     tokenErr,
+		}
 	}
 
 	// parse signature header for Proof-of-Possession
@@ -107,13 +107,13 @@ func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (connectI
 	clientSig, tokenErr := base64.StdEncoding.DecodeString(signatureB64)
 	if tokenErr != nil {
 		return Info{
-				Claims: gatClaims,
-				ConnID: connID,
-			}, &HTTPError{
-				Code:    http.StatusUnauthorized,
-				Message: fmt.Sprintf("failed to decode client signature with error %v", tokenErr),
-				Err:     tokenErr,
-			}
+			Claims: gatClaims,
+			ConnID: connID,
+		}, &HTTPError{
+			Code:    http.StatusUnauthorized,
+			Message: fmt.Sprintf("failed to decode client signature with error %v", tokenErr),
+			Err:     tokenErr,
+		}
 	}
 
 	// verify signature
@@ -122,13 +122,13 @@ func (v *MessageValidator) ParseConnect(req *http.Request, ekm []byte) (connectI
 	ok := ecdsa.VerifyASN1(&gatClaims.ClientPublicKey.PublicKey, hashed[:], clientSig)
 	if !ok {
 		return Info{
-				Claims: gatClaims,
-				ConnID: connID,
-			}, &HTTPError{
-				Code:    http.StatusUnauthorized,
-				Message: "failed to verify signature",
-				Err:     nil,
-			}
+			Claims: gatClaims,
+			ConnID: connID,
+		}, &HTTPError{
+			Code:    http.StatusUnauthorized,
+			Message: "failed to verify signature",
+			Err:     nil,
+		}
 	}
 
 	// verify the CONNECT target against the GAT token and resolve the upstream host

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -44,12 +44,10 @@ func newClient() client {
 
 func newGATTokenClaims(clientPublicKey token.PublicKey) token.GATClaims {
 	return token.GATClaims{
-		RegisteredClaims: jwt.RegisteredClaims{
-			Issuer:    "twingate",
-			Audience:  jwt.ClaimStrings{"acme"},
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
-		},
+		Issuer:          "twingate",
+		Audience:        jwt.ClaimStrings{"acme"},
+		ExpiresAt:       jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		IssuedAt:        jwt.NewNumericDate(time.Now()),
 		Type:            "GAT",
 		Version:         "1",
 		RenewAt:         jwt.NewNumericDate(time.Now().Add(time.Minute)),
@@ -183,9 +181,7 @@ func TestConnectValidator_ParseConnect(t *testing.T) {
 		parser, invalidToken := createParserAndGATToken(
 			t,
 			token.GATClaims{
-				RegisteredClaims: jwt.RegisteredClaims{
-					ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Minute)),
-				},
+				ExpiresAt:       jwt.NewNumericDate(time.Now().Add(-time.Minute)),
 				ClientPublicKey: c.getPublicKey(),
 			},
 		)

--- a/internal/connect/listener_test.go
+++ b/internal/connect/listener_test.go
@@ -96,9 +96,7 @@ func createClaims(t *testing.T, resourceType token.ResourceType) *token.GATClaim
 	t.Helper()
 
 	return &token.GATClaims{
-		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
-		},
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
 		User: token.User{
 			ID:       "user-1",
 			Username: "user@acme.com",

--- a/internal/httpproxy/audit_middleware.go
+++ b/internal/httpproxy/audit_middleware.go
@@ -19,6 +19,9 @@ var (
 	errFailedToHijack = errors.New("failed to hijack")
 )
 
+// Audit log field names.
+const fieldHeaders = "headers"
+
 type responseWriter struct {
 	http.ResponseWriter
 
@@ -113,22 +116,22 @@ func auditMiddleware(config auditMiddlewareConfig) http.Handler {
 			if recovered != nil && recovered != http.ErrAbortHandler { //nolint:err113,errorlint
 				auditLogger.Error("API request failed",
 					zap.Any("request", map[string]any{
-						"headers": r.Header,
+						fieldHeaders: r.Header,
 					}),
 					zap.Any("response", map[string]any{
 						"status_code": rw.statusCode,
-						"headers":     rw.headers,
+						fieldHeaders:  rw.headers,
 					}),
 					zap.Any("panic", recovered),
 				)
 			} else {
 				auditLogger.Info("API request completed",
 					zap.Any("request", map[string]any{
-						"headers": r.Header,
+						fieldHeaders: r.Header,
 					}),
 					zap.Any("response", map[string]any{
 						"status_code": rw.statusCode,
-						"headers":     rw.headers,
+						fieldHeaders:  rw.headers,
 					}),
 				)
 			}

--- a/internal/metrics/http_middleware.go
+++ b/internal/metrics/http_middleware.go
@@ -18,6 +18,8 @@ import (
 // Metric label names.
 const (
 	labelRequestType = "type"
+	labelMethod      = "method"
+	labelCode        = "code"
 )
 
 // Request type values.
@@ -44,13 +46,13 @@ func RegisterHTTPMetrics(registry *prometheus.Registry) *HTTPMetrics {
 			Namespace: Namespace,
 			Name:      "http_requests_total",
 			Help:      "Total number of HTTP requests processed",
-		}, []string{labelResourceType, "type", "method", "code"}),
+		}, []string{labelResourceType, labelRequestType, labelMethod, labelCode}),
 
 		activeRequests: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Name:      "http_active_requests",
 			Help:      "Number of currently active HTTP requests",
-		}, []string{labelResourceType, "type"}),
+		}, []string{labelResourceType, labelRequestType}),
 
 		requestDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -58,21 +60,21 @@ func RegisterHTTPMetrics(registry *prometheus.Registry) *HTTPMetrics {
 				Name:      "http_request_duration_seconds",
 				Help:      "Latencies of HTTP requests in seconds",
 				Buckets:   []float64{0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600, 1800, 3600},
-			}, []string{labelResourceType, "type", "method", "code"}),
+			}, []string{labelResourceType, labelRequestType, labelMethod, labelCode}),
 
 		requestSizeBytes: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: Namespace,
 			Name:      "http_request_size_bytes",
 			Help:      "Size of incoming HTTP request in bytes",
 			Buckets:   prometheus.ExponentialBuckets(100, 10, 6),
-		}, []string{labelResourceType, "type", "method", "code"}),
+		}, []string{labelResourceType, labelRequestType, labelMethod, labelCode}),
 
 		responseSizeBytes: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: Namespace,
 			Name:      "http_response_size_bytes",
 			Help:      "Size of outgoing HTTP response in bytes",
 			Buckets:   prometheus.ExponentialBuckets(100, 10, 6),
-		}, []string{labelResourceType, "type", "method", "code"}),
+		}, []string{labelResourceType, labelRequestType, labelMethod, labelCode}),
 	}
 
 	registry.MustRegister(m.requestsTotal, m.activeRequests, m.requestDuration, m.requestSizeBytes, m.responseSizeBytes)

--- a/internal/metrics/round_tripper.go
+++ b/internal/metrics/round_tripper.go
@@ -35,13 +35,13 @@ func RegisterRoundTripperMetrics(registry *prometheus.Registry) *RoundTripperMet
 			Namespace: Namespace,
 			Name:      "api_server_requests_total",
 			Help:      "Total number of requests from Gateway to HTTP server processed",
-		}, []string{labelResourceType, "type", "method", "code"}),
+		}, []string{labelResourceType, labelRequestType, labelMethod, labelCode}),
 
 		activeRequests: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Name:      "api_server_active_requests",
 			Help:      "Number of currently active requests from Gateway to HTTP server",
-		}, []string{labelResourceType, "type"}),
+		}, []string{labelResourceType, labelRequestType}),
 
 		requestDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -49,7 +49,7 @@ func RegisterRoundTripperMetrics(registry *prometheus.Registry) *RoundTripperMet
 				Name:      "api_server_request_duration_seconds",
 				Help:      "Measures the initial HTTP request-response latency between Gateway and HTTP server in seconds. For HTTP streaming, WebSocket, and SPDY connections, this metric captures only the setup time and not the duration of the data transfer.",
 				Buckets:   prometheus.DefBuckets,
-			}, []string{labelResourceType, "type", "method", "code"}),
+			}, []string{labelResourceType, labelRequestType, labelMethod, labelCode}),
 	}
 
 	registry.MustRegister(c.requestsTotal, c.activeRequests, c.requestDuration)

--- a/internal/sshhandler/ca_test.go
+++ b/internal/sshhandler/ca_test.go
@@ -678,9 +678,7 @@ func TestVerifyCertificate(t *testing.T) {
 				ValidPrincipals: []string{"alice"},
 				ValidAfter:      mustUint64(now.Add(-clockSkewBuffer)),
 				ValidBefore:     mustUint64(now.Add(30 * time.Minute)),
-				Permissions: ssh.Permissions{
-					Extensions: map[string]string{"permit-pty": ""},
-				},
+				Extensions:      map[string]string{"permit-pty": ""},
 			}
 			tt.setupFn(req, cert)
 

--- a/internal/sshhandler/ssh_context.go
+++ b/internal/sshhandler/ssh_context.go
@@ -9,6 +9,13 @@ import (
 	"github.com/google/uuid"
 )
 
+// Audit log field names.
+const (
+	fieldType   = "type"
+	fieldSource = "source"
+	fieldTarget = "target"
+)
+
 // sshContext carries connection-level SSH metadata for audit logging.
 type sshContext struct {
 	id            string
@@ -30,9 +37,9 @@ func (s *sshContext) withGlobalRequest(reqType, source, target string, extra map
 	m := s.baseFields()
 
 	req := map[string]any{
-		"type":   reqType,
-		"source": source,
-		"target": target,
+		fieldType:   reqType,
+		fieldSource: source,
+		fieldTarget: target,
 	}
 
 	maps.Copy(req, extra)
@@ -78,10 +85,10 @@ func (c *sshChannelContext) baseFields() map[string]any {
 	m := c.sshContext.baseFields()
 
 	ch := map[string]any{
-		"id":     c.channelID,
-		"type":   c.channelType,
-		"source": c.sourceLabel,
-		"target": c.targetLabel,
+		"id":        c.channelID,
+		fieldType:   c.channelType,
+		fieldSource: c.sourceLabel,
+		fieldTarget: c.targetLabel,
 	}
 
 	maps.Copy(ch, c.extra)
@@ -95,9 +102,9 @@ func (c *sshChannelContext) withRequest(reqType string, reqExtra map[string]any)
 	m := c.baseFields()
 
 	req := map[string]any{
-		"type":   reqType,
-		"source": c.sourceLabel,
-		"target": c.targetLabel,
+		fieldType:   reqType,
+		fieldSource: c.sourceLabel,
+		fieldTarget: c.targetLabel,
 	}
 
 	maps.Copy(req, reqExtra)

--- a/internal/token/gat_claims_test.go
+++ b/internal/token/gat_claims_test.go
@@ -246,11 +246,9 @@ func TestPublicKey_MarshalJSON(t *testing.T) {
 		x, _ := new(big.Int).SetString("ccf05474241308bffdca1392dbb28fd98deeaf8ca15f04b3cf163c6da3b10c94", 16)
 		y, _ := new(big.Int).SetString("764efdffccbf662172d8256b7bf46c4d6bf1efd5a205fd12a162db4eb01a2216", 16)
 		pubKey := &PublicKey{
-			PublicKey: ecdsa.PublicKey{
-				Curve: elliptic.P256(),
-				X:     x,
-				Y:     y,
-			},
+			Curve: elliptic.P256(),
+			X:     x,
+			Y:     y,
 		}
 
 		jsonBytes, err := pubKey.MarshalJSON()
@@ -261,11 +259,9 @@ func TestPublicKey_MarshalJSON(t *testing.T) {
 
 	t.Run("Invalid public key", func(t *testing.T) {
 		pubKey := &PublicKey{
-			PublicKey: ecdsa.PublicKey{
-				Curve: elliptic.P256(),
-				X:     big.NewInt(1),
-				Y:     big.NewInt(1),
-			},
+			Curve: elliptic.P256(),
+			X:     big.NewInt(1),
+			Y:     big.NewInt(1),
 		}
 
 		_, err := pubKey.MarshalJSON()

--- a/test/fake/controller.go
+++ b/test/fake/controller.go
@@ -76,12 +76,10 @@ func NewController(network string, port int) *httptest.Server {
 		logger.Info("Received GAT request", zap.Any("user", &requestBody.User), zap.Any("device", &requestBody.Device), zap.Any("resource", &requestBody.Resource))
 
 		claims := token.GATClaims{
-			RegisteredClaims: jwt.RegisteredClaims{
-				Issuer:    issuer,
-				Audience:  jwt.ClaimStrings([]string{network}),
-				IssuedAt:  jwt.NewNumericDate(time.Now()),
-				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
-			},
+			Issuer:          issuer,
+			Audience:        jwt.ClaimStrings([]string{network}),
+			IssuedAt:        jwt.NewNumericDate(time.Now()),
+			ExpiresAt:       jwt.NewNumericDate(time.Now().Add(time.Hour)),
 			Type:            "GAT",
 			Version:         "1",
 			RenewAt:         jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),

--- a/test/integration/concurrent_users_test.go
+++ b/test/integration/concurrent_users_test.go
@@ -209,7 +209,7 @@ func TestConcurrentUsers(t *testing.T) {
 					},
 				},
 			}
-			rand.Shuffle(len(commands), func(i, j int) {
+			rand.Shuffle(len(commands), func(i, j int) { //nolint:gosec // G404: shuffles command order in a test, not security-sensitive
 				commands[i], commands[j] = commands[j], commands[i]
 			})
 


### PR DESCRIPTION
## Changes

- Bump Go to 1.27.0
- Bump `golangci-lint` to v2.13.1 (v2.13.0 is required for Go 1.27.0)
  - Add `exhaustruct_v5` and `gomodguard` to the disable list
  - `gci`: drop the `Check Format` CI step, whose `gofmt` disagrees with golangci-lint's
    formatter on multi-value returns of composite literals as of v2.13.0
  - `modernize/embedlit`: initialize promoted fields directly in struct literals
  - `modernize/errorsastype`: match `*HTTPError` with `errors.AsType`
  - `goconst`: extract repeated audit log field and Prometheus label names into constants
  - `gosec`: suppress the new G710 open redirect and G404 weak random findings in tests
