### PR TITLE
chore: Ignore charmtone in Dependabot Go module updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: daily
     allow:
       - dependency-type: all
+    ignore:
+      # Nested module with no tags of its own; Dependabot mistakes the stale
+      # charmbracelet/x root tag v0.1.0 for a release of the submodule and
+      # produces an unresolvable go.mod. Updated transitively via svu/fang.
+      - dependency-name: github.com/charmbracelet/x/exp/charmtone
     open-pull-requests-limit: 5
   - package-ecosystem: docker
     directory: "/"


### PR DESCRIPTION
## Related Tickets & Documents

- Failed Dependabot run: https://github.com/Twingate/gateway/actions/runs/33657022237/job/100338000657

## Changes

- Ignore `github.com/charmbracelet/x/exp/charmtone` in the `gomod` ecosystem: it is an untagged nested module, and Dependabot reads the stale `charmbracelet/x` root tag `v0.1.0` as a release of it, producing a `go.mod` that resolves to a parent module without that package.
  - Indirect dependency of the `svu` tool dependency (`svu/v3` -> `fang/v2` -> `charmtone`), so it still updates transitively.
