### PR TITLE
fix: support Host header rewrite

### DIFF
--- a/internal/webapphandler/handler.go
+++ b/internal/webapphandler/handler.go
@@ -118,7 +118,7 @@ func rewrite(r *httputil.ProxyRequest, conn *connect.ProxyConn, headers map[stri
 			return fmt.Errorf("header %q: %w", headerName, err)
 		}
 
-		r.Out.Header.Set(headerName, headerValue)
+		setHeader(r, headerName, headerValue)
 	}
 
 	// Per-resource request header rewrites from the GAT are applied last, so they override
@@ -139,8 +139,17 @@ func rewrite(r *httputil.ProxyRequest, conn *connect.ProxyConn, headers map[stri
 			continue
 		}
 
-		r.Out.Header.Set(headerName, headerValue)
+		setHeader(r, headerName, headerValue)
 	}
 
 	return nil
+}
+
+func setHeader(r *httputil.ProxyRequest, name, value string) {
+	switch http.CanonicalHeaderKey(name) {
+	case "Host":
+		r.Out.Host = value
+	default:
+		r.Out.Header.Set(name, value)
+	}
 }

--- a/internal/webapphandler/handler_test.go
+++ b/internal/webapphandler/handler_test.go
@@ -93,6 +93,7 @@ func TestRewrite(t *testing.T) {
 		claims       *token.GATClaims
 		headers      map[string]string
 		wantHeaders  map[string]string
+		wantHost     string
 	}{
 		{
 			name:     "resolves all header templates",
@@ -195,6 +196,38 @@ func TestRewrite(t *testing.T) {
 				"Existing": "old-value",
 			},
 		},
+		{
+			name:     "config Host rewrite sets the outbound Host and not the header map",
+			jwtToken: "test-token",
+			claims:   baseClaims,
+			headers: map[string]string{
+				"Host": "kibana.corp.internal",
+			},
+			wantHeaders: map[string]string{
+				"Host": "",
+			},
+			wantHost: "kibana.corp.internal",
+		},
+		{
+			name:     "GAT Host rewrite overrides config Host",
+			jwtToken: "test-token",
+			claims: withRequestHeaderRewrites(baseClaims, map[string]string{
+				"Host": "kibana.corp.internal",
+			}),
+			headers: map[string]string{
+				"Host": "config.corp.internal",
+			},
+			wantHost: "kibana.corp.internal",
+		},
+		{
+			name:     "lowercase host rewrite is treated as Host",
+			jwtToken: "test-token",
+			claims: withRequestHeaderRewrites(baseClaims, map[string]string{
+				"host": "kibana.corp.internal",
+			}),
+			headers:  map[string]string{},
+			wantHost: "kibana.corp.internal",
+		},
 	}
 
 	for _, tt := range tests {
@@ -214,11 +247,14 @@ func TestRewrite(t *testing.T) {
 			}
 			parsedHeaders := mustParse(t, tt.headers)
 
-			err := rewrite(proxyReq, conn, parsedHeaders)
-			require.NoError(t, err)
+			require.NoError(t, rewrite(proxyReq, conn, parsedHeaders))
 
 			for name, wantValue := range tt.wantHeaders {
 				assert.Equal(t, wantValue, proxyReq.Out.Header.Get(name))
+			}
+
+			if tt.wantHost != "" {
+				assert.Equal(t, tt.wantHost, proxyReq.Out.Host)
 			}
 		})
 	}


### PR DESCRIPTION
## Changes

- `Host` in `webApp.requestHeaders` or a GAT request header rewrite now replaces the Host header sent to the upstream
  - `net/http` ignores a `Host` entry in the header map and sends `Request.Host` instead, so the rewrite was silently dropped