### PR TITLE
chore(deps): Revert "bump danger/danger-js from 14.0.5 to 14.0.6 (#467)"

### DIFF
--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout main repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Danger
-        uses: danger/danger-js@279443b7b3fdf4488d79546b3d40dbd76c51d83a # 14.0.6
+        uses: danger/danger-js@a236e3b8c41f0babbf133568db851a20a34f9a7b # 14.0.5
         if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'
         with:
           args: "--failOnErrors --dangerfile ./dangerfile.js"


### PR DESCRIPTION
This reverts commit 774036ef6c8fcfef1ae27f9a19478dcd1687ad49.

## Related Tickets & Documents

- Issue:

## Changes

Revert #467. `14.0.6` breaks Github action. The fix https://github.com/danger/danger-js/pull/1536 was merged so we need to wait for `14.0.7`