### PR TITLE
test(ssh): reduce test instability due to docker pull

### DIFF
--- a/test/integration/testutil/command.go
+++ b/test/integration/testutil/command.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func RunCommand(cmd *exec.Cmd) ([]byte, error) {
@@ -28,11 +27,12 @@ func RunCommand(cmd *exec.Cmd) ([]byte, error) {
 }
 
 const (
-	// A failed pull discards its progress whatever ended it, so waiting out containerd's 30s
-	// response-header timeout gains nothing. The cap still has to clear a legitimate slow pull of
-	// these images, which take 2-8s, because a retry starts over.
+	// A failed pull discards its progress, so there is nothing to gain by waiting out containerd's
+	// 30s response-header timeout. The cap must still clear a slow but healthy pull, because a
+	// retry restarts the download from scratch.
 	pullAttemptTimeout = 15 * time.Second
-	pullBudget         = 90 * time.Second
+	pullAttempts       = 3
+	pullRetryInterval  = 2 * time.Second
 )
 
 // ensureDockerImage makes image available in the local image store. It skips the pull when the
@@ -43,30 +43,36 @@ func ensureDockerImage(t *testing.T, image string) {
 	// `docker pull` contacts the registry even when the image is already present, so this check avoids an
 	// unnecessary network request.
 	//
-	// #nosec G204 -- image is a constant defined in this package
+	// #nosec G204 -- image is supplied by test code
 	if _, err := RunCommand(exec.Command("docker", "image", "inspect", image)); err == nil {
 		return
 	}
 
 	var pullErr error
 
-	err := wait.PollUntilContextTimeout(t.Context(), 2*time.Second, pullBudget, true, func(ctx context.Context) (bool, error) {
-		attemptCtx, cancel := context.WithTimeout(ctx, pullAttemptTimeout)
-		defer cancel()
-
-		// #nosec G204 -- image is a constant defined in this package
-		if _, pullErr = RunCommand(exec.CommandContext(attemptCtx, "docker", "pull", image)); pullErr != nil {
-			// The cap kills the command, so on its own the error reads only as a signal.
-			if errors.Is(attemptCtx.Err(), context.DeadlineExceeded) {
-				pullErr = fmt.Errorf("timed out after %s: %w", pullAttemptTimeout, pullErr)
-			}
-
-			t.Logf("Retrying pull of %s: %v", image, pullErr)
-
-			return false, nil //nolint:nilerr
+	for attempt := range pullAttempts {
+		if attempt > 0 {
+			time.Sleep(pullRetryInterval)
 		}
 
-		return true, nil
-	})
-	require.NoError(t, err, "failed to pull docker image %s: %v", image, pullErr)
+		attemptCtx, cancel := context.WithTimeout(t.Context(), pullAttemptTimeout)
+
+		// #nosec G204 -- image is supplied by test code
+		_, pullErr = RunCommand(exec.CommandContext(attemptCtx, "docker", "pull", image))
+
+		cancel()
+
+		if pullErr == nil {
+			return
+		}
+
+		// A killed process reports only "signal: killed", so name the deadline that killed it.
+		if errors.Is(attemptCtx.Err(), context.DeadlineExceeded) {
+			pullErr = fmt.Errorf("timed out after %s: %w", pullAttemptTimeout, pullErr)
+		}
+
+		t.Logf("Pull of %s failed: %v", image, pullErr)
+	}
+
+	require.NoError(t, pullErr, "failed to pull docker image %s", image)
 }

--- a/test/integration/testutil/command.go
+++ b/test/integration/testutil/command.go
@@ -4,9 +4,16 @@
 package testutil
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func RunCommand(cmd *exec.Cmd) ([]byte, error) {
@@ -18,4 +25,48 @@ func RunCommand(cmd *exec.Cmd) ([]byte, error) {
 	}
 
 	return output, nil
+}
+
+const (
+	// A failed pull discards its progress whatever ended it, so waiting out containerd's 30s
+	// response-header timeout gains nothing. The cap still has to clear a legitimate slow pull of
+	// these images, which take 2-8s, because a retry starts over.
+	pullAttemptTimeout = 15 * time.Second
+	pullBudget         = 90 * time.Second
+)
+
+// ensureDockerImage makes image available in the local image store. It skips the pull when the
+// image is already there, and retries a failed pull because registries fail intermittently.
+func ensureDockerImage(t *testing.T, image string) {
+	t.Helper()
+
+	// `docker pull` contacts the registry even when the image is already present, so this check avoids an
+	// unnecessary network request.
+	//
+	// #nosec G204 -- image is a constant defined in this package
+	if _, err := RunCommand(exec.Command("docker", "image", "inspect", image)); err == nil {
+		return
+	}
+
+	var pullErr error
+
+	err := wait.PollUntilContextTimeout(t.Context(), 2*time.Second, pullBudget, true, func(ctx context.Context) (bool, error) {
+		attemptCtx, cancel := context.WithTimeout(ctx, pullAttemptTimeout)
+		defer cancel()
+
+		// #nosec G204 -- image is a constant defined in this package
+		if _, pullErr = RunCommand(exec.CommandContext(attemptCtx, "docker", "pull", image)); pullErr != nil {
+			// The cap kills the command, so on its own the error reads only as a signal.
+			if errors.Is(attemptCtx.Err(), context.DeadlineExceeded) {
+				pullErr = fmt.Errorf("timed out after %s: %w", pullAttemptTimeout, pullErr)
+			}
+
+			t.Logf("Retrying pull of %s: %v", image, pullErr)
+
+			return false, nil //nolint:nilerr
+		}
+
+		return true, nil
+	})
+	require.NoError(t, err, "failed to pull docker image %s: %v", image, pullErr)
 }

--- a/test/integration/testutil/ssh_server.go
+++ b/test/integration/testutil/ssh_server.go
@@ -18,6 +18,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+// sshServerImage uses the ghcr.io URL rather than the lscr.io one, a scarf.sh vanity URL that
+// redirects to ghcr.io and can hang, failing the test. See
+// https://docs.linuxserver.io/FAQ/#storage
+const sshServerImage = "ghcr.io/linuxserver/openssh-server:version-10.3_p1-r1"
+
 func SetupSSHServer(t *testing.T, userName string) (string, int) {
 	t.Helper()
 
@@ -31,9 +36,7 @@ func SetupSSHServer(t *testing.T, userName string) (string, int) {
 	gid, err := RunCommand(exec.Command("id", "-g"))
 	require.NoError(t, err, "failed to get group ID")
 
-	// #nosec G204 -- inputs are from trusted operator configuration
-	_, err = RunCommand(exec.Command("docker", "pull", "lscr.io/linuxserver/openssh-server:latest"))
-	require.NoError(t, err, "failed to pull OpenSSH server docker image")
+	ensureDockerImage(t, sshServerImage)
 
 	// #nosec G204 -- inputs are from trusted operator configuration
 	output, err := RunCommand(exec.Command("docker", "run", "-d",
@@ -44,7 +47,7 @@ func SetupSSHServer(t *testing.T, userName string) (string, int) {
 		"--env", "USER_NAME="+userName,
 		"--env", "TZ=UTC",
 		"--volume", "../data/ssh/sshd_test.conf:/config/sshd/sshd_config.d/sshd_test.conf",
-		"lscr.io/linuxserver/openssh-server:latest",
+		sshServerImage,
 	))
 	require.NoError(t, err, "failed to create OpenSSH server docker container")
 
@@ -98,17 +101,13 @@ func SetupSSHServer(t *testing.T, userName string) (string, int) {
 	return containerID, serverPort
 }
 
-// SetupRemoteEchoServer installs socat and starts a TCP echo server inside the Docker container.
+// SetupRemoteEchoServer starts a TCP echo server inside the Docker container.
 func SetupRemoteEchoServer(t *testing.T, containerID string, port int) {
 	t.Helper()
 
 	// #nosec G204 -- inputs are from trusted operator configuration
-	_, err := RunCommand(exec.Command("docker", "exec", containerID, "apk", "add", "--no-cache", "socat"))
-	require.NoError(t, err, "failed to install socat in docker container")
-
-	// #nosec G204 -- inputs are from trusted operator configuration
-	_, err = RunCommand(exec.Command("docker", "exec", "-d", containerID, "socat",
-		fmt.Sprintf("TCP-LISTEN:%d,fork,reuseaddr", port), "EXEC:cat"))
+	_, err := RunCommand(exec.Command("docker", "exec", "-d", containerID,
+		"/bin/busybox", "nc", "-lk", "-p", strconv.Itoa(port), "-e", "/bin/cat"))
 	require.NoError(t, err, "failed to start echo server in docker container")
 }
 

--- a/test/integration/testutil/ssh_server.go
+++ b/test/integration/testutil/ssh_server.go
@@ -107,7 +107,8 @@ func SetupRemoteEchoServer(t *testing.T, containerID string, port int) {
 
 	// #nosec G204 -- inputs are from trusted operator configuration
 	_, err := RunCommand(exec.Command("docker", "exec", "-d", containerID,
-		"/bin/busybox", "nc", "-lk", "-p", strconv.Itoa(port), "-e", "/bin/cat"))
+		// Must use the busybox applet because the image installs netcat-openbsd as `nc`, which has no -e.
+		"/bin/busybox", "nc", "-l", "-p", strconv.Itoa(port), "-e", "/bin/cat"))
 	require.NoError(t, err, "failed to start echo server in docker container")
 }
 

--- a/test/integration/testutil/vault.go
+++ b/test/integration/testutil/vault.go
@@ -15,10 +15,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+const vaultImage = "hashicorp/vault:1.21.4"
+
 func SetupVaultServer(t *testing.T) (string, int) {
 	t.Helper()
 
 	containerName := "gateway-integration-test-vault-" + strings.ToLower(t.Name())
+
+	ensureDockerImage(t, vaultImage)
 
 	// #nosec G204 -- inputs are from trusted operator configuration
 	_, err := RunCommand(exec.Command("docker", "run", "-d",
@@ -29,7 +33,7 @@ func SetupVaultServer(t *testing.T) (string, int) {
 		"-e", "VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200",
 		"-e", "VAULT_TOKEN=root",
 		"-e", "VAULT_ADDR=http://127.0.0.1:8200",
-		"hashicorp/vault:1.21.4",
+		vaultImage,
 		"server", "-dev",
 	))
 	require.NoError(t, err, "failed to create Vault container")


### PR DESCRIPTION
## Related Tickets & Documents

- Failing build: <https://github.com/Twingate/gateway/actions/runs/33526954491/job/99920121788?pr=485>

## Changes

- Pull the OpenSSH server image from `ghcr.io/linuxserver/openssh-server` rather than `lscr.io`, whose scarf.sh redirect layer sits in front of every manifest and blob request and is what hangs.
- Pin that image to `version-10.3_p1-r1` instead of `latest`, so a moved tag does not force a fresh pull.
- Skip `docker pull` when the image is already in the local store, and retry a failed pull under a per-attempt timeout, since registry failures are intermittent.

## Notes

Besides improving stability, this saves roughly 4-8s for SSH integration tests.